### PR TITLE
feat(hubs): implement single active hub profile with automatic bundle management

### DIFF
--- a/.vscodeignore.production
+++ b/.vscodeignore.production
@@ -42,8 +42,6 @@ scripts/
 build/
 tools/
 *.sh
-!dist/extension.js
-!dist/extension.js.LICENSE.txt
 apply_*.sh
 create-*.sh
 ensure-*.sh
@@ -127,9 +125,12 @@ INTEGRATION_TEST_*.md
 !dist/extension.js
 !dist/extension.js.LICENSE.txt
 
-# IMPORTANT: Include templates directory with all its contents
+
+# IMPORTANT: Include templates and config directories with all its contents
 !templates/
 !templates/**
+!config/
+!config/**
 
 # Cache directories
 .cache/
@@ -137,3 +138,6 @@ INTEGRATION_TEST_*.md
 # Project-specific exclusions
 .specification/
 .tmp/
+
+# Test results
+test-results/

--- a/config/defaultHubs.json
+++ b/config/defaultHubs.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "../schemas/default-hubs-config.schema.json",
+  "defaultHubs": [
+    {
+      "name": "Amadeus",
+      "description": "Profiles curated by Amadeus",
+      "icon": "cloud",
+      "reference": {
+        "type": "github",
+        "location": "Amadeus-xDLC/genai.prompt-registry-config",
+        "ref": "main"
+      },
+      "recommended": true,
+      "enabled": true
+    },
+    {
+      "name": "Prompt Registry Community Hub",
+      "description": "Profiles cureated by the Prompt Registry Community",
+      "icon": "cloud",
+      "reference": {
+        "type": "github",
+        "location": "AmadeusITGroup/prompt-registry-config",
+        "ref": "main"
+      },
+      "recommended": true,
+      "enabled": true
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -253,7 +253,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -523,6 +522,7 @@
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -536,6 +536,7 @@
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -1124,28 +1125,32 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
       "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/adm-zip": {
       "version": "0.5.7",
@@ -1264,8 +1269,7 @@
       "version": "16.18.126",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
       "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/readdir-glob": {
       "version": "1.1.5",
@@ -1359,7 +1363,6 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -2118,7 +2121,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2155,6 +2157,7 @@
       "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "acorn": "^8.11.0"
       },
@@ -2603,7 +2606,8 @@
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -2819,7 +2823,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.2",
         "caniuse-lite": "^1.0.30001741",
@@ -3661,7 +3664,8 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4145,7 +4149,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5890,13 +5893,13 @@
       }
     },
     "node_modules/jws": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.3.tgz",
+      "integrity": "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "jwa": "^1.4.1",
+        "jwa": "^1.4.2",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -6145,7 +6148,8 @@
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/markdown-it": {
       "version": "12.3.2",
@@ -7881,7 +7885,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -8174,7 +8177,6 @@
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -8689,6 +8691,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -8733,6 +8736,7 @@
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -8832,7 +8836,6 @@
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8944,7 +8947,8 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
@@ -8988,7 +8992,6 @@
       "integrity": "sha512-7b0dTKR3Ed//AD/6kkx/o7duS8H3f1a4w3BYpIriX4BzIhjkn4teo05cptsxvLesHFKK5KObnadmCHBwGc+51A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -9038,7 +9041,6 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",
@@ -9438,6 +9440,7 @@
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }

--- a/package.json
+++ b/package.json
@@ -160,19 +160,19 @@
         "command": "promptRegistry.exportSettings",
         "title": "Export Settings",
         "category": "Prompt Registry",
-        "icon": "$(export)"
+        "icon": "$(save-as)"
       },
       {
         "command": "promptRegistry.importSettings",
         "title": "Import Settings",
         "category": "Prompt Registry",
-        "icon": "$(cloud-download)"
+        "icon": "$(folder-opened)"
       },
       {
         "command": "promptRegistry.openSettings",
         "title": "Open Settings",
         "category": "Prompt Registry",
-        "icon": "$(settings-gear)"
+        "icon": "$(gear)"
       },
       {
         "command": "promptRegistry.listProfiles",
@@ -342,10 +342,22 @@
         "icon": "$(clear-all)"
       },
       {
+        "command": "promptregistry.switchHub",
+        "title": "Switch Hub",
+        "category": "Prompt Registry",
+        "icon": "$(sync)"
+      },
+      {
         "command": "promptregistry.exportHubConfig",
         "title": "Export Hub Configuration",
         "category": "Prompt Registry",
         "icon": "$(export)"
+      },
+      {
+        "command": "promptregistry.openHubRepository",
+        "title": "Open Hub Repository",
+        "category": "Prompt Registry",
+        "icon": "$(repo)"
       }
     ],
     "viewsContainers": {
@@ -416,6 +428,21 @@
           "command": "promptRegistry.openSettings",
           "when": "view == promptRegistryExplorer",
           "group": "navigation@3"
+        },
+        {
+          "command": "promptregistry.switchHub",
+          "when": "view == promptRegistryExplorer",
+          "group": "navigation@4"
+        },
+        {
+          "command": "promptregistry.exportHubConfig",
+          "when": "view == promptRegistryExplorer",
+          "group": "navigation@5"
+        },
+        {
+          "command": "promptregistry.openHubRepository",
+          "when": "view == promptRegistryExplorer",
+          "group": "navigation@6"
         }
       ],
       "view/item/context": [

--- a/schemas/default-hubs-config.schema.json
+++ b/schemas/default-hubs-config.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Default Hubs Configuration",
+  "description": "Configuration for default hubs offered during extension installation",
+  "type": "object",
+  "properties": {
+    "defaultHubs": {
+      "type": "array",
+      "description": "List of default hub configurations",
+      "items": {
+        "type": "object",
+        "required": ["name", "description", "icon", "reference"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Display name for the hub"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description shown in the selector"
+          },
+          "icon": {
+            "type": "string",
+            "description": "VS Code codicon name (without $() wrapper)",
+            "examples": ["cloud", "organization", "repo", "globe"]
+          },
+          "reference": {
+            "type": "object",
+            "description": "Hub reference configuration",
+            "required": ["type", "location"],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["github", "local", "url"],
+                "description": "Type of hub source"
+              },
+              "location": {
+                "type": "string",
+                "description": "Location of the hub (repo path, local path, or URL)"
+              },
+              "ref": {
+                "type": "string",
+                "description": "Git ref for GitHub sources (branch, tag, or commit)",
+                "default": "main"
+              },
+              "autoSync": {
+                "type": "boolean",
+                "description": "Whether to automatically sync this hub",
+                "default": false
+              }
+            }
+          },
+          "recommended": {
+            "type": "boolean",
+            "description": "Whether this is the recommended default hub",
+            "default": false
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether to show this hub in first-run selector",
+            "default": true
+          }
+        }
+      }
+    }
+  },
+  "required": ["defaultHubs"]
+}

--- a/schemas/hub-config.schema.json
+++ b/schemas/hub-config.schema.json
@@ -4,7 +4,11 @@
   "title": "Hub Configuration Schema",
   "description": "JSON Schema for Prompt Registry hub configuration files",
   "type": "object",
-  "required": ["version", "metadata", "sources"],
+  "required": [
+    "version",
+    "metadata",
+    "sources"
+  ],
   "additionalProperties": false,
   "properties": {
     "version": {
@@ -15,7 +19,12 @@
     "metadata": {
       "type": "object",
       "description": "Hub metadata and descriptive information",
-      "required": ["name", "description", "maintainer", "updatedAt"],
+      "required": [
+        "name",
+        "description",
+        "maintainer",
+        "updatedAt"
+      ],
       "additionalProperties": false,
       "properties": {
         "name": {
@@ -53,7 +62,12 @@
       "description": "List of bundle sources available in this hub",
       "items": {
         "type": "object",
-        "required": ["id", "type", "enabled", "priority"],
+        "required": [
+          "id",
+          "type",
+          "enabled",
+          "priority"
+        ],
         "additionalProperties": true,
         "properties": {
           "id": {
@@ -65,8 +79,16 @@
           },
           "type": {
             "type": "string",
-            "description": "Type of the source repository",
-            "enum": ["github", "local", "url"]
+            "description": "Type of the source repository (github, gitlab, http/url, local, awesome-copilot, local-awesome-copilot)",
+            "enum": [
+              "github",
+              "gitlab",
+              "http",
+              "url",
+              "local",
+              "awesome-copilot",
+              "local-awesome-copilot"
+            ]
           },
           "url": {
             "type": "string",
@@ -93,6 +115,44 @@
             "description": "Priority order for source resolution (higher = higher priority)",
             "minimum": 0,
             "maximum": 100
+          },
+          "config": {
+            "type": "object",
+            "description": "Source-specific configuration settings (e.g., branch, collectionsPath for awesome-copilot sources)",
+            "additionalProperties": true,
+            "properties": {
+              "branch": {
+                "type": "string",
+                "description": "Git branch name (for git-based sources)"
+              },
+              "collectionsPath": {
+                "type": "string",
+                "description": "Path to collections directory (for awesome-copilot sources)"
+              },
+              "indexFile": {
+                "type": "string",
+                "description": "Index file name (for awesome-copilot sources)"
+              }
+            }
+          },
+          "metadata": {
+            "type": "object",
+            "description": "Additional source metadata",
+            "additionalProperties": true,
+            "properties": {
+              "description": {
+                "type": "string",
+                "description": "Source description"
+              },
+              "homepage": {
+                "type": "string",
+                "description": "Source homepage URL"
+              },
+              "contact": {
+                "type": "string",
+                "description": "Contact information"
+              }
+            }
           }
         }
       }
@@ -103,7 +163,12 @@
       "default": [],
       "items": {
         "type": "object",
-        "required": ["id", "name", "description", "bundles"],
+        "required": [
+          "id",
+          "name",
+          "description",
+          "bundles"
+        ],
         "additionalProperties": true,
         "properties": {
           "id": {
@@ -149,7 +214,12 @@
             "minItems": 1,
             "items": {
               "type": "object",
-              "required": ["id", "version", "source", "required"],
+              "required": [
+                "id",
+                "version",
+                "source",
+                "required"
+              ],
               "additionalProperties": false,
               "properties": {
                 "id": {

--- a/src/config/README.md
+++ b/src/config/README.md
@@ -1,0 +1,156 @@
+# Default Hubs Configuration
+
+This directory contains the configuration for default hubs that are offered to users during their first-time installation of the Prompt Registry extension.
+
+## Files
+
+- **`defaultHubs.ts`** - TypeScript module that loads and manages default hub configurations
+- **`defaultHubs.json`** - JSON configuration file for defining default hubs (optional)
+
+## How It Works
+
+1. **Configuration Loading**:
+   - The system first attempts to load hubs from `defaultHubs.json`
+   - If the JSON file is not found or invalid, it falls back to hardcoded defaults in `defaultHubs.ts`
+
+2. **Hub Verification**:
+   - During first-run, each enabled hub is verified for accessibility
+   - Only hubs that pass verification are shown to the user
+   - Verification uses the same authentication logic as manual hub imports (includes GitHub token support)
+
+3. **User Selection**:
+   - Users see a quick-pick menu with verified hubs
+   - Recommended hubs are marked with a star (⭐)
+   - Users can also choose "Custom Hub URL" or "Skip for now"
+
+## Configuration Format
+
+### JSON Configuration (`defaultHubs.json`)
+
+```json
+{
+  "defaultHubs": [
+    {
+      "name": "Awesome Copilot Hub",
+      "description": "Official curated collection",
+      "icon": "cloud",
+      "reference": {
+        "type": "github",
+        "location": "github/awesome-copilot",
+        "ref": "main"
+      },
+      "recommended": true,
+      "enabled": true
+    }
+  ]
+}
+```
+
+### Properties
+
+- **`name`** (required): Display name shown in the selector
+- **`description`** (required): Brief description of the hub
+- **`icon`** (required): VS Code codicon name (without `$()` wrapper)
+  - Examples: `cloud`, `organization`, `repo`, `globe`, `star`
+- **`reference`** (required): Hub reference configuration
+  - **`type`**: `"github"`, `"local"`, or `"url"`
+  - **`location`**: Repository path, file path, or URL
+  - **`ref`**: Git reference (branch, tag, or commit) - defaults to "main"
+  - **`autoSync`**: Whether to auto-sync (optional)
+- **`recommended`** (optional): Mark as recommended (shows star icon) - default: `false`
+- **`enabled`** (optional): Show in first-run selector - default: `true`
+
+## Adding New Default Hubs
+
+### Option 1: Modify JSON (Recommended)
+
+Edit `src/config/defaultHubs.json`:
+
+```json
+{
+  "defaultHubs": [
+    {
+      "name": "My Custom Hub",
+      "description": "Description here",
+      "icon": "repo",
+      "reference": {
+        "type": "github",
+        "location": "owner/repository",
+        "ref": "main"
+      },
+      "enabled": true
+    }
+  ]
+}
+```
+
+### Option 2: Modify TypeScript
+
+Edit the `HARDCODED_DEFAULT_HUBS` array in `src/config/defaultHubs.ts`:
+
+```typescript
+const HARDCODED_DEFAULT_HUBS: DefaultHubConfig[] = [
+    {
+        name: 'My Custom Hub',
+        description: 'Description here',
+        icon: 'repo',
+        reference: {
+            type: 'github',
+            location: 'owner/repository',
+            ref: 'main'
+        },
+        enabled: true
+    }
+];
+```
+
+## Hub Verification Process
+
+When a hub is offered during first-run:
+
+1. **Reference Validation**: Validates the hub reference format
+2. **Fetch Attempt**: Attempts to fetch `hub-config.yml` from the specified location
+3. **Authentication**: For GitHub URLs, automatically includes user's GitHub token
+4. **Success/Failure**: 
+   - ✓ Success: Hub is shown in the selector
+   - ✗ Failure: Hub is hidden from selector (logged for debugging)
+
+## Available Icons
+
+Common VS Code codicon names for hubs:
+
+- `cloud` - Cloud/SaaS service
+- `organization` - Organization/team
+- `repo` - Repository
+- `globe` - Public/internet
+- `star` - Featured/special
+- `book` - Documentation/learning
+- `beaker` - Experimental
+- `verified` - Verified/trusted
+
+See [VS Code Codicons](https://microsoft.github.io/vscode-codicons/dist/codicon.html) for full list.
+
+## Testing
+
+To test hub verification locally:
+
+```typescript
+import { HubManager } from '../services/HubManager';
+import { getEnabledDefaultHubs } from './defaultHubs';
+
+const hubs = getEnabledDefaultHubs();
+for (const hub of hubs) {
+    const isAvailable = await hubManager.verifyHubAvailability(hub.reference);
+    console.log(`${hub.name}: ${isAvailable ? '✓' : '✗'}`);
+}
+```
+
+## Schema Validation
+
+The JSON configuration is validated against `schemas/default-hubs-config.schema.json`. This ensures:
+
+- Required fields are present
+- Types are correct
+- Enum values are valid (e.g., hub type must be "github", "local", or "url")
+
+Enable schema validation in VS Code by ensuring the `$schema` property is set in `defaultHubs.json`.

--- a/src/config/defaultHubs.ts
+++ b/src/config/defaultHubs.ts
@@ -1,0 +1,140 @@
+/**
+ * Default Hub Configurations
+ * 
+ * This file contains the default hub configurations offered to users
+ * during first-time installation. Each hub configuration is verified
+ * for accessibility before being activated.
+ * 
+ * Configurations can be:
+ * 1. Defined in code (DEFAULT_HUBS constant)
+ * 2. Loaded from defaultHubs.json (if available)
+ */
+
+import { HubReference } from '../types/hub';
+import * as fs from 'fs';
+import * as path from 'path';
+import { Logger } from '../utils/logger';
+
+const logger = Logger.getInstance();
+
+export interface DefaultHubConfig {
+    /** Display name for the hub */
+    name: string;
+    
+    /** Description shown in the selector */
+    description: string;
+    
+    /** Icon to display (VS Code codicon name without $()) */
+    icon: string;
+    
+    /** Hub reference configuration */
+    reference: HubReference;
+    
+    /** Whether this is the recommended default */
+    recommended?: boolean;
+    
+    /** Whether to show this hub in first-run selector */
+    enabled?: boolean;
+}
+
+/**
+ * Default hubs offered during installation (hardcoded fallback)
+ * 
+ * These hubs will be:
+ * 1. Verified for accessibility (URL reachable)
+ * 2. Shown in the first-run hub selector
+ * 3. Imported with proper authentication if selected
+ */
+const HARDCODED_DEFAULT_HUBS: DefaultHubConfig[] = [
+    {
+        name: 'Awesome Copilot Hub',
+        description: 'Official curated collection',
+        icon: 'cloud',
+        reference: {
+            type: 'github',
+            location: 'github/awesome-copilot',
+            ref: 'main'
+        },
+        recommended: true,
+        enabled: true
+    },
+    {
+        name: 'Community Hub',
+        description: 'Community-contributed prompts',
+        icon: 'organization',
+        reference: {
+            type: 'github',
+            location: 'promptregistry/community-hub',
+            ref: 'main'
+        },
+        enabled: false // Disabled by default
+    }
+];
+
+let cachedHubs: DefaultHubConfig[] | null = null;
+
+/**
+ * Load default hubs from JSON configuration file (if available)
+ * Falls back to hardcoded configuration
+ */
+function loadDefaultHubs(): DefaultHubConfig[] | null {
+    if (cachedHubs) {
+        return cachedHubs;
+    }
+
+    try {
+        // Try to load from JSON file
+        const configPath = path.join(__dirname, '..', 'config' , 'defaultHubs.json');
+        logger.debug(`Loading default hubs from: ${configPath}`);
+        if (fs.existsSync(configPath)) {
+            const content = fs.readFileSync(configPath, 'utf-8');
+            const config = JSON.parse(content);
+            if (config.defaultHubs && Array.isArray(config.defaultHubs)) {
+                cachedHubs = config.defaultHubs;
+                return cachedHubs;
+            }
+        }
+    } catch (error) {
+        console.warn('Failed to load defaultHubs.json, using hardcoded defaults:', error);
+    }
+
+    // Fallback to hardcoded defaults
+    cachedHubs = HARDCODED_DEFAULT_HUBS;
+    return cachedHubs;
+}
+
+/**
+ * Get all default hubs (loaded from JSON or hardcoded)
+ */
+export function getDefaultHubs(): DefaultHubConfig[] {
+    const hubs = loadDefaultHubs();
+    return hubs || HARDCODED_DEFAULT_HUBS;
+}
+
+/**
+ * Get all enabled default hubs
+ */
+export function getEnabledDefaultHubs(): DefaultHubConfig[] {
+    return getDefaultHubs().filter(hub => hub.enabled !== false);
+}
+
+/**
+ * Get the recommended default hub
+ */
+export function getRecommendedHub(): DefaultHubConfig | undefined {
+    return getDefaultHubs().find(hub => hub.recommended && hub.enabled !== false);
+}
+
+/**
+ * Find a default hub by name
+ */
+export function findDefaultHub(name: string): DefaultHubConfig | undefined {
+    return getDefaultHubs().find(hub => hub.name === name);
+}
+
+/**
+ * Clear the cached hubs (for testing purposes)
+ */
+export function clearCache(): void {
+    cachedHubs = null;
+}

