### PR TITLE
fix(ci): Install all dependencies for building extension in publish workflow

### DIFF
--- a/.github/workflows/vscode-extension-secure-publish.yml
+++ b/.github/workflows/vscode-extension-secure-publish.yml
@@ -99,8 +99,8 @@ jobs:
       - name: Install dependencies with integrity check
         working-directory: ${{ env.EXTENSION_DIR }}
         run: |
-          npm ci --fund=false --production --audit
-          npm audit --production --audit-level=moderate --omit=dev
+          npm ci --fund=false
+          npm audit --omit=dev --audit-level=moderate
 
       - name: Update version in package.json
         working-directory: ${{ env.EXTENSION_DIR }}


### PR DESCRIPTION

The workflow was failing because npm ci --omit=dev excluded dev dependencies like ts-loader, webpack, and @vscode/vsce which are required to build the extension package.

Changes:
- Remove --omit=dev from npm ci to install ALL dependencies (build needs them)
- Keep npm audit --omit=dev to only audit production dependencies for security
- Remove deprecated --audit flag from npm ci

This ensures the build step has access to webpack, ts-loader, and other build tools while still only auditing production dependencies for vulnerabilities.

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**
