### PR TITLE
fix: importing a new hub duplicate sources

### DIFF
--- a/src/commands/HubCommands.ts
+++ b/src/commands/HubCommands.ts
@@ -115,37 +115,8 @@ export class HubCommands {
                         // Load the hub
                         const importedHubConfig = await this.hubManager.loadHub(importedHubId);
 
-                        // Sync sources from hub
-                        if (importedHubConfig.config.sources && importedHubConfig.config.sources.length > 0) {
-                            progress.report({ message: 'Importing sources...' });
-                            try {
-                                const existingSources = await this.registryManager.listSources();
-                                
-                                for (const sourceConfig of importedHubConfig.config.sources) {
-                                    // Check if source already exists
-                                    const existing = existingSources.find(s => s.id === sourceConfig.id);
-                                    
-                                    if (existing) {
-                                        this.logger.info(`Source ${sourceConfig.id} already exists, skipping import from hub.`);
-                                    } else {
-                                        try {
-                                            // Inject hubId to track provenance
-                                            const sourceToAdd = {
-                                                ...sourceConfig,
-                                                hubId: importedHubId
-                                            };
-                                            await this.registryManager.addSource(sourceToAdd);
-                                            this.logger.info(`Imported source ${sourceConfig.id} from hub`);
-                                        } catch (error) {
-                                            this.logger.error(`Failed to import source ${sourceConfig.id}`, error as Error);
-                                        }
-                                    }
-                                }
-                                this.logger.info(`Processed ${importedHubConfig.config.sources.length} sources from hub`);
-                            } catch (error) {
-                                this.logger.error('Failed to sync sources from hub', error as Error);
-                            }
-                        }
+                        // Note: Sources are automatically loaded by HubManager.importHub() via loadHubSources()
+                        // No need to manually import sources here - that would create duplicates
                         
                         if (importedHubConfig.config.profiles && importedHubConfig.config.profiles.length > 0) {
                             progress.report({ message: 'Creating profiles...' });


### PR DESCRIPTION
## Description

Fixed a bug where importing a hub would create duplicate sources in the registry. The issue was caused by both `HubCommands.ts` and `HubManager.ts` adding sources independently during hub import operations.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test coverage improvement
- [ ] 🔧 Configuration/build changes

## Related Issues

Closes #
Fixes #
Relates to #

## Changes Made

- Removed duplicate source-adding logic from `HubCommands.ts` - delegated entirely to `HubManager.ts`
- Refactored `HubManager.ts` to consolidate source management logic
- Added comprehensive integration test in `HubSourceLoading.test.ts` that reproduces the duplicate source bug and validates the fix
- Updated `.github/copilot-instructions.md` with bug-fixing methodology emphasizing test-first approach

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

### Manual Testing Steps

1. Import a hub using the "Import Hub from URL" command
2. Check the sources tree view to verify no duplicate sources appear
3. Verify hub bundles are correctly available after import
4. Inspect `globalStorage/amadeusitgroup.prompt-registry/sources.json` to confirm only one entry per source

### Tested On

- [x] macOS
- [ ] Windows
- [ ] Linux

- [x] VS Code Stable
- [ ] VS Code Insiders

## Screenshots

N/A - Bug fix with no UI changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Documentation

- [ ] README.md updated
- [ ] JSDoc comments added/updated
- [x] No documentation changes needed

## Additional Notes

This fix follows the bug-fixing methodology documented in `.github/copilot-instructions.md`:
1. Wrote integration test that reproduced the duplicate source issue
2. Identified the root cause: both command layer and service layer were adding sources
3. Fixed by removing duplicate logic from commands and centralizing in `HubManager`

The test now verifies that importing a hub results in exactly one source entry per unique source URL.

## Reviewer Guidelines

Please pay special attention to:

- The integration test `HubSourceLoading.test.ts` - verify it properly validates single source creation
- Verify no other code paths still duplicate source addition logic
- Ensure the layering is correct: commands delegate to services, services own the business logic

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**