--- a/src/types/registry.ts
+++ b/src/types/registry.ts
@@ -36,6 +36,12 @@ export interface RegistrySource {
         homepage?: string;
         contact?: string;
     };
+    config?: {
+        branch?: string;          // Git branch (for git-based sources)
+        collectionsPath?: string;  // Collections directory (for awesome-copilot)
+        indexFile?: string;        // Index file name (for awesome-copilot)
+        [key: string]: any;        // Allow additional source-specific config
+    };
 }
 
 /**

--- a/src/ui/RegistryTreeProvider.ts
+++ b/src/ui/RegistryTreeProvider.ts
@@ -17,14 +17,7 @@ export enum TreeItemType {
     PROFILES_ROOT = 'profiles_root',
     INSTALLED_ROOT = 'installed_root',
     DISCOVER_ROOT = 'discover_root',
-    SOURCES_ROOT = 'sources_root',
-
-    // Hub items
-    HUBS_ROOT = 'hubs_root',
-    HUB = 'hub',
-    IMPORT_HUB = 'import_hub',
-
-    // Profile items
+    SOURCES_ROOT = 'sources_root',// Profile items
     PROFILE = 'profile',
     PROFILE_BUNDLE = 'profile_bundle',
     CREATE_PROFILE = 'create_profile',
@@ -44,6 +37,10 @@ export enum TreeItemType {
 
     // Bundle items
     BUNDLE = 'bundle',
+
+    // Hub items
+    IMPORT_HUB = 'import_hub',
+    LIST_HUB = 'list_hub',
 }
 
 /**
@@ -94,11 +91,7 @@ export class RegistryTreeItem extends vscode.TreeItem {
             [TreeItemType.SOURCES_ROOT]: 'radio-tower',
             [TreeItemType.SOURCE]: 'repo',
             [TreeItemType.ADD_SOURCE]: 'add',
-            [TreeItemType.HUBS_ROOT]: 'server',
-            [TreeItemType.HUB]: 'server-process',
-            [TreeItemType.IMPORT_HUB]: 'cloud-download',
-            
-            [TreeItemType.BUNDLE]: 'file-zip',
+[TreeItemType.BUNDLE]: 'file-zip',
         };
 
         const iconId = iconMap[this.type];
@@ -174,10 +167,8 @@ export class RegistryTreeItem extends vscode.TreeItem {
             TreeItemType.INSTALLED_BUNDLE,
             TreeItemType.PROFILE,
             TreeItemType.SOURCE,
-            TreeItemType.HUB,
             TreeItemType.CREATE_PROFILE,
             TreeItemType.ADD_SOURCE,
-            TreeItemType.IMPORT_HUB,
             TreeItemType.DISCOVER_CATEGORY,
             TreeItemType.DISCOVER_POPULAR,
             TreeItemType.DISCOVER_RECENT,
@@ -204,9 +195,9 @@ export class RegistryTreeItem extends vscode.TreeItem {
             case TreeItemType.ADD_SOURCE:
                 return 'promptRegistry.addSource';
             case TreeItemType.IMPORT_HUB:
-                return 'promptregistry.importHub';
-            case TreeItemType.HUB:
-                return 'promptregistry.listHubs';
+                return 'promptRegistry.importHub';
+            case TreeItemType.LIST_HUB:
+                return 'promptRegistry.listHubs';
             case TreeItemType.DISCOVER_CATEGORY:
                 return 'promptRegistry.browseByCategory';
             case TreeItemType.DISCOVER_POPULAR:
@@ -245,6 +236,7 @@ export class RegistryTreeProvider implements vscode.TreeDataProvider<RegistryTre
 
         // Listen to profile events
         registryManager.onProfileActivated(() => this.refresh());
+        registryManager.onProfileDeactivated(() => this.refresh());
         registryManager.onProfileCreated(() => this.refresh());
         registryManager.onProfileUpdated(() => this.refresh());
         registryManager.onProfileDeleted(() => this.refresh());
@@ -286,10 +278,7 @@ export class RegistryTreeProvider implements vscode.TreeDataProvider<RegistryTre
 
         // Get children based on parent type
         switch (element.type) {
-            case TreeItemType.HUBS_ROOT:
-                return this.getHubItems();
- 
-            case TreeItemType.PROFILES_ROOT:
+case TreeItemType.PROFILES_ROOT:
                 return this.getProfileItems();
             
             case TreeItemType.PROFILE:
@@ -338,12 +327,6 @@ export class RegistryTreeProvider implements vscode.TreeDataProvider<RegistryTre
             new RegistryTreeItem(
                 '📡 Sources',
                 TreeItemType.SOURCES_ROOT,
-                undefined,
-                vscode.TreeItemCollapsibleState.Collapsed
-            ),
-            new RegistryTreeItem(
-                '🌐 Hubs',
-                TreeItemType.HUBS_ROOT,
                 undefined,
                 vscode.TreeItemCollapsibleState.Collapsed
             ),
@@ -554,39 +537,5 @@ export class RegistryTreeProvider implements vscode.TreeDataProvider<RegistryTre
     /**
      * Get hub items for tree view
      */
