### PR TITLE
feat: add WSL remote support for prompt syncing

### DIFF
--- a/docs/WSL_SUPPORT.md
+++ b/docs/WSL_SUPPORT.md
@@ -1,0 +1,134 @@
+# WSL Support
+
+The Prompt Registry extension now fully supports Windows Subsystem for Linux (WSL) environments.
+
+## Background
+
+When VS Code is connected to a WSL remote window:
+- The extension runs in the **WSL (Linux) context**
+- GitHub Copilot runs in the **Windows UI context**
+- Prompts must be synced to the **Windows filesystem** for Copilot to access them
+
+## How It Works
+
+The extension automatically detects WSL remote connections using `vscode.env.remoteName` and:
+
+1. **Detects the Windows username** via `cmd.exe /c echo %USERNAME%`
+2. **Maps to Windows filesystem** via WSL mount points (`/mnt/c/`, `/mnt/d/`, etc.)
+3. **Syncs prompts to Windows directory**: `/mnt/c/Users/{username}/AppData/Roaming/Code/User/prompts`
+
+## Supported Scenarios
+
+### ✅ Scenario A: Windows Mount Storage
+When VS Code uses Windows-mounted storage:
+```
+globalStoragePath: /mnt/c/Users/username/AppData/Roaming/Code/User/globalStorage/...
+→ Prompts synced to: /mnt/c/Users/username/AppData/Roaming/Code/User/prompts
+```
+
+### ✅ Scenario B: WSL Remote Storage
+When VS Code uses WSL remote storage:
+```
+globalStoragePath: /home/username/.vscode-server/data/User/globalStorage/...
+→ Prompts synced to: /mnt/c/Users/{windows-username}/AppData/Roaming/Code/User/prompts
+```
+
+## Edge Cases Handled
+
+### Different Usernames
+If your WSL username differs from Windows username:
+- Extension executes `cmd.exe /c echo %USERNAME%` to get actual Windows username
+- Fallback: Uses WSL username if command fails
+
+### Multiple Drive Letters
+If Windows is installed on D: or other drive:
+- Extension checks `/mnt/c/`, `/mnt/d/`, `/mnt/e/`, `/mnt/f/` in priority order
+- Uses first accessible drive with `Users/{username}/AppData/Roaming`
+
+### VS Code Flavors
+Automatically detects and supports:
+- VS Code Stable (`Code`)
+- VS Code Insiders (`Code - Insiders`)
+- Windsurf (`Windsurf`)
+- Cursor (`Cursor`)
+
+### VS Code Profiles
+Profile-based installations are fully supported:
+```
+→ Prompts synced to: /mnt/c/Users/username/AppData/Roaming/Code/User/profiles/{profile-id}/prompts
+```
+
+## Other Remote Types
+
+- **SSH Remote** (`remoteName === 'ssh-remote'`): Uses existing logic (not WSL-specific)
+- **Local** (`remoteName === undefined`): Uses platform-native paths (Windows/macOS/Linux)
+
+## Troubleshooting
+
+### Prompts not appearing in Copilot chat
+
+**Symptoms**: Downloaded collections don't show in Copilot when working in WSL project
+
+**Solutions**:
+1. Check VS Code Output panel → "Prompt Registry" for WSL detection logs
+2. Verify Windows username detection: Look for `WSL: Windows username from cmd.exe:`
+3. Ensure Windows AppData directory is accessible from WSL: `ls /mnt/c/Users/{username}/AppData/Roaming/Code/User/prompts`
+4. Check permissions on Windows prompts directory
+5. Restart VS Code after installing collections
+
+### Permission Errors
+
+If you see `EACCES: permission denied` errors:
+- Ensure Windows user has write access to `C:\Users\{username}\AppData\Roaming\Code\User\prompts`
+- Check if antivirus is blocking WSL file access
+- Verify WSL mount is accessible: `ls /mnt/c/Users`
+
+### Wrong Drive Letter
+
+If extension uses wrong drive (e.g., C: instead of D:):
+- Extension checks drives in order: C → D → E → F
+- Manually create directory if needed: `mkdir -p /mnt/d/Users/{username}/AppData/Roaming/Code/User/prompts`
+- Check logs for drive detection: `WSL: Found Windows drive:`
+
+## Technical Details
+
+### Detection Method
+```typescript
+if (vscode.env.remoteName === 'wsl') {
+    // Use WSL-specific logic
+}
+```
+
+### Username Detection
+```bash
+# Primary method
+cmd.exe /c echo %USERNAME%
+
+# Fallback methods
+process.env.LOGNAME
+process.env.USER
+os.userInfo().username
+```
+
+### Drive Detection
+Checks in priority order:
+1. `/mnt/c/Users/{username}/AppData/Roaming` (most common)
+2. `/mnt/d/Users/{username}/AppData/Roaming`
+3. `/mnt/e/Users/{username}/AppData/Roaming`
+4. `/mnt/f/Users/{username}/AppData/Roaming`
+
+## Related Issues
+
+- [Issue #22: WSL Support](https://github.com/AmadeusITGroup/prompt-registry/issues/22)
+
+## Testing
+
+Comprehensive unit tests cover:
+- WSL with `/mnt/c/` mount paths
+- WSL with `/mnt/d/` (alternate drive)
+- WSL with Code Insiders flavor
+- WSL with profile-based paths
+- Local context (non-WSL)
+- SSH remote context
+
+See `test/services/CopilotSyncService.test.ts` → "WSL Support" suite.

--- a/src/services/CopilotSyncService.ts
+++ b/src/services/CopilotSyncService.ts
@@ -16,7 +16,9 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
+import * as os from 'os';
 import { promisify } from 'util';
+import { execSync } from 'child_process';
 import * as yaml from 'js-yaml';
 import { Logger } from '../utils/logger';
 import { escapeRegex } from '../utils/regexUtils';
@@ -62,8 +64,18 @@ export class CopilotSyncService {
      * 
      * WORKAROUND: If extension is installed globally but user is in a profile,
      * we detect the active profile using combined detection methods
+     * 
+     * WSL Support: When running in WSL remote context, GitHub Copilot runs in the Windows UI,
+     * so we need to sync prompts to the Windows filesystem, not the WSL filesystem.
      */
     private getCopilotPromptsDirectory(): string {
+        // WSL Support: Check if we're running in WSL remote context
+        // In WSL, the extension runs in the remote (Linux) context, but Copilot runs in UI (Windows) context
+        // We need to write prompts to the Windows filesystem where Copilot can find them
+        if (vscode.env.remoteName === 'wsl') {
+            return this.getWindowsPromptDirectoryFromWSL();
+        }
+
         const globalStoragePath = this.context.globalStorageUri.fsPath;
         
         // Find the User directory by looking for '/User/' or '\User\' in the path
@@ -117,6 +129,158 @@ export class CopilotSyncService {
         return path.join(userDir, 'prompts');
     }
 
+
+    /**
+     * Get Windows Copilot prompts directory when running in WSL
+     * 
+     * In WSL, the extension runs in the remote (Linux) context,
+     * but Copilot runs in the UI (Windows) context.
+     * We need to sync prompts to the Windows filesystem.
+     * 
+     * Strategy:
+     * 1. Detect if globalStorageUri already points to Windows mount (/mnt/c/)
+     * 2. If not, get Windows username and construct Windows path
+     * 3. Handle multiple drive letters (C:, D:, etc.)
+     * 4. Detect VS Code flavor (Code, Insiders, Windsurf)
+     * 5. Support profile detection
+     * 
+     * Edge cases handled:
+     * - Different WSL and Windows usernames (exec Windows USERNAME command)
+     * - Multiple drive letters (/mnt/c, /mnt/d, etc.)
+     * - VS Code profiles
+     * - Different VS Code flavors
+     */
+    private getWindowsPromptDirectoryFromWSL(): string {
+        const globalStoragePath = this.context.globalStorageUri.fsPath;
+        this.logger.info(`[CopilotSync] WSL detected, globalStoragePath: ${globalStoragePath}`);
+
+        let windowsUsername: string;
+        let appDataPath: string;
+        let vscodeFlavorDir: string;
+        let driveLetter = 'c'; // Default to C:
+
+        // Check if globalStoragePath already points to Windows mount (/mnt/X/)
+        const mountMatch = globalStoragePath.match(/^\/mnt\/([a-z])\/Users\/([^/]+)\/AppData\/Roaming\/([^/]+)/);
+        
+        if (mountMatch) {
+            // Scenario A: Already pointing to Windows filesystem via WSL mount
+            // Path like: /mnt/c/Users/username/AppData/Roaming/Code/User/globalStorage/...
+            driveLetter = mountMatch[1];
+            windowsUsername = mountMatch[2];
+            vscodeFlavorDir = mountMatch[3]; // "Code", "Code - Insiders", "Windsurf", etc.
+            appDataPath = `/mnt/${driveLetter}/Users/${windowsUsername}/AppData/Roaming`;
+            
+            this.logger.info(`[CopilotSync] WSL: Detected Windows mount - User: ${windowsUsername}, Flavor: ${vscodeFlavorDir}, Drive: ${driveLetter.toUpperCase()}:`);
+        } else {
+            // Scenario B: globalStoragePath points to WSL filesystem (e.g., /home/username/.vscode-server)
+            // Need to map to Windows equivalent
+            
+            this.logger.info(`[CopilotSync] WSL: Remote storage detected, mapping to Windows filesystem`);
+            
+            // Get Windows username - try multiple methods for robustness
+            try {
+                // Method 1: Execute Windows command to get actual Windows username
+                // This handles cases where WSL username differs from Windows username
+                const result = execSync('cmd.exe /c echo %USERNAME%', { 
+                    encoding: 'utf-8',
+                    timeout: 5000,
+                    stdio: ['pipe', 'pipe', 'ignore'] // Suppress stderr
+                }).trim();
+                
+                if (result && result !== '%USERNAME%') {
+                    windowsUsername = result;
+                    this.logger.info(`[CopilotSync] WSL: Windows username from cmd.exe: ${windowsUsername}`);
+                } else {
+                    throw new Error('cmd.exe returned empty or unexpanded variable');
+                }
+            } catch (error) {
+                // Method 2: Fallback to WSL username (assumes same as Windows username)
+                windowsUsername = process.env.LOGNAME || process.env.USER || os.userInfo().username || 'default';
+                this.logger.warn(`[CopilotSync] WSL: Could not get Windows username via cmd.exe, using WSL username: ${windowsUsername}`);
+                this.logger.debug(`[CopilotSync] WSL: cmd.exe error: ${error}`);
+            }
+            
+            // Detect VS Code flavor from appName
+            const appName = vscode.env.appName;
+            if (appName.includes('Insiders')) {
+                vscodeFlavorDir = 'Code - Insiders';
+            } else if (appName.includes('Windsurf')) {
+                vscodeFlavorDir = 'Windsurf';
+            } else if (appName.includes('Cursor')) {
+                vscodeFlavorDir = 'Cursor';
+            } else {
+                vscodeFlavorDir = 'Code';
+            }
+            
+            this.logger.info(`[CopilotSync] WSL: Detected VS Code flavor: ${vscodeFlavorDir}`);
+            
+            // Try to find the correct Windows drive by checking common mount points
+            // Priority: C: > D: > E: > F:
+            const driveLetters = ['c', 'd', 'e', 'f'];
+            let foundDrive = false;
+            
+            for (const letter of driveLetters) {
+                const testPath = `/mnt/${letter}/Users/${windowsUsername}/AppData/Roaming`;
+                try {
+                    if (fs.existsSync(testPath)) {
+                        driveLetter = letter;
+                        foundDrive = true;
+                        this.logger.info(`[CopilotSync] WSL: Found Windows drive: ${letter.toUpperCase()}:`);
+                        break;
+                    }
+                } catch (error) {
+                    // Drive not accessible, continue to next
+                    continue;
+                }
+            }
+            
+            if (!foundDrive) {
+                this.logger.warn(`[CopilotSync] WSL: Could not find Windows AppData, defaulting to C: drive`);
+                driveLetter = 'c';
+            }
+            
+            appDataPath = `/mnt/${driveLetter}/Users/${windowsUsername}/AppData/Roaming`;
+        }
+
+        // Check for profile in globalStoragePath
+        // Profiles can appear in both Windows mount paths and WSL remote paths
+        const escapedSep = escapeRegex(path.sep);
+        const profilesMatch = globalStoragePath.match(new RegExp(`profiles${escapedSep}([^${escapedSep}]+)`));
+        
+        if (profilesMatch) {
+            const profileId = profilesMatch[1];
+            const promptsDir = path.join(appDataPath, vscodeFlavorDir, 'User', 'profiles', profileId, 'prompts');
+            this.logger.info(`[CopilotSync] WSL: Using profile prompts directory: ${promptsDir}`);
+            
+            // Ensure directory exists
+            try {
+                if (!fs.existsSync(promptsDir)) {
+                    fs.mkdirSync(promptsDir, { recursive: true });
+                    this.logger.info(`[CopilotSync] WSL: Created profile prompts directory`);
+                }
+            } catch (error) {
+                this.logger.error(`[CopilotSync] WSL: Failed to create profile prompts directory: ${error}`);
+            }
+            
+            return promptsDir;
+        }
+
+        // Standard path: User/prompts
+        const promptsDir = path.join(appDataPath, vscodeFlavorDir, 'User', 'prompts');
+        this.logger.info(`[CopilotSync] WSL: Using default prompts directory: ${promptsDir}`);
+        
+        // Ensure directory exists
+        try {
+            if (!fs.existsSync(promptsDir)) {
+                fs.mkdirSync(promptsDir, { recursive: true });
+                this.logger.info(`[CopilotSync] WSL: Created prompts directory`);
+            }
+        } catch (error) {
+            this.logger.error(`[CopilotSync] WSL: Failed to create prompts directory: ${error}`);
+        }
+        
+        return promptsDir;
+    }
     /**
      * Detect active profile using combined workarounds
      * 

--- a/test/services/CopilotSyncService.test.ts
+++ b/test/services/CopilotSyncService.test.ts
@@ -644,6 +644,220 @@ prompts:
                 `Should prefer storage.json over filesystem heuristic, got: ${status.copilotDir}`
             );
         });
+
+    suite('WSL Support', () => {
+        test('should detect WSL remote and return Windows mount path when globalStorage is on /mnt/c', async () => {
+            // Mock WSL scenario where globalStorage is already on Windows mount
+            const wslMountContext: any = {
+                globalStorageUri: { 
+                    fsPath: '/mnt/c/Users/testuser/AppData/Roaming/Code/User/globalStorage/publisher.extension' 
+                },
+                storageUri: { fsPath: '/home/testuser/workspace' },
+                extensionPath: __dirname,
+                subscriptions: [],
+            };
+
+            // Mock vscode.env.remoteName
+            const originalEnv = (global as any).vscode?.env;
+            if (!(global as any).vscode) {
+                (global as any).vscode = {};
+            }
+            (global as any).vscode.env = { remoteName: 'wsl', appName: 'Visual Studio Code' };
+
+            try {
+                const wslService = new CopilotSyncService(wslMountContext);
+                const status = await wslService.getStatus();
+                
+                assert.ok(
+                    status.copilotDir.startsWith('/mnt/c/Users/testuser/AppData/Roaming/Code/User'),
+                    `WSL should use Windows mount path, got: ${status.copilotDir}`
+                );
+                assert.ok(
+                    status.copilotDir.includes('/prompts'),
+                    'WSL path should include prompts directory'
+                );
+            } finally {
+                // Restore original env
+                if (originalEnv) {
+                    (global as any).vscode.env = originalEnv;
+                } else {
+                    delete (global as any).vscode;
+                }
+            }
+        });
+
+        test('should handle WSL with D: drive mount', async () => {
+            const wslDriveContext: any = {
+                globalStorageUri: { 
+                    fsPath: '/mnt/d/Users/testuser/AppData/Roaming/Code/User/globalStorage/publisher.extension' 
+                },
+                storageUri: { fsPath: '/home/testuser/workspace' },
+                extensionPath: __dirname,
+                subscriptions: [],
+            };
+
+            // Mock vscode.env.remoteName
+            if (!(global as any).vscode) {
+                (global as any).vscode = {};
+            }
+            const originalEnv = (global as any).vscode.env;
+            (global as any).vscode.env = { remoteName: 'wsl', appName: 'Visual Studio Code' };
+
+            try {
+                const wslService = new CopilotSyncService(wslDriveContext);
+                const status = await wslService.getStatus();
+                
+                assert.ok(
+                    status.copilotDir.startsWith('/mnt/d/Users/testuser'),
+                    `WSL should detect D: drive, got: ${status.copilotDir}`
+                );
+            } finally {
+                if (originalEnv) {
+                    (global as any).vscode.env = originalEnv;
+                } else {
+                    delete (global as any).vscode?.env;
+                }
+            }
+        });
+
+        test('should handle WSL with Code Insiders flavor', async () => {
+            const wslInsidersContext: any = {
+                globalStorageUri: { 
+                    fsPath: '/mnt/c/Users/testuser/AppData/Roaming/Code - Insiders/User/globalStorage/publisher.extension' 
+                },
+                storageUri: { fsPath: '/home/testuser/workspace' },
+                extensionPath: __dirname,
+                subscriptions: [],
+            };
+
+            // Mock vscode.env
+            if (!(global as any).vscode) {
+                (global as any).vscode = {};
+            }
+            const originalEnv = (global as any).vscode.env;
+            (global as any).vscode.env = { remoteName: 'wsl', appName: 'Visual Studio Code Insiders' };
+
+            try {
+                const wslService = new CopilotSyncService(wslInsidersContext);
+                const status = await wslService.getStatus();
+                
+                assert.ok(
+                    status.copilotDir.includes('Code - Insiders'),
+                    `WSL should detect Insiders flavor, got: ${status.copilotDir}`
+                );
+            } finally {
+                if (originalEnv) {
+                    (global as any).vscode.env = originalEnv;
+                } else {
+                    delete (global as any).vscode?.env;
+                }
+            }
+        });
+
+        test('should handle WSL with profile path', async () => {
+            const wslProfileContext: any = {
+                globalStorageUri: { 
+                    fsPath: '/mnt/c/Users/testuser/AppData/Roaming/Code/User/profiles/abc123/globalStorage/publisher.extension' 
+                },
+                storageUri: { fsPath: '/home/testuser/workspace' },
+                extensionPath: __dirname,
+                subscriptions: [],
+            };
+
+            // Mock vscode.env
+            if (!(global as any).vscode) {
+                (global as any).vscode = {};
+            }
+            const originalEnv = (global as any).vscode.env;
+            (global as any).vscode.env = { remoteName: 'wsl', appName: 'Visual Studio Code' };
+
+            try {
+                const wslService = new CopilotSyncService(wslProfileContext);
+                const status = await wslService.getStatus();
+                
+                assert.ok(
+                    status.copilotDir.includes('/profiles/abc123/prompts'),
+                    `WSL should handle profile path, got: ${status.copilotDir}`
+                );
+            } finally {
+                if (originalEnv) {
+                    (global as any).vscode.env = originalEnv;
+                } else {
+                    delete (global as any).vscode?.env;
+                }
+            }
+        });
+
+        test('should not use WSL path for local context (remoteName undefined)', async () => {
+            const localContext: any = {
+                globalStorageUri: { 
+                    fsPath: path.join(tempDir, 'Code', 'User', 'globalStorage', 'publisher.extension')
+                },
+                storageUri: { fsPath: path.join(tempDir, 'workspace') },
+                extensionPath: __dirname,
+                subscriptions: [],
+            };
+
+            // Mock vscode.env with undefined remoteName (local)
+            if (!(global as any).vscode) {
+                (global as any).vscode = {};
+            }
+            const originalEnv = (global as any).vscode.env;
+            (global as any).vscode.env = { remoteName: undefined, appName: 'Visual Studio Code' };
+
+            try {
+                const localService = new CopilotSyncService(localContext);
+                const status = await localService.getStatus();
+                
+                assert.ok(
+                    !status.copilotDir.includes('/mnt/'),
+                    `Local context should not use WSL mount, got: ${status.copilotDir}`
+                );
+            } finally {
+                if (originalEnv) {
+                    (global as any).vscode.env = originalEnv;
+                } else {
+                    delete (global as any).vscode?.env;
+                }
+            }
+        });
+
+        test('should handle SSH remote (not WSL) with existing logic', async () => {
+            const sshContext: any = {
+                globalStorageUri: { 
+                    fsPath: '/home/remoteuser/.vscode-server/data/User/globalStorage/publisher.extension'
+                },
+                storageUri: { fsPath: '/home/remoteuser/workspace' },
+                extensionPath: __dirname,
+                subscriptions: [],
+            };
+
+            // Mock vscode.env with ssh-remote
+            if (!(global as any).vscode) {
+                (global as any).vscode = {};
+            }
+            const originalEnv = (global as any).vscode.env;
+            (global as any).vscode.env = { remoteName: 'ssh-remote', appName: 'Visual Studio Code' };
+
+            try {
+                const sshService = new CopilotSyncService(sshContext);
+                const status = await sshService.getStatus();
+                
+                // SSH should use existing logic, not WSL-specific handling
+                assert.ok(
+                    !status.copilotDir.includes('/mnt/c/'),
+                    `SSH remote should not use WSL mount path, got: ${status.copilotDir}`
+                );
+            } finally {
+                if (originalEnv) {
+                    (global as any).vscode.env = originalEnv;
+                } else {
+                    delete (global as any).vscode?.env;
+                }
+            }
+        });
+    });
+
     });
 });
 });


### PR DESCRIPTION
## Description

When VS Code is connected to a WSL remote window, the extension now properly syncs prompts to the Windows filesystem where GitHub Copilot runs, rather than the WSL filesystem.

## Type of Change

<!-- Mark relevant items with an [x] -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Related Issues

<!-- Link to related issues using #issue_number -->
Fixes #22

## Changes Made

- Added WSL detection using vscode.env.remoteName === 'wsl'
- Implemented getWindowsPromptDirectoryFromWSL() method with comprehensive edge case handling:
  - Different WSL and Windows usernames (uses cmd.exe to get Windows user)
  - Multiple drive letters (checks /mnt/c, /mnt/d, /mnt/e, /mnt/f)
  - All VS Code flavors (Code, Insiders, Windsurf, Cursor)
  - VS Code profiles support
- Added comprehensive unit tests (6 new test cases)
- Added detailed documentation in docs/WSL_SUPPORT.md

Technical details:
- Imports: Added os and child_process for system operations
- Detection: Parses globalStoragePath for Windows mount patterns
- Fallback: Gracefully handles missing or inaccessible Windows paths
- Logging: Extensive debug logging for troubleshooting

The implementation handles both scenarios:
1. globalStorage already on Windows mount (/mnt/c/Users/...)
2. globalStorage on WSL filesystem (/home/.../.vscode-server)

## Testing

<!-- Describe the testing you've done -->
All unit tests passing including new WSL tests.

### Test Coverage

- [x] Unit tests added/updated
- [x] All existing tests pass

## Checklist

<!-- Mark completed items with an [x] -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Documentation

<!-- Describe any documentation changes needed -->

- [x] JSDoc comments added/updated

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**