-    private async getHubItems(): Promise<RegistryTreeItem[]> {
-        try {
-            const items: RegistryTreeItem[] = [];
-            
-            // Get all hubs
-            const hubs = await this.hubManager.listHubs();
-            
-            for (const hub of hubs) {
-                items.push(
-                    new RegistryTreeItem(
-                        hub.name,
-                        TreeItemType.HUB,
-                        hub,
-                        vscode.TreeItemCollapsibleState.None
-                    )
-                );
-            }
-            
-            // Add "Import Hub" item
-            items.push(
-                new RegistryTreeItem(
-                    '➕ Import Hub...',
-                    TreeItemType.IMPORT_HUB,
-                    undefined,
-                    vscode.TreeItemCollapsibleState.None
-                )
-            );
-            
-            return items;
-        } catch (error) {
-            this.logger.error('Failed to load hubs', error as Error);
-            return [];
-        }
-    }
 
 }

--- a/test/commands/HubProfileActivationCommands.test.ts
+++ b/test/commands/HubProfileActivationCommands.test.ts
@@ -194,7 +194,7 @@ suite('Hub Profile Activation Commands - Integration', () => {
     });
 
     suite('Show Active Profiles Command Integration', () => {
-        test('should list multiple active profiles from different hubs', async () => {
+        test('should list only one active profile (enforces single active profile globally)', async () => {
             const hub1 = createTestHub();
             const hub2 = createTestHub();
             await storage.saveHub('hub-1', hub1, { type: 'github', location: 'test/repo1' });
@@ -205,9 +205,10 @@ suite('Hub Profile Activation Commands - Integration', () => {
 
             const activeProfiles = await hubManager.listAllActiveProfiles();
 
-            assert.strictEqual(activeProfiles.length, 2);
-            assert.ok(activeProfiles.some(p => p.hubId === 'hub-1' && p.profileId === 'profile-1'));
-            assert.ok(activeProfiles.some(p => p.hubId === 'hub-2' && p.profileId === 'profile-2'));
+            // Only the last activated profile should be active (single active profile enforcement)
+            assert.strictEqual(activeProfiles.length, 1);
+            assert.strictEqual(activeProfiles[0].hubId, 'hub-2');
+            assert.strictEqual(activeProfiles[0].profileId, 'profile-2');
         });
 
         test('should include activation timestamps in active profiles', async () => {

--- a/test/commands/HubSyncCommands.test.ts
+++ b/test/commands/HubSyncCommands.test.ts
@@ -255,11 +255,8 @@ suite('Hub Sync Commands', () => {
             await storage.saveHub('hub-1', updated.config, updated.reference);
 
             const results = await commands.checkAllHubsForUpdates();
-            assert.strictEqual(results.length, 2);
-            
-            const hub1Result = results.find(r => r.hubId === 'hub-1');
-            assert.ok(hub1Result);
-            assert.ok(hub1Result.hasUpdates);
+            // Only hub-2 is active (single active profile enforcement deactivated hub-1)
+            assert.strictEqual(results.length, 1);
             
             const hub2Result = results.find(r => r.hubId === 'hub-2');
             assert.ok(hub2Result);

--- a/test/services/HubBundleResolution.test.ts
+++ b/test/services/HubBundleResolution.test.ts
@@ -204,7 +204,7 @@ suite('Hub Bundle Resolution', () => {
             const resolved = await hubManager.resolveProfileBundles('test-hub', 'test-profile');
 
             assert.strictEqual(resolved.length, 3);
-            assert.ok(resolved.every(b => b.url));
+            // URL is no longer populated by resolveProfileBundles
             assert.ok(resolved.every(b => b.bundle));
         });
 
@@ -309,14 +309,15 @@ suite('Hub Bundle Resolution', () => {
             assert.strictEqual(source.enabled, false);
         });
 
-        test('should throw error for bundle with missing source reference', async () => {
+        test('should resolve bundles even with missing source reference', async () => {
             const hub = createHubWithSources();
             hub.profiles[0].bundles[0].source = 'missing-source';
             await storage.saveHub('test-hub', hub, { type: 'github', location: 'test/hub' });
 
-            await assert.rejects(
-                async () => await hubManager.resolveProfileBundles('test-hub', 'test-profile')
-            );
+            // resolveProfileBundles no longer validates sources - that happens during installation
+            const resolved = await hubManager.resolveProfileBundles('test-hub', 'test-profile');
+            assert.ok(resolved.length > 0);
+            assert.strictEqual(resolved[0].bundle.source, 'missing-source');
         });
     });
 });

--- a/test/services/HubProfileActivationLogic.test.ts
+++ b/test/services/HubProfileActivationLogic.test.ts
@@ -299,7 +299,7 @@ suite('Hub Profile Activation Logic', () => {
             assert.ok(result.resolvedBundles);
             assert.strictEqual(result.resolvedBundles.length, 2);
             assert.ok(result.resolvedBundles[0].bundle);
-            assert.ok(result.resolvedBundles[0].url);
+            // URL is no longer populated by resolveProfileBundles
         });
     });
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
Implement single active hub profile with automatic bundle management

## Type of Change

<!-- Mark relevant items with an [x] -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 📝 Documentation update

## Changes Made

<!-- Provide a detailed list of changes -->
- Add single active hub profile enforcement across all hubs
- Implement automatic bundle installation/uninstallation on profile activation
- Add default hubs configuration with first-run automatic activation
- Add hub configuration auto-sync on extension startup
- Add command to open hub configuration files
- Ensure proper cleanup of activation states on hub deletion
- Treat local and hub profiles identically for deactivation
- Add comprehensive tests for hub profile activation flows

## Testing

<!-- Describe the testing you've done -->

### Test Coverage

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

### Tested On

- [x] Linux

- [x] VS Code Insiders

## Checklist

<!-- Mark completed items with an [x] -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Documentation

<!-- Describe any documentation changes needed -->

- [x] README.md updated
- [x] JSDoc comments added/updated

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**
