### PR TITLE
feat: Support for copilot skills datasource

### DIFF
--- a/src/adapters/LocalSkillsAdapter.ts
+++ b/src/adapters/LocalSkillsAdapter.ts
@@ -1,0 +1,590 @@
+/**
+ * Local Skills filesystem adapter
+ * Handles local filesystem directories containing Anthropic-style skills with SKILL.md files
+ * 
+ * Directory structure:
+ * - skills/ folder at root
+ * - Each subfolder is a skill (folder name = skill ID)
+ * - Each skill has a SKILL.md file with YAML frontmatter (name, description) and markdown instructions
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { promisify } from 'util';
+import AdmZip = require('adm-zip');
+import * as yaml from 'js-yaml';
+import { RepositoryAdapter } from './RepositoryAdapter';
+import { Bundle, SourceMetadata, ValidationResult, RegistrySource } from '../types/registry';
+import { SkillItem, SkillFrontmatter, ParsedSkillFile } from '../types/skills';
+import { Logger } from '../utils/logger';
+
+const readdir = promisify(fs.readdir);
+const readFile = promisify(fs.readFile);
+const stat = promisify(fs.stat);
+const access = promisify(fs.access);
+
+/**
+ * Local Skills filesystem adapter implementation
+ * Expects a directory structure with skills/ subdirectory containing skill folders
+ */
+export class LocalSkillsAdapter extends RepositoryAdapter {
+    readonly type = 'local-skills';
+    private logger: Logger;
+
+    constructor(source: RegistrySource) {
+        super(source);
+        this.logger = Logger.getInstance();
+        
+        if (!this.isValidLocalPath(source.url)) {
+            throw new Error(`Invalid local skills path: ${source.url}`);
+        }
+    }
+
+    /**
+     * Get local directory path from file:// URL or direct path
+     */
+    private getLocalPath(): string {
+        let localPath = this.source.url;
+        
+        if (localPath.startsWith('file://')) {
+            localPath = localPath.substring(7);
+        }
+        
+        if (localPath.startsWith('~/')) {
+            const os = require('os');
+            localPath = path.join(os.homedir(), localPath.slice(2));
+        }
+        
+        return path.normalize(localPath);
+    }
+
+    /**
+     * Check if path is valid local filesystem path
+     */
+    private isValidLocalPath(url: string): boolean {
+        return url.startsWith('file://') || 
+               path.isAbsolute(url) ||
+               url.startsWith('~/') ||
+               url.startsWith('./');
+    }
+
+    /**
+     * Check if directory exists and is accessible
+     */
+    private async directoryExists(dirPath: string): Promise<boolean> {
+        try {
+            await access(dirPath, fs.constants.R_OK);
+            const stats = await stat(dirPath);
+            return stats.isDirectory();
+        } catch {
+            return false;
+        }
+    }
+
+    /**
+     * Validate directory structure for local skills source
+     */
+    private async validateDirectoryStructure(): Promise<ValidationResult> {
+        const localPath = this.getLocalPath();
+        const errors: string[] = [];
+        const warnings: string[] = [];
+
+        this.logger.debug(`[LocalSkillsAdapter] Validating directory structure: ${localPath}`);
+
+        try {
+            await access(localPath, fs.constants.R_OK);
+            const stats = await stat(localPath);
+            if (!stats.isDirectory()) {
+                return {
+                    valid: false,
+                    errors: [`Path is not a directory: ${localPath}`],
+                    warnings: [],
+                };
+            }
+        } catch (error) {
+            const errorCode = (error as NodeJS.ErrnoException).code;
+            let errorMessage = `Directory not accessible: ${localPath}`;
+            
+            if (errorCode === 'ENOENT') {
+                errorMessage = `Directory does not exist: ${localPath}`;
+            } else if (errorCode === 'EACCES') {
+                errorMessage = `Permission denied accessing directory: ${localPath}`;
+            }
+            
+            return {
+                valid: false,
+                errors: [errorMessage],
+                warnings: [],
+            };
+        }
+
+        const skillsPath = path.join(localPath, 'skills');
+        if (!(await this.directoryExists(skillsPath))) {
+            errors.push(`Missing required 'skills' directory: ${skillsPath}`);
+        }
+
+        const isValid = errors.length === 0;
+        
+        if (isValid) {
+            this.logger.debug(`[LocalSkillsAdapter] Directory structure validation passed`);
+        } else {
+            this.logger.warn(`[LocalSkillsAdapter] Directory structure validation failed: ${errors.join(', ')}`);
+        }
+
+        return {
+            valid: isValid,
+            errors,
+            warnings,
+        };
+    }
+
+    /**
+     * Validate local skills source
+     */
+    async validate(): Promise<ValidationResult> {
+        const errors: string[] = [];
+        const warnings: string[] = [];
+        
+        try {
+            this.logger.info(`[LocalSkillsAdapter] Validating local skills source: ${this.source.url}`);
+            
+            const structureValidation = await this.validateDirectoryStructure();
+            if (!structureValidation.valid) {
+                return structureValidation;
+            }
+            
+            let skillCount = 0;
+            try {
+                const skills = await this.scanSkillsDirectory();
+                skillCount = skills.length;
+                
+                if (skillCount === 0) {
+                    warnings.push('No valid skills found in skills/ directory (skills must have SKILL.md file)');
+                } else {
+                    this.logger.info(`[LocalSkillsAdapter] Found ${skillCount} valid skill(s)`);
+                }
+            } catch (scanError) {
+                warnings.push(`Failed to scan skills: ${scanError}`);
+            }
+            
+            return {
+                valid: true,
+                errors: [],
+                warnings,
+                bundlesFound: skillCount,
+            };
+            
+        } catch (error) {
+            return {
+                valid: false,
+                errors: [`Local skills source validation failed: ${error}`],
+                warnings,
+            };
+        }
+    }
+
+    /**
+     * Fetch repository metadata
+     */
+    async fetchMetadata(): Promise<SourceMetadata> {
+        try {
+            const localPath = this.getLocalPath();
+            const skills = await this.scanSkillsDirectory();
+            const stats = await stat(localPath);
+
+            return {
+                name: path.basename(localPath),
+                description: 'Local Skills Repository',
+                bundleCount: skills.length,
+                lastUpdated: stats.mtime.toISOString(),
+                version: '1.0.0',
+            };
+        } catch (error) {
+            throw new Error(`Failed to fetch local skills metadata: ${error}`);
+        }
+    }
+
+    /**
+     * Fetch all skills as bundles
+     */
+    async fetchBundles(): Promise<Bundle[]> {
+        this.logger.info(`[LocalSkillsAdapter] Fetching skills from: ${this.source.url}`);
+        
+        try {
+            const skills = await this.scanSkillsDirectory();
+            this.logger.info(`[LocalSkillsAdapter] Found ${skills.length} skills`);
+            
+            const bundles: Bundle[] = [];
+            for (const skill of skills) {
+                try {
+                    const bundle = this.createBundleFromSkill(skill);
+                    bundles.push(bundle);
+                    this.logger.debug(`[LocalSkillsAdapter] Created bundle: ${bundle.id}`);
+                } catch (error) {
+                    this.logger.warn(`[LocalSkillsAdapter] Failed to create bundle from skill ${skill.id}: ${error}`);
+                }
+            }
+            
+            this.logger.info(`[LocalSkillsAdapter] Successfully created ${bundles.length} bundles`);
+            return bundles;
+            
+        } catch (error) {
+            this.logger.error(`[LocalSkillsAdapter] Failed to fetch skills: ${error}`);
+            throw new Error(`Failed to fetch local skills: ${error}`);
+        }
+    }
+
+    /**
+     * Scan skills/ directory for skill folders
+     */
+    private async scanSkillsDirectory(): Promise<SkillItem[]> {
+        const localPath = this.getLocalPath();
+        const skillsPath = path.join(localPath, 'skills');
+        
+        this.logger.debug(`[LocalSkillsAdapter] Scanning skills directory: ${skillsPath}`);
+        
+        try {
+            const entries = await readdir(skillsPath, { withFileTypes: true });
+            const skills: SkillItem[] = [];
+            
+            const directories = entries.filter(entry => entry.isDirectory());
+            this.logger.debug(`[LocalSkillsAdapter] Found ${directories.length} directories in skills/`);
+            
+            for (const dir of directories) {
+                try {
+                    const skill = await this.processSkillDirectory(dir.name, skillsPath);
+                    if (skill) {
+                        skills.push(skill);
+                    }
+                } catch (error) {
+                    this.logger.warn(`[LocalSkillsAdapter] Failed to process skill directory ${dir.name}: ${error}`);
+                }
+            }
+            
+            return skills;
+            
+        } catch (error) {
+            this.logger.error(`[LocalSkillsAdapter] Failed to scan skills directory: ${error}`);
+            throw new Error(`Failed to scan skills directory: ${error}`);
+        }
+    }
+
+    /**
+     * Process a skill directory
+     */
+    private async processSkillDirectory(skillId: string, skillsPath: string): Promise<SkillItem | null> {
+        const skillPath = path.join(skillsPath, skillId);
+        const skillMdPath = path.join(skillPath, 'SKILL.md');
+        
+        this.logger.debug(`[LocalSkillsAdapter] Processing skill directory: ${skillId}`);
+        
+        try {
+            try {
+                await access(skillMdPath, fs.constants.R_OK);
+            } catch {
+                this.logger.debug(`[LocalSkillsAdapter] Skill ${skillId} missing SKILL.md, skipping`);
+                return null;
+            }
+            
+            const parsedSkillMd = await this.parseSkillMd(skillMdPath);
+            
+            const entries = await readdir(skillPath);
+            const files = entries.filter(entry => {
+                const entryPath = path.join(skillPath, entry);
+                try {
+                    return fs.statSync(entryPath).isFile();
+                } catch {
+                    return false;
+                }
+            });
+            
+            const skillItem: SkillItem = {
+                id: skillId,
+                name: parsedSkillMd.frontmatter.name || skillId,
+                description: parsedSkillMd.frontmatter.description || 'No description',
+                license: parsedSkillMd.frontmatter.license,
+                path: `skills/${skillId}`,
+                skillMdPath: `skills/${skillId}/SKILL.md`,
+                files,
+                parsedSkillMd,
+            };
+            
+            this.logger.debug(`[LocalSkillsAdapter] Successfully processed skill: ${skillItem.name}`);
+            return skillItem;
+            
+        } catch (error) {
+            this.logger.error(`[LocalSkillsAdapter] Error processing skill ${skillId}: ${error}`);
+            return null;
+        }
+    }
+
+    /**
+     * Parse SKILL.md file
+     */
+    private async parseSkillMd(skillMdPath: string): Promise<ParsedSkillFile> {
+        this.logger.debug(`[LocalSkillsAdapter] Parsing SKILL.md: ${skillMdPath}`);
+        
+        try {
+            const raw = await readFile(skillMdPath, 'utf-8');
+            
+            const frontmatterMatch = raw.match(/^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/);
+            
+            if (!frontmatterMatch) {
+                this.logger.warn(`[LocalSkillsAdapter] SKILL.md missing valid frontmatter`);
+                return {
+                    frontmatter: { name: '', description: '' },
+                    content: raw,
+                    raw,
+                };
+            }
+            
+            const frontmatterYaml = frontmatterMatch[1];
+            const markdownContent = frontmatterMatch[2];
+            
+            let frontmatter: SkillFrontmatter;
+            try {
+                frontmatter = yaml.load(frontmatterYaml) as SkillFrontmatter;
+            } catch (yamlError) {
+                this.logger.warn(`[LocalSkillsAdapter] Failed to parse YAML frontmatter: ${yamlError}`);
+                frontmatter = { name: '', description: '' };
+            }
+            
+            return {
+                frontmatter,
+                content: markdownContent,
+                raw,
+            };
+            
+        } catch (error) {
+            this.logger.error(`[LocalSkillsAdapter] Failed to parse SKILL.md: ${error}`);
+            throw error;
+        }
+    }
+
+    /**
+     * Create Bundle from SkillItem
+     */
+    private createBundleFromSkill(skill: SkillItem): Bundle {
+        const localPath = this.getLocalPath();
+        const sourceName = path.basename(localPath);
+        
+        const bundleId = `local-skills-${sourceName}-${skill.id}`;
+        
+        const bundle: Bundle = {
+            id: bundleId,
+            name: skill.name,
+            version: '1.0.0',
+            description: skill.description,
+            author: 'Local',
+            sourceId: this.source.id,
+            environments: ['claude', 'vscode', 'claude-code'],
+            tags: ['skill', 'anthropic', 'local'],
+            lastUpdated: new Date().toISOString(),
+            size: this.estimateSkillSize(skill.files),
+            dependencies: [],
+            license: skill.license || 'Unknown',
+            repository: this.source.url,
+            homepage: this.source.url,
+            manifestUrl: this.getManifestUrl(bundleId),
+            downloadUrl: this.getDownloadUrl(bundleId),
+        };
+        
+        return bundle;
+    }
+
+    /**
+     * Estimate skill size
+     */
+    private estimateSkillSize(files: string[]): string {
+        const estimatedBytes = files.length * 4096;
+        
+        if (estimatedBytes < 1024) {
+            return `${estimatedBytes} B`;
+        }
+        if (estimatedBytes < 1024 * 1024) {
+            return `${(estimatedBytes / 1024).toFixed(1)} KB`;
+        }
+        return `${(estimatedBytes / (1024 * 1024)).toFixed(1)} MB`;
+    }
+
+    /**
+     * Get manifest URL
+     */
+    getManifestUrl(bundleId: string, version?: string): string {
+        const localPath = this.getLocalPath();
+        const sourceName = path.basename(localPath);
+        const skillId = bundleId.replace(`local-skills-${sourceName}-`, '');
+        return `file://${path.join(localPath, 'skills', skillId, 'SKILL.md')}`;
+    }
+
+    /**
+     * Get download URL
+     */
+    getDownloadUrl(bundleId: string, version?: string): string {
+        const localPath = this.getLocalPath();
+        const sourceName = path.basename(localPath);
+        const skillId = bundleId.replace(`local-skills-${sourceName}-`, '');
+        return `file://${path.join(localPath, 'skills', skillId)}`;
+    }
+
+    /**
+     * Download a skill bundle
+     */
+    async downloadBundle(bundle: Bundle): Promise<Buffer> {
+        const localPath = this.getLocalPath();
+        const sourceName = path.basename(localPath);
+        const skillId = bundle.id.replace(`local-skills-${sourceName}-`, '');
+        
+        this.logger.info(`[LocalSkillsAdapter] Downloading skill: ${skillId}`);
+        
+        try {
+            const skills = await this.scanSkillsDirectory();
+            const skill = skills.find(s => s.id === skillId);
+            
+            if (!skill) {
+                throw new Error(`Skill not found: ${skillId}`);
+            }
+            
+            const zipBuffer = await this.packageSkillAsZip(skill);
+            
+            this.logger.info(`[LocalSkillsAdapter] Successfully packaged skill ${skillId} (${zipBuffer.length} bytes)`);
+            return zipBuffer;
+            
+        } catch (error) {
+            this.logger.error(`[LocalSkillsAdapter] Failed to download skill ${skillId}: ${error}`);
+            throw new Error(`Failed to download skill ${skillId}: ${error}`);
+        }
+    }
+
+    /**
+     * Get the original source path for a skill (for symlink creation)
+     * This is used by BundleInstaller to create symlinks instead of copying for local skills
+     * @param bundle The bundle to get the source path for
+     * @returns The absolute path to the skill directory
+     */
+    getSkillSourcePath(bundle: Bundle): string {
+        const localPath = this.getLocalPath();
+        const sourceName = path.basename(localPath);
+        const skillId = bundle.id.replace(`local-skills-${sourceName}-`, '');
+        return path.join(localPath, 'skills', skillId);
+    }
+
+    /**
+     * Get the skill name from a bundle ID
+     * @param bundle The bundle to extract skill name from
+     * @returns The skill name/ID
+     */
+    getSkillName(bundle: Bundle): string {
+        const localPath = this.getLocalPath();
+        const sourceName = path.basename(localPath);
+        return bundle.id.replace(`local-skills-${sourceName}-`, '');
+    }
+
+    /**
+     * Package skill as ZIP
+     */
+    private async packageSkillAsZip(skill: SkillItem): Promise<Buffer> {
+        const localPath = this.getLocalPath();
+        const skillPath = path.join(localPath, skill.path);
+        
+        this.logger.debug(`[LocalSkillsAdapter] Packaging skill as ZIP: ${skill.id}`);
+        
+        try {
+            const zip = new AdmZip();
+            
+            const deploymentManifest = this.generateDeploymentManifest(skill);
+            const manifestYaml = yaml.dump(deploymentManifest);
+            zip.addFile('deployment-manifest.yml', Buffer.from(manifestYaml, 'utf8'));
+            
+            // Use skills/{skill-id}/ structure to match CopilotSyncService expectations
+            await this.addDirectoryToZip(zip, skillPath, `skills/${skill.id}`);
+            
+            const zipBuffer = zip.toBuffer();
+            this.logger.debug(`[LocalSkillsAdapter] Created ZIP bundle: ${zipBuffer.length} bytes`);
+            return zipBuffer;
+            
+        } catch (error) {
+            this.logger.error(`[LocalSkillsAdapter] Failed to package skill ${skill.id}: ${error}`);
+            throw new Error(`Failed to package skill as ZIP: ${error}`);
+        }
+    }
+
+    /**
+     * Add directory contents to ZIP recursively
+     */
+    private async addDirectoryToZip(zip: AdmZip, dirPath: string, zipPath: string): Promise<void> {
+        try {
+            const entries = await readdir(dirPath, { withFileTypes: true });
+            
+            for (const entry of entries) {
+                const entryPath = path.join(dirPath, entry.name);
+                const entryZipPath = `${zipPath}/${entry.name}`;
+                
+                if (entry.isFile()) {
+                    const content = await readFile(entryPath);
+                    zip.addFile(entryZipPath, content);
+                    this.logger.debug(`[LocalSkillsAdapter] Added file to ZIP: ${entryZipPath}`);
+                } else if (entry.isDirectory()) {
+                    await this.addDirectoryToZip(zip, entryPath, entryZipPath);
+                }
+            }
+        } catch (error) {
+            this.logger.warn(`[LocalSkillsAdapter] Failed to add directory ${dirPath} to ZIP: ${error}`);
+        }
+    }
+
+    /**
+     * Generate deployment manifest
+     */
+    private generateDeploymentManifest(skill: SkillItem): any {
+        const localPath = this.getLocalPath();
+        const sourceName = path.basename(localPath);
+        
+        return {
+            id: `local-skills-${sourceName}-${skill.id}`,
+            version: '1.0.0',
+            name: skill.name,
+            
+            metadata: {
+                manifest_version: '1.0',
+                description: skill.description,
+                author: 'Local',
+                last_updated: new Date().toISOString(),
+                repository: {
+                    type: 'local',
+                    url: this.source.url,
+                    directory: skill.path
+                },
+                license: skill.license || 'Unknown',
+                keywords: ['skill', 'anthropic', 'local']
+            },
+            
+            common: {
+                directories: [`skills/${skill.id}`],
+                files: [],
+                include_patterns: ['**/*'],
+                exclude_patterns: []
+            },
+            
+            bundle_settings: {
+                include_common_in_environment_bundles: true,
+                create_common_bundle: true,
+                compression: 'zip',
+                naming: {
+                    common_bundle: skill.id
+                }
+            },
+            
+            prompts: [
+                {
+                    id: skill.id,
+                    name: skill.name,
+                    description: skill.description,
+                    file: `skills/${skill.id}/SKILL.md`,
+                    type: 'skill',
+                    tags: ['skill', 'anthropic', 'local']
+                }
+            ]
+        };
+    }
+}

--- a/src/adapters/SkillsAdapter.ts
+++ b/src/adapters/SkillsAdapter.ts
@@ -1,0 +1,706 @@
+/**
+ * Skills repository adapter
+ * Handles GitHub repositories containing Anthropic-style skills with SKILL.md files
+ * 
+ * Repository structure:
+ * - skills/ folder at root
+ * - Each subfolder is a skill (folder name = skill ID)
+ * - Each skill has a SKILL.md file with YAML frontmatter (name, description) and markdown instructions
+ */
+
+import { RepositoryAdapter } from './RepositoryAdapter';
+import { GitHubAdapter } from './GitHubAdapter';
+import { Bundle, ValidationResult, RegistrySource, SourceMetadata } from '../types/registry';
+import { SkillItem, SkillFrontmatter, ParsedSkillFile, GitHubContentItem } from '../types/skills';
+import { Logger } from '../utils/logger';
+import * as yaml from 'js-yaml';
+
+/**
+ * Skills adapter implementation for GitHub repositories
+ * Discovers skills from skills/ directory with SKILL.md files
+ */
+export class SkillsAdapter extends RepositoryAdapter {
+    readonly type = 'skills';
+    private logger: Logger;
+    private githubAdapter: GitHubAdapter;
+
+    constructor(source: RegistrySource) {
+        super(source);
+        this.logger = Logger.getInstance();
+        
+        if (!this.isValidGitHubUrl(source.url)) {
+            throw new Error(`Invalid GitHub URL for skills source: ${source.url}`);
+        }
+        
+        this.githubAdapter = new GitHubAdapter(source);
+    }
+
+    /**
+     * Validate GitHub URL format
+     */
+    private isValidGitHubUrl(url: string): boolean {
+        if (url.startsWith('https://')) {
+            return url.includes('github.com');
+        }
+        if (url.startsWith('git@')) {
+            return url.includes('github.com:');
+        }
+        return false;
+    }
+
+    /**
+     * Parse GitHub URL to extract owner and repo
+     */
+    private parseGitHubUrl(): { owner: string; repo: string } {
+        const url = this.source.url.replace(/\.git$/, '');
+        const match = url.match(/github\.com[/:]([^/]+)\/([^/]+)/);
+        
+        if (!match) {
+            throw new Error(`Invalid GitHub URL format: ${this.source.url}`);
+        }
+
+        return {
+            owner: match[1],
+            repo: match[2],
+        };
+    }
+
+    /**
+     * Fetch all skills from the repository as bundles
+     * Each skill becomes a separate bundle
+     */
+    async fetchBundles(): Promise<Bundle[]> {
+        this.logger.info(`[SkillsAdapter] Fetching skills from repository: ${this.source.url}`);
+        
+        try {
+            const skills = await this.scanSkillsDirectory();
+            this.logger.info(`[SkillsAdapter] Found ${skills.length} skills in repository`);
+            
+            const bundles: Bundle[] = [];
+            for (const skill of skills) {
+                try {
+                    const bundle = this.createBundleFromSkill(skill);
+                    bundles.push(bundle);
+                    this.logger.debug(`[SkillsAdapter] Created bundle: ${bundle.id}`);
+                } catch (error) {
+                    this.logger.warn(`[SkillsAdapter] Failed to create bundle from skill ${skill.id}: ${error}`);
+                }
+            }
+            
+            this.logger.info(`[SkillsAdapter] Successfully created ${bundles.length} bundles`);
+            return bundles;
+            
+        } catch (error) {
+            this.logger.error(`[SkillsAdapter] Failed to fetch skills: ${error}`);
+            throw new Error(`Failed to fetch skills: ${error}`);
+        }
+    }
+
+    /**
+     * Scan skills/ directory for skill folders with SKILL.md files
+     */
+    private async scanSkillsDirectory(): Promise<SkillItem[]> {
+        const { owner, repo } = this.parseGitHubUrl();
+        const apiBase = 'https://api.github.com';
+        const skillsUrl = `${apiBase}/repos/${owner}/${repo}/contents/skills`;
+        
+        this.logger.debug(`[SkillsAdapter] Scanning skills directory: ${skillsUrl}`);
+        
+        try {
+            const contents: GitHubContentItem[] = await this.makeGitHubRequest(skillsUrl);
+            const skills: SkillItem[] = [];
+            
+            const directories = contents.filter(item => item.type === 'dir');
+            this.logger.debug(`[SkillsAdapter] Found ${directories.length} directories in skills/`);
+            
+            for (const dir of directories) {
+                try {
+                    const skill = await this.processSkillDirectory(dir, owner, repo);
+                    if (skill) {
+                        skills.push(skill);
+                    }
+                } catch (error) {
+                    this.logger.warn(`[SkillsAdapter] Failed to process skill directory ${dir.name}: ${error}`);
+                }
+            }
+            
+            return skills;
+            
+        } catch (error) {
+            this.logger.error(`[SkillsAdapter] Failed to scan skills directory: ${error}`);
+            throw new Error(`Failed to scan skills directory: ${error}`);
+        }
+    }
+
+    /**
+     * Process a skill directory and extract skill information
+     */
+    private async processSkillDirectory(dir: GitHubContentItem, owner: string, repo: string): Promise<SkillItem | null> {
+        const skillPath = dir.path;
+        const skillId = dir.name;
+        
+        this.logger.debug(`[SkillsAdapter] Processing skill directory: ${skillId}`);
+        
+        try {
+            const apiBase = 'https://api.github.com';
+            const skillContentsUrl = `${apiBase}/repos/${owner}/${repo}/contents/${skillPath}`;
+            const skillContents: GitHubContentItem[] = await this.makeGitHubRequest(skillContentsUrl);
+            
+            const skillMdFile = skillContents.find(file => 
+                file.name === 'SKILL.md' && file.type === 'file'
+            );
+            
+            if (!skillMdFile) {
+                this.logger.debug(`[SkillsAdapter] Skill ${skillId} missing SKILL.md, skipping`);
+                return null;
+            }
+            
+            const parsedSkillMd = await this.parseSkillMd(skillMdFile.download_url!);
+            
+            const files = skillContents
+                .filter(item => item.type === 'file')
+                .map(item => item.name);
+            
+            const skillItem: SkillItem = {
+                id: skillId,
+                name: parsedSkillMd.frontmatter.name || skillId,
+                description: parsedSkillMd.frontmatter.description || 'No description',
+                license: parsedSkillMd.frontmatter.license,
+                path: skillPath,
+                skillMdPath: `${skillPath}/SKILL.md`,
+                files,
+                parsedSkillMd,
+            };
+            
+            this.logger.debug(`[SkillsAdapter] Successfully processed skill: ${skillItem.name}`);
+            return skillItem;
+            
+        } catch (error) {
+            this.logger.error(`[SkillsAdapter] Error processing skill ${skillId}: ${error}`);
+            return null;
+        }
+    }
+
+    /**
+     * Parse SKILL.md file content (YAML frontmatter + markdown)
+     */
+    private async parseSkillMd(downloadUrl: string): Promise<ParsedSkillFile> {
+        this.logger.debug(`[SkillsAdapter] Parsing SKILL.md from: ${downloadUrl}`);
+        
+        try {
+            const content = await this.downloadFileContent(downloadUrl);
+            const raw = content.toString('utf-8');
+            
+            const frontmatterMatch = raw.match(/^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/);
+            
+            if (!frontmatterMatch) {
+                this.logger.warn(`[SkillsAdapter] SKILL.md missing valid frontmatter`);
+                return {
+                    frontmatter: { name: '', description: '' },
+                    content: raw,
+                    raw,
+                };
+            }
+            
+            const frontmatterYaml = frontmatterMatch[1];
+            const markdownContent = frontmatterMatch[2];
+            
+            let frontmatter: SkillFrontmatter;
+            try {
+                frontmatter = yaml.load(frontmatterYaml) as SkillFrontmatter;
+            } catch (yamlError) {
+                this.logger.warn(`[SkillsAdapter] Failed to parse YAML frontmatter: ${yamlError}`);
+                frontmatter = { name: '', description: '' };
+            }
+            
+            return {
+                frontmatter,
+                content: markdownContent,
+                raw,
+            };
+            
+        } catch (error) {
+            this.logger.error(`[SkillsAdapter] Failed to parse SKILL.md: ${error}`);
+            throw error;
+        }
+    }
+
+    /**
+     * Create Bundle object from SkillItem
+     */
+    private createBundleFromSkill(skill: SkillItem): Bundle {
+        const { owner, repo } = this.parseGitHubUrl();
+        
+        const bundleId = `skills-${owner}-${repo}-${skill.id}`;
+        
+        const bundle: Bundle = {
+            id: bundleId,
+            name: skill.name,
+            version: '1.0.0',
+            description: skill.description,
+            author: owner,
+            sourceId: this.source.id,
+            environments: ['claude', 'vscode', 'claude-code'],
+            tags: ['skill', 'anthropic'],
+            lastUpdated: new Date().toISOString(),
+            size: this.estimateSkillSize(skill.files),
+            dependencies: [],
+            license: skill.license || 'Unknown',
+            repository: this.source.url,
+            homepage: `https://github.com/${owner}/${repo}/tree/main/${skill.path}`,
+            manifestUrl: this.getManifestUrl(bundleId),
+            downloadUrl: this.getDownloadUrl(bundleId),
+        };
+        
+        return bundle;
+    }
+
+    /**
+     * Estimate skill size based on file count
+     */
+    private estimateSkillSize(files: string[]): string {
+        const estimatedBytes = files.length * 4096;
+        
+        if (estimatedBytes < 1024) {
+            return `${estimatedBytes} B`;
+        }
+        if (estimatedBytes < 1024 * 1024) {
+            return `${(estimatedBytes / 1024).toFixed(1)} KB`;
+        }
+        return `${(estimatedBytes / (1024 * 1024)).toFixed(1)} MB`;
+    }
+
+    /**
+     * Validate skills repository structure
+     */
+    async validate(): Promise<ValidationResult> {
+        this.logger.info(`[SkillsAdapter] Validating skills repository: ${this.source.url}`);
+        
+        const errors: string[] = [];
+        const warnings: string[] = [];
+        
+        try {
+            const { owner, repo } = this.parseGitHubUrl();
+            
+            const baseValidation = await this.githubAdapter.validate();
+            if (!baseValidation.valid) {
+                return baseValidation;
+            }
+            
+            const apiBase = 'https://api.github.com';
+            
+            let hasSkillsDir = false;
+            try {
+                const skillsUrl = `${apiBase}/repos/${owner}/${repo}/contents/skills`;
+                await this.makeGitHubRequest(skillsUrl);
+                hasSkillsDir = true;
+                this.logger.debug(`[SkillsAdapter] Found skills/ directory`);
+            } catch (error) {
+                if (error instanceof Error && error.message.includes('404')) {
+                    errors.push(`Missing required 'skills' directory at repository root`);
+                } else {
+                    errors.push(`Failed to access skills directory: ${error}`);
+                }
+            }
+            
+            if (!hasSkillsDir) {
+                return {
+                    valid: false,
+                    errors,
+                    warnings,
+                    bundlesFound: 0,
+                };
+            }
+            
+            let skillCount = 0;
+            try {
+                const skills = await this.scanSkillsDirectory();
+                skillCount = skills.length;
+                
+                if (skillCount === 0) {
+                    warnings.push('No valid skills found in skills/ directory (skills must have SKILL.md file)');
+                } else {
+                    this.logger.info(`[SkillsAdapter] Found ${skillCount} valid skill(s)`);
+                }
+            } catch (scanError) {
+                warnings.push(`Failed to scan skills: ${scanError}`);
+            }
+            
+            return {
+                valid: true,
+                errors: [],
+                warnings,
+                bundlesFound: skillCount,
+            };
+            
+        } catch (error) {
+            return {
+                valid: false,
+                errors: [`Skills repository validation failed: ${error}`],
+                warnings: [],
+                bundlesFound: 0,
+            };
+        }
+    }
+
+    /**
+     * Fetch repository metadata
+     */
+    async fetchMetadata(): Promise<SourceMetadata> {
+        try {
+            const skills = await this.scanSkillsDirectory();
+            const { owner, repo } = this.parseGitHubUrl();
+            
+            return {
+                name: `${owner}/${repo}`,
+                description: 'Skills Repository',
+                bundleCount: skills.length,
+                lastUpdated: new Date().toISOString(),
+                version: '1.0.0',
+            };
+        } catch (error) {
+            throw new Error(`Failed to fetch skills repository metadata: ${error}`);
+        }
+    }
+
+    /**
+     * Get manifest URL for a skill
+     */
+    getManifestUrl(bundleId: string, version?: string): string {
+        const { owner, repo } = this.parseGitHubUrl();
+        const skillId = bundleId.replace(`skills-${owner}-${repo}-`, '');
+        return `https://raw.githubusercontent.com/${owner}/${repo}/main/skills/${skillId}/SKILL.md`;
+    }
+
+    /**
+     * Get download URL for a skill
+     */
+    getDownloadUrl(bundleId: string, version?: string): string {
+        const { owner, repo } = this.parseGitHubUrl();
+        return `https://github.com/${owner}/${repo}/archive/refs/heads/main.zip`;
+    }
+
+    /**
+     * Download a skill bundle
+     * Creates a ZIP with the skill folder and deployment manifest
+     */
+    async downloadBundle(bundle: Bundle): Promise<Buffer> {
+        const { owner, repo } = this.parseGitHubUrl();
+        const skillId = bundle.id.replace(`skills-${owner}-${repo}-`, '');
+        
+        this.logger.info(`[SkillsAdapter] Downloading skill: ${skillId}`);
+        
+        try {
+            // Fetch only the specific skill instead of scanning all skills
+            const skill = await this.fetchSingleSkill(skillId);
+            
+            if (!skill) {
+                throw new Error(`Skill not found: ${skillId}`);
+            }
+            
+            const zipBuffer = await this.packageSkillAsZip(skill);
+            
+            this.logger.info(`[SkillsAdapter] Successfully packaged skill ${skillId} (${zipBuffer.length} bytes)`);
+            return zipBuffer;
+            
+        } catch (error) {
+            this.logger.error(`[SkillsAdapter] Failed to download skill ${skillId}: ${error}`);
+            throw new Error(`Failed to download skill ${skillId}: ${error}`);
+        }
+    }
+
+    /**
+     * Fetch a single skill by ID (optimized - doesn't scan all skills)
+     */
+    private async fetchSingleSkill(skillId: string): Promise<SkillItem | null> {
+        const { owner, repo } = this.parseGitHubUrl();
+        const apiBase = 'https://api.github.com';
+        const skillPath = `skills/${skillId}`;
+        
+        this.logger.debug(`[SkillsAdapter] Fetching single skill: ${skillId}`);
+        
+        try {
+            // Get skill directory contents
+            const skillContentsUrl = `${apiBase}/repos/${owner}/${repo}/contents/${skillPath}`;
+            const skillContents: GitHubContentItem[] = await this.makeGitHubRequest(skillContentsUrl);
+            
+            // Find SKILL.md
+            const skillMdFile = skillContents.find(item => 
+                item.type === 'file' && item.name === 'SKILL.md'
+            );
+            
+            if (!skillMdFile || !skillMdFile.download_url) {
+                this.logger.warn(`[SkillsAdapter] No SKILL.md found for skill: ${skillId}`);
+                return null;
+            }
+            
+            // Parse SKILL.md
+            const parsedSkill = await this.parseSkillMd(skillMdFile.download_url);
+            if (!parsedSkill) {
+                return null;
+            }
+            
+            // Get file list
+            const files = skillContents
+                .filter(item => item.type === 'file')
+                .map(item => item.name);
+            
+            return {
+                id: skillId,
+                name: parsedSkill.frontmatter.name || skillId,
+                description: parsedSkill.frontmatter.description || '',
+                path: skillPath,
+                skillMdPath: `${skillPath}/SKILL.md`,
+                files,
+                license: parsedSkill.frontmatter.license
+            };
+            
+        } catch (error) {
+            this.logger.error(`[SkillsAdapter] Failed to fetch skill ${skillId}: ${error}`);
+            return null;
+        }
+    }
+
+    /**
+     * Package a skill as a ZIP bundle
+     */
+    private async packageSkillAsZip(skill: SkillItem): Promise<Buffer> {
+        const { owner, repo } = this.parseGitHubUrl();
+        const AdmZip = require('adm-zip');
+        const yamlLib = require('js-yaml');
+        
+        this.logger.debug(`[SkillsAdapter] Packaging skill as ZIP: ${skill.id}`);
+        
+        try {
+            const zip = new AdmZip();
+            
+            const deploymentManifest = this.generateDeploymentManifest(skill, owner, repo);
+            const manifestYaml = yamlLib.dump(deploymentManifest);
+            zip.addFile('deployment-manifest.yml', Buffer.from(manifestYaml, 'utf8'));
+            
+            const apiBase = 'https://api.github.com';
+            const skillContentsUrl = `${apiBase}/repos/${owner}/${repo}/contents/${skill.path}`;
+            const skillContents: GitHubContentItem[] = await this.makeGitHubRequest(skillContentsUrl);
+            
+            // Use skills/{skill-id}/ structure to match CopilotSyncService expectations
+            for (const item of skillContents) {
+                if (item.type === 'file' && item.download_url) {
+                    try {
+                        const fileContent = await this.downloadFileContent(item.download_url);
+                        const filePath = `skills/${skill.id}/${item.name}`;
+                        zip.addFile(filePath, fileContent);
+                        
+                        this.logger.debug(`[SkillsAdapter] Added file to ZIP: ${filePath}`);
+                    } catch (error) {
+                        this.logger.warn(`[SkillsAdapter] Failed to download file ${item.name}: ${error}`);
+                    }
+                } else if (item.type === 'dir') {
+                    await this.addDirectoryToZip(zip, owner, repo, item.path, `skills/${skill.id}/${item.name}`);
+                }
+            }
+            
+            const zipBuffer = zip.toBuffer();
+            this.logger.debug(`[SkillsAdapter] Created ZIP bundle: ${zipBuffer.length} bytes`);
+            return zipBuffer;
+            
+        } catch (error) {
+            this.logger.error(`[SkillsAdapter] Failed to package skill ${skill.id}: ${error}`);
+            throw new Error(`Failed to package skill as ZIP: ${error}`);
+        }
+    }
+
+    /**
+     * Recursively add directory contents to ZIP
+     */
+    private async addDirectoryToZip(zip: any, owner: string, repo: string, dirPath: string, zipPath: string): Promise<void> {
+        try {
+            const apiBase = 'https://api.github.com';
+            const dirContentsUrl = `${apiBase}/repos/${owner}/${repo}/contents/${dirPath}`;
+            const dirContents: GitHubContentItem[] = await this.makeGitHubRequest(dirContentsUrl);
+            
+            for (const item of dirContents) {
+                if (item.type === 'file' && item.download_url) {
+                    try {
+                        const fileContent = await this.downloadFileContent(item.download_url);
+                        const filePath = `${zipPath}/${item.name}`;
+                        zip.addFile(filePath, fileContent);
+                    } catch (error) {
+                        this.logger.warn(`[SkillsAdapter] Failed to download nested file ${item.name}: ${error}`);
+                    }
+                } else if (item.type === 'dir') {
+                    await this.addDirectoryToZip(zip, owner, repo, item.path, `${zipPath}/${item.name}`);
+                }
+            }
+        } catch (error) {
+            this.logger.warn(`[SkillsAdapter] Failed to add directory ${dirPath} to ZIP: ${error}`);
+        }
+    }
+
+    /**
+     * Generate deployment manifest for a skill
+     */
+    private generateDeploymentManifest(skill: SkillItem, owner: string, repo: string): any {
+        return {
+            id: `skills-${owner}-${repo}-${skill.id}`,
+            version: '1.0.0',
+            name: skill.name,
+            
+            metadata: {
+                manifest_version: '1.0',
+                description: skill.description,
+                author: owner,
+                last_updated: new Date().toISOString(),
+                repository: {
+                    type: 'git',
+                    url: this.source.url,
+                    directory: skill.path
+                },
+                license: skill.license || 'Unknown',
+                keywords: ['skill', 'anthropic']
+            },
+            
+            common: {
+                directories: [`skills/${skill.id}`],
+                files: [],
+                include_patterns: ['**/*'],
+                exclude_patterns: []
+            },
+            
+            bundle_settings: {
+                include_common_in_environment_bundles: true,
+                create_common_bundle: true,
+                compression: 'zip',
+                naming: {
+                    common_bundle: skill.id
+                }
+            },
+            
+            prompts: [
+                {
+                    id: skill.id,
+                    name: skill.name,
+                    description: skill.description,
+                    file: `skills/${skill.id}/SKILL.md`,
+                    type: 'skill',
+                    tags: ['skill', 'anthropic']
+                }
+            ]
+        };
+    }
+
+    /**
+     * Download file content from URL
+     */
+    private async downloadFileContent(url: string): Promise<Buffer> {
+        const https = require('https');
+        
+        return new Promise((resolve, reject) => {
+            const headers: Record<string, string> = {
+                'User-Agent': 'Prompt-Registry-VSCode-Extension',
+            };
+            
+            const token = this.getAuthToken();
+            if (token) {
+                headers.Authorization = `token ${token}`;
+            }
+            
+            https.get(url, { headers }, (res: any) => {
+                const chunks: Buffer[] = [];
+                
+                res.on('data', (chunk: Buffer) => {
+                    chunks.push(chunk);
+                });
+                
+                res.on('end', () => {
+                    if (res.statusCode >= 400) {
+                        reject(new Error(`HTTP ${res.statusCode}: ${res.statusMessage}`));
+                        return;
+                    }
+                    resolve(Buffer.concat(chunks));
+                });
+            }).on('error', (error: any) => {
+                reject(new Error(`Download failed: ${error.message}`));
+            });
+        });
+    }
+
+    /**
+     * Make GitHub API request with authentication
+     */
+    private async makeGitHubRequest(url: string): Promise<any> {
+        const https = require('https');
+        const vscode = require('vscode');
+        const { exec } = require('child_process');
+        const { promisify } = require('util');
+        const execAsync = promisify(exec);
+        
+        let authToken: string | undefined;
+        
+        const explicitToken = this.getAuthToken();
+        if (explicitToken && explicitToken.trim().length > 0) {
+            authToken = explicitToken.trim();
+            this.logger.debug('[SkillsAdapter] Using explicit token from configuration');
+        } else {
+            try {
+                const session = await vscode.authentication.getSession('github', ['repo'], { createIfNone: false });
+                if (session) {
+                    authToken = session.accessToken;
+                    this.logger.debug('[SkillsAdapter] Using VSCode GitHub authentication');
+                }
+            } catch (error) {
+                this.logger.debug(`[SkillsAdapter] VSCode auth failed: ${error}`);
+            }
+            
+            if (!authToken) {
+                try {
+                    const { stdout } = await execAsync('gh auth token');
+                    const token = stdout.trim();
+                    if (token && token.length > 0) {
+                        authToken = token;
+                        this.logger.debug('[SkillsAdapter] Using gh CLI authentication');
+                    }
+                } catch (error) {
+                    this.logger.debug(`[SkillsAdapter] gh CLI auth failed: ${error}`);
+                }
+            }
+        }
+        
+        return new Promise((resolve, reject) => {
+            let headers: Record<string, string> = {
+                'User-Agent': 'Prompt-Registry-VSCode-Extension',
+                'Accept': 'application/json',
+            };
+            
+            if (authToken) {
+                headers = {
+                    ...headers,
+                    'Authorization': `token ${authToken}`,
+                };
+                this.logger.debug(`[SkillsAdapter] Request to ${url} with authentication`);
+            } else {
+                this.logger.debug(`[SkillsAdapter] Request to ${url} without authentication`);
+            }
+            
+            https.get(url, { headers }, (res: any) => {
+                let data = '';
+                res.on('data', (chunk: any) => data += chunk);
+                res.on('end', () => {
+                    if (res.statusCode >= 400) {
+                        this.logger.error(`[SkillsAdapter] HTTP ${res.statusCode}: ${res.statusMessage}`);
+                        reject(new Error(`HTTP ${res.statusCode}: ${res.statusMessage}`));
+                        return;
+                    }
+                    try {
+                        resolve(JSON.parse(data));
+                    } catch (error) {
+                        this.logger.error(`[SkillsAdapter] Failed to parse JSON response: ${error}`);
+                        reject(new Error(`Failed to parse JSON response: ${error}`));
+                    }
+                });
+            }).on('error', (error: any) => {
+                this.logger.error(`[SkillsAdapter] Network error: ${error.message}`);
+                reject(new Error(`Request failed: ${error.message}`));
+            });
+        });
+    }
+}

--- a/src/commands/SourceCommands.ts
+++ b/src/commands/SourceCommands.ts
@@ -77,6 +77,16 @@ export class SourceCommands {
                         description: 'Local filesystem directory with OLAF skills organized in bundle-based structure',
                         value: 'local-olaf' as SourceType
                     },
+                    {
+                        label: '$(sparkle) Skills Repository',
+                        description: 'GitHub repository with skills in skills/ folder (Anthropic-style SKILL.md files)',
+                        value: 'skills' as SourceType
+                    },
+                    {
+                        label: '$(folder-library) Local Skills',
+                        description: 'Local filesystem directory with skills in skills/ folder (SKILL.md files)',
+                        value: 'local-skills' as SourceType
+                    },
                 ],
                 {
                     placeHolder: 'Select source type',
@@ -741,6 +751,32 @@ export class SourceCommands {
                     canSelectFiles: false,
                     canSelectMany: false,
                     title: 'Select local OLAF skills directory',
+                    openLabel: 'Select Directory'
+                });
+                
+                return uris && uris.length > 0 ? uris[0].fsPath : undefined;
+            }
+
+            case 'skills':
+                return await vscode.window.showInputBox({
+                    prompt: 'Enter GitHub repository URL containing skills (e.g., anthropics/skills)',
+                    placeHolder: 'https://github.com/anthropics/skills',
+                    value: 'https://github.com/anthropics/skills',
+                    validateInput: (value) => {
+                        if (!value || !value.match(/github\.com/)) {
+                            return 'Please enter a valid GitHub URL';
+                        }
+                        return undefined;
+                    },
+                    ignoreFocusOut: true
+                });
+
+            case 'local-skills': {
+                const uris = await vscode.window.showOpenDialog({
+                    canSelectFolders: true,
+                    canSelectFiles: false,
+                    canSelectMany: false,
+                    title: 'Select local skills directory (must contain skills/ folder)',
                     openLabel: 'Select Directory'
                 });
                 

--- a/src/types/registry.ts
+++ b/src/types/registry.ts
@@ -6,7 +6,7 @@ import { McpServersManifest } from './mcp';
 /**
  * Registry source types
  */
-export type SourceType = 'github' | 'gitlab' | 'http' | 'local' | 'awesome-copilot' | 'local-awesome-copilot' | 'apm' | 'local-apm' | 'olaf' | 'local-olaf';
+export type SourceType = 'github' | 'gitlab' | 'http' | 'local' | 'awesome-copilot' | 'local-awesome-copilot' | 'apm' | 'local-apm' | 'olaf' | 'local-olaf' | 'skills' | 'local-skills';
 
 /**
  * Installation scope

--- a/src/types/skills.ts
+++ b/src/types/skills.ts
@@ -1,0 +1,99 @@
+/**
+ * Type definitions for Anthropic-style Skills repositories
+ * Skills are folders with SKILL.md files containing YAML frontmatter and markdown instructions
+ */
+
+/**
+ * SKILL.md frontmatter structure
+ * Required: name, description
+ * Optional: license
+ */
+export interface SkillFrontmatter {
+    /** Skill name (lowercase, hyphens for spaces) */
+    name: string;
+    
+    /** Description of what the skill does and when to use it */
+    description: string;
+    
+    /** License information (optional) */
+    license?: string;
+    
+    /** Additional frontmatter fields */
+    [key: string]: any;
+}
+
+/**
+ * Parsed SKILL.md file content
+ */
+export interface ParsedSkillFile {
+    /** Parsed YAML frontmatter */
+    frontmatter: SkillFrontmatter;
+    
+    /** Markdown content (instructions) */
+    content: string;
+    
+    /** Raw file content */
+    raw: string;
+}
+
+/**
+ * Information about a discovered skill
+ */
+export interface SkillItem {
+    /** Skill ID (folder name) */
+    id: string;
+    
+    /** Skill name from frontmatter */
+    name: string;
+    
+    /** Skill description from frontmatter */
+    description: string;
+    
+    /** License from frontmatter (optional) */
+    license?: string;
+    
+    /** Path to the skill folder relative to repository root */
+    path: string;
+    
+    /** Path to SKILL.md file */
+    skillMdPath: string;
+    
+    /** List of files in the skill folder */
+    files: string[];
+    
+    /** Parsed SKILL.md content */
+    parsedSkillMd?: ParsedSkillFile;
+}
+
+/**
+ * Skills repository metadata
+ */
+export interface SkillsRepositoryInfo {
+    /** Repository name */
+    name: string;
+    
+    /** Repository description */
+    description?: string;
+    
+    /** Number of skills found */
+    skillCount: number;
+    
+    /** Last updated timestamp */
+    lastUpdated?: string;
+    
+    /** Repository URL */
+    url: string;
+}
+
+/**
+ * GitHub directory content item (for API responses)
+ */
+export interface GitHubContentItem {
+    name: string;
+    path: string;
+    type: 'file' | 'dir';
+    download_url?: string;
+    url?: string;
+    sha?: string;
+    size?: number;
+}

--- a/test/adapters/LocalSkillsAdapter.test.ts
+++ b/test/adapters/LocalSkillsAdapter.test.ts
@@ -1,0 +1,502 @@
+/**
+ * LocalSkillsAdapter Tests
+ * Tests for local filesystem Anthropic-style skills repository adapter
+ */
+
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import * as sinon from 'sinon';
+import { LocalSkillsAdapter } from '../../src/adapters/LocalSkillsAdapter';
+import { RegistrySource } from '../../src/types/registry';
+
+suite('LocalSkillsAdapter Tests', () => {
+    let tempDir: string;
+    let skillsDir: string;
+
+    /**
+     * Create a temporary directory structure for testing
+     */
+    function createTempSkillsStructure(): string {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'skills-test-'));
+        skillsDir = path.join(tempDir, 'skills');
+        fs.mkdirSync(skillsDir);
+        return tempDir;
+    }
+
+    /**
+     * Create a skill in the temporary directory
+     */
+    function createSkill(skillId: string, options: {
+        name?: string;
+        description?: string;
+        license?: string;
+        additionalFiles?: string[];
+    } = {}): void {
+        const skillPath = path.join(skillsDir, skillId);
+        fs.mkdirSync(skillPath, { recursive: true });
+
+        const name = options.name || skillId;
+        const description = options.description || `Description for ${skillId}`;
+        const license = options.license ? `license: ${options.license}` : '';
+
+        const skillMdContent = `---
+name: ${name}
+description: ${description}
+${license}
+---
+
+# ${name}
+
+Instructions for ${name}
+`;
+
+        fs.writeFileSync(path.join(skillPath, 'SKILL.md'), skillMdContent);
+
+        for (const file of options.additionalFiles || []) {
+            fs.writeFileSync(path.join(skillPath, file), `Content of ${file}`);
+        }
+    }
+
+    /**
+     * Clean up temporary directory
+     */
+    function cleanupTempDir(): void {
+        if (tempDir && fs.existsSync(tempDir)) {
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        }
+    }
+
+    setup(() => {
+        createTempSkillsStructure();
+    });
+
+    teardown(() => {
+        cleanupTempDir();
+        sinon.restore();
+    });
+
+    suite('Constructor', () => {
+        test('should create adapter with valid local path', () => {
+            const source: RegistrySource = {
+                id: 'test-local-skills',
+                name: 'Test Local Skills',
+                type: 'local-skills',
+                url: tempDir,
+                enabled: true,
+                priority: 1,
+            };
+
+            const adapter = new LocalSkillsAdapter(source);
+            assert.strictEqual(adapter.type, 'local-skills');
+        });
+
+        test('should create adapter with file:// URL', () => {
+            const source: RegistrySource = {
+                id: 'test-local-skills',
+                name: 'Test Local Skills',
+                type: 'local-skills',
+                url: `file://${tempDir}`,
+                enabled: true,
+                priority: 1,
+            };
+
+            const adapter = new LocalSkillsAdapter(source);
+            assert.strictEqual(adapter.type, 'local-skills');
+        });
+
+        test('should throw error for invalid path', () => {
+            const source: RegistrySource = {
+                id: 'test-local-skills',
+                name: 'Test Local Skills',
+                type: 'local-skills',
+                url: 'https://github.com/owner/repo',
+                enabled: true,
+                priority: 1,
+            };
+
+            assert.throws(() => {
+                new LocalSkillsAdapter(source);
+            }, /Invalid local skills path/);
+        });
+    });
+
+    suite('fetchBundles()', () => {
+        test('should discover skills from skills/ directory', async () => {
+            createSkill('algorithmic-art', {
+                name: 'algorithmic-art',
+                description: 'Creating algorithmic art using p5.js',
+                license: 'Apache-2.0',
+                additionalFiles: ['README.md']
+            });
+
+            const source: RegistrySource = {
+                id: 'test-local-skills',
+                name: 'Test Local Skills',
+                type: 'local-skills',
+                url: tempDir,
+                enabled: true,
+                priority: 1,
+            };
+
+            const adapter = new LocalSkillsAdapter(source);
+            const bundles = await adapter.fetchBundles();
+
+            assert.strictEqual(bundles.length, 1);
+            assert.strictEqual(bundles[0].name, 'algorithmic-art');
+            assert.strictEqual(bundles[0].description, 'Creating algorithmic art using p5.js');
+            assert.ok(bundles[0].id.includes('algorithmic-art'));
+            assert.ok(bundles[0].tags.includes('skill'));
+            assert.ok(bundles[0].tags.includes('local'));
+        });
+
+        test('should discover multiple skills', async () => {
+            createSkill('skill-one', { description: 'First skill' });
+            createSkill('skill-two', { description: 'Second skill' });
+            createSkill('skill-three', { description: 'Third skill' });
+
+            const source: RegistrySource = {
+                id: 'test-local-skills',
+                name: 'Test Local Skills',
+                type: 'local-skills',
+                url: tempDir,
+                enabled: true,
+                priority: 1,
+            };
+
+            const adapter = new LocalSkillsAdapter(source);
+            const bundles = await adapter.fetchBundles();
+
+            assert.strictEqual(bundles.length, 3);
+            
+            const skillOne = bundles.find(b => b.name === 'skill-one');
+            const skillTwo = bundles.find(b => b.name === 'skill-two');
+            const skillThree = bundles.find(b => b.name === 'skill-three');
+            
+            assert.ok(skillOne);
+            assert.ok(skillTwo);
+            assert.ok(skillThree);
+        });
+
+        test('should skip directories without SKILL.md', async () => {
+            createSkill('valid-skill', { description: 'Valid skill' });
+            
+            // Create invalid skill directory without SKILL.md
+            const invalidSkillPath = path.join(skillsDir, 'invalid-skill');
+            fs.mkdirSync(invalidSkillPath);
+            fs.writeFileSync(path.join(invalidSkillPath, 'README.md'), 'No SKILL.md here');
+
+            const source: RegistrySource = {
+                id: 'test-local-skills',
+                name: 'Test Local Skills',
+                type: 'local-skills',
+                url: tempDir,
+                enabled: true,
+                priority: 1,
+            };
+
+            const adapter = new LocalSkillsAdapter(source);
+            const bundles = await adapter.fetchBundles();
+
+            assert.strictEqual(bundles.length, 1);
+            assert.strictEqual(bundles[0].name, 'valid-skill');
+        });
+
+        test('should handle empty skills directory', async () => {
+            const source: RegistrySource = {
+                id: 'test-local-skills',
+                name: 'Test Local Skills',
+                type: 'local-skills',
+                url: tempDir,
+                enabled: true,
+                priority: 1,
+            };
+
+            const adapter = new LocalSkillsAdapter(source);
+            const bundles = await adapter.fetchBundles();
+
+            assert.strictEqual(bundles.length, 0);
+        });
+    });
+
+    suite('validate()', () => {
+        test('should validate directory with skills/ subdirectory', async () => {
+            createSkill('test-skill', { description: 'Test skill' });
+
+            const source: RegistrySource = {
+                id: 'test-local-skills',
+                name: 'Test Local Skills',
+                type: 'local-skills',
+                url: tempDir,
+                enabled: true,
+                priority: 1,
+            };
+
+            const adapter = new LocalSkillsAdapter(source);
+            const result = await adapter.validate();
+
+            assert.strictEqual(result.valid, true);
+            assert.strictEqual(result.errors.length, 0);
+            assert.strictEqual(result.bundlesFound, 1);
+        });
+
+        test('should fail validation when skills/ directory is missing', async () => {
+            // Remove skills directory
+            fs.rmSync(skillsDir, { recursive: true });
+
+            const source: RegistrySource = {
+                id: 'test-local-skills',
+                name: 'Test Local Skills',
+                type: 'local-skills',
+                url: tempDir,
+                enabled: true,
+                priority: 1,
+            };
+
+            const adapter = new LocalSkillsAdapter(source);
+            const result = await adapter.validate();
+
+            assert.strictEqual(result.valid, false);
+            assert.ok(result.errors.some(e => e.includes('skills')));
+        });
+
+        test('should fail validation when directory does not exist', async () => {
+            const source: RegistrySource = {
+                id: 'test-local-skills',
+                name: 'Test Local Skills',
+                type: 'local-skills',
+                url: '/nonexistent/path/to/skills',
+                enabled: true,
+                priority: 1,
+            };
+
+            const adapter = new LocalSkillsAdapter(source);
+            const result = await adapter.validate();
+
+            assert.strictEqual(result.valid, false);
+            assert.ok(result.errors.some(e => e.includes('not exist') || e.includes('not accessible')));
+        });
+
+        test('should warn when no valid skills found', async () => {
+            // skills/ directory exists but is empty
+            const source: RegistrySource = {
+                id: 'test-local-skills',
+                name: 'Test Local Skills',
+                type: 'local-skills',
+                url: tempDir,
+                enabled: true,
+                priority: 1,
+            };
+
+            const adapter = new LocalSkillsAdapter(source);
+            const result = await adapter.validate();
+
+            assert.strictEqual(result.valid, true);
+            assert.ok(result.warnings.some(w => w.includes('No valid skills')));
+        });
+    });
+
+    suite('fetchMetadata()', () => {
+        test('should return correct metadata', async () => {
+            createSkill('skill-one', { description: 'First skill' });
+            createSkill('skill-two', { description: 'Second skill' });
+
+            const source: RegistrySource = {
+                id: 'test-local-skills',
+                name: 'Test Local Skills',
+                type: 'local-skills',
+                url: tempDir,
+                enabled: true,
+                priority: 1,
+            };
+
+            const adapter = new LocalSkillsAdapter(source);
+            const metadata = await adapter.fetchMetadata();
+
+            assert.strictEqual(metadata.bundleCount, 2);
+            assert.strictEqual(metadata.description, 'Local Skills Repository');
+            assert.ok(metadata.name);
+            assert.ok(metadata.lastUpdated);
+        });
+    });
+
+    suite('getManifestUrl()', () => {
+        test('should return file:// URL for skill manifest', () => {
+            const source: RegistrySource = {
+                id: 'test-local-skills',
+                name: 'Test Local Skills',
+                type: 'local-skills',
+                url: tempDir,
+                enabled: true,
+                priority: 1,
+            };
+
+            const adapter = new LocalSkillsAdapter(source);
+            const sourceName = path.basename(tempDir);
+            const url = adapter.getManifestUrl(`local-skills-${sourceName}-test-skill`);
+            
+            assert.ok(url.startsWith('file://'));
+            assert.ok(url.includes('SKILL.md'));
+        });
+    });
+
+    suite('getDownloadUrl()', () => {
+        test('should return file:// URL for skill directory', () => {
+            const source: RegistrySource = {
+                id: 'test-local-skills',
+                name: 'Test Local Skills',
+                type: 'local-skills',
+                url: tempDir,
+                enabled: true,
+                priority: 1,
+            };
+
+            const adapter = new LocalSkillsAdapter(source);
+            const sourceName = path.basename(tempDir);
+            const url = adapter.getDownloadUrl(`local-skills-${sourceName}-test-skill`);
+            
+            assert.ok(url.startsWith('file://'));
+            assert.ok(url.includes('test-skill'));
+        });
+    });
+
+    suite('downloadBundle()', () => {
+        test('should package skill as ZIP buffer', async () => {
+            createSkill('test-skill', {
+                description: 'Test skill for download',
+                additionalFiles: ['helper.md']
+            });
+
+            const source: RegistrySource = {
+                id: 'test-local-skills',
+                name: 'Test Local Skills',
+                type: 'local-skills',
+                url: tempDir,
+                enabled: true,
+                priority: 1,
+            };
+
+            const adapter = new LocalSkillsAdapter(source);
+            const bundles = await adapter.fetchBundles();
+            
+            assert.strictEqual(bundles.length, 1);
+            
+            const zipBuffer = await adapter.downloadBundle(bundles[0]);
+            
+            assert.ok(Buffer.isBuffer(zipBuffer));
+            assert.ok(zipBuffer.length > 0);
+            
+            // Verify it's a valid ZIP (starts with PK signature)
+            assert.strictEqual(zipBuffer[0], 0x50); // 'P'
+            assert.strictEqual(zipBuffer[1], 0x4B); // 'K'
+        });
+
+        test('should throw error for non-existent skill', async () => {
+            const source: RegistrySource = {
+                id: 'test-local-skills',
+                name: 'Test Local Skills',
+                type: 'local-skills',
+                url: tempDir,
+                enabled: true,
+                priority: 1,
+            };
+
+            const adapter = new LocalSkillsAdapter(source);
+            
+            const fakeBundle = {
+                id: `local-skills-${path.basename(tempDir)}-nonexistent`,
+                name: 'nonexistent',
+                version: '1.0.0',
+                description: 'Does not exist',
+                author: 'test',
+                sourceId: 'test-local-skills',
+                environments: [],
+                tags: [],
+                lastUpdated: new Date().toISOString(),
+                size: '0 B',
+                dependencies: [],
+                license: 'Unknown',
+            };
+
+            await assert.rejects(
+                adapter.downloadBundle(fakeBundle as any),
+                /Skill not found/
+            );
+        });
+    });
+
+    suite('getSkillSourcePath()', () => {
+        test('should return absolute path to skill directory', () => {
+            createSkill('test-skill', { description: 'Test skill' });
+
+            const source: RegistrySource = {
+                id: 'test-local-skills',
+                name: 'Test Local Skills',
+                type: 'local-skills',
+                url: tempDir,
+                enabled: true,
+                priority: 1,
+            };
+
+            const adapter = new LocalSkillsAdapter(source);
+            const sourceName = path.basename(tempDir);
+            
+            const mockBundle = {
+                id: `local-skills-${sourceName}-test-skill`,
+                name: 'test-skill',
+                version: '1.0.0',
+                description: 'Test skill',
+                author: 'test',
+                sourceId: 'test-local-skills',
+                environments: [],
+                tags: [],
+                lastUpdated: new Date().toISOString(),
+                size: '0 B',
+                dependencies: [],
+                license: 'Unknown',
+            };
+
+            const skillPath = adapter.getSkillSourcePath(mockBundle as any);
+            
+            assert.ok(path.isAbsolute(skillPath));
+            assert.ok(skillPath.includes('test-skill'));
+            assert.strictEqual(skillPath, path.join(tempDir, 'skills', 'test-skill'));
+        });
+    });
+
+    suite('getSkillName()', () => {
+        test('should extract skill name from bundle ID', () => {
+            const source: RegistrySource = {
+                id: 'test-local-skills',
+                name: 'Test Local Skills',
+                type: 'local-skills',
+                url: tempDir,
+                enabled: true,
+                priority: 1,
+            };
+
+            const adapter = new LocalSkillsAdapter(source);
+            const sourceName = path.basename(tempDir);
+            
+            const mockBundle = {
+                id: `local-skills-${sourceName}-my-awesome-skill`,
+                name: 'my-awesome-skill',
+                version: '1.0.0',
+                description: 'Test skill',
+                author: 'test',
+                sourceId: 'test-local-skills',
+                environments: [],
+                tags: [],
+                lastUpdated: new Date().toISOString(),
+                size: '0 B',
+                dependencies: [],
+                license: 'Unknown',
+            };
+
+            const skillName = adapter.getSkillName(mockBundle as any);
+            
+            assert.strictEqual(skillName, 'my-awesome-skill');
+        });
+    });
+});

--- a/test/adapters/SkillsAdapter.test.ts
+++ b/test/adapters/SkillsAdapter.test.ts
@@ -1,0 +1,304 @@
+/**
+ * SkillsAdapter Tests
+ * Tests for GitHub-based Anthropic-style skills repository adapter
+ */
+
+import * as assert from 'assert';
+import nock from 'nock';
+import * as sinon from 'sinon';
+import { SkillsAdapter } from '../../src/adapters/SkillsAdapter';
+import { RegistrySource } from '../../src/types/registry';
+
+suite('SkillsAdapter Tests', () => {
+    const mockSource: RegistrySource = {
+        id: 'test-skills-source',
+        name: 'Test Skills Source',
+        type: 'skills',
+        url: 'https://github.com/test-owner/test-skills-repo',
+        enabled: true,
+        priority: 1,
+        token: 'test-token',
+    };
+
+    /**
+     * Helper to set up mock GitHub API responses for skills structure
+     */
+    function setupSkillsStructureMocks(options: {
+        skills?: Array<{
+            id: string;
+            name: string;
+            description: string;
+            license?: string;
+            files?: string[];
+        }>;
+        skillsDirectoryExists?: boolean;
+    }) {
+        const { skills = [], skillsDirectoryExists = true } = options;
+
+        if (!skillsDirectoryExists) {
+            nock('https://api.github.com')
+                .get('/repos/test-owner/test-skills-repo/contents/skills')
+                .reply(404, { message: 'Not Found' });
+            return;
+        }
+
+        // Mock skills/ directory listing (persist to allow multiple calls during validation)
+        const skillDirs = skills.map(skill => ({
+            name: skill.id,
+            path: `skills/${skill.id}`,
+            type: 'dir' as const,
+        }));
+
+        nock('https://api.github.com')
+            .persist()
+            .get('/repos/test-owner/test-skills-repo/contents/skills')
+            .reply(200, skillDirs);
+
+        // Mock each skill directory contents and SKILL.md
+        for (const skill of skills) {
+            const skillFiles = [
+                {
+                    name: 'SKILL.md',
+                    path: `skills/${skill.id}/SKILL.md`,
+                    type: 'file' as const,
+                    download_url: `https://raw.githubusercontent.com/test-owner/test-skills-repo/main/skills/${skill.id}/SKILL.md`
+                },
+                ...(skill.files || []).map(f => ({
+                    name: f,
+                    path: `skills/${skill.id}/${f}`,
+                    type: 'file' as const,
+                    download_url: `https://raw.githubusercontent.com/test-owner/test-skills-repo/main/skills/${skill.id}/${f}`
+                }))
+            ];
+
+            nock('https://api.github.com')
+                .get(`/repos/test-owner/test-skills-repo/contents/skills/${skill.id}`)
+                .reply(200, skillFiles);
+
+            // Mock SKILL.md download
+            const skillMdContent = `---
+name: ${skill.name}
+description: ${skill.description}
+${skill.license ? `license: ${skill.license}` : ''}
+---
+
+# ${skill.name}
+
+Instructions for ${skill.name}
+`;
+
+            nock('https://raw.githubusercontent.com')
+                .get(`/test-owner/test-skills-repo/main/skills/${skill.id}/SKILL.md`)
+                .reply(200, skillMdContent);
+        }
+    }
+
+    /**
+     * Helper to set up GitHub repository validation mocks
+     */
+    function setupValidationMocks() {
+        // Mock GitHub releases endpoint for GitHubAdapter validation
+        nock('https://api.github.com')
+            .get('/repos/test-owner/test-skills-repo/releases')
+            .reply(200, []);
+        
+        // Mock repository info endpoint (may be called during validation)
+        nock('https://api.github.com')
+            .get('/repos/test-owner/test-skills-repo')
+            .reply(200, {
+                name: 'test-skills-repo',
+                full_name: 'test-owner/test-skills-repo',
+                default_branch: 'main'
+            });
+    }
+
+    setup(() => {
+        nock.cleanAll();
+    });
+
+    teardown(() => {
+        nock.cleanAll();
+        sinon.restore();
+    });
+
+    suite('Constructor', () => {
+        test('should create adapter with valid GitHub URL', () => {
+            const adapter = new SkillsAdapter(mockSource);
+            assert.strictEqual(adapter.type, 'skills');
+        });
+
+        test('should throw error for invalid URL', () => {
+            const invalidSource: RegistrySource = {
+                ...mockSource,
+                url: 'https://gitlab.com/owner/repo',
+            };
+            
+            assert.throws(() => {
+                new SkillsAdapter(invalidSource);
+            }, /Invalid GitHub URL/);
+        });
+    });
+
+    suite('fetchBundles()', () => {
+        test('should discover skills from skills/ directory', async () => {
+            setupSkillsStructureMocks({
+                skills: [{
+                    id: 'algorithmic-art',
+                    name: 'algorithmic-art',
+                    description: 'Creating algorithmic art using p5.js',
+                    license: 'Apache-2.0',
+                    files: ['README.md']
+                }]
+            });
+
+            const adapter = new SkillsAdapter(mockSource);
+            const bundles = await adapter.fetchBundles();
+
+            assert.strictEqual(bundles.length, 1);
+            assert.strictEqual(bundles[0].name, 'algorithmic-art');
+            assert.strictEqual(bundles[0].description, 'Creating algorithmic art using p5.js');
+            assert.strictEqual(bundles[0].id, 'skills-test-owner-test-skills-repo-algorithmic-art');
+            assert.ok(bundles[0].tags.includes('skill'));
+            assert.ok(bundles[0].tags.includes('anthropic'));
+        });
+
+        test('should discover multiple skills', async () => {
+            setupSkillsStructureMocks({
+                skills: [
+                    {
+                        id: 'algorithmic-art',
+                        name: 'algorithmic-art',
+                        description: 'Creating algorithmic art',
+                    },
+                    {
+                        id: 'code-review',
+                        name: 'code-review',
+                        description: 'Code review skill',
+                    },
+                    {
+                        id: 'testing',
+                        name: 'testing',
+                        description: 'Testing skill',
+                    }
+                ]
+            });
+
+            const adapter = new SkillsAdapter(mockSource);
+            const bundles = await adapter.fetchBundles();
+
+            assert.strictEqual(bundles.length, 3);
+            
+            const artBundle = bundles.find(b => b.name === 'algorithmic-art');
+            const reviewBundle = bundles.find(b => b.name === 'code-review');
+            const testingBundle = bundles.find(b => b.name === 'testing');
+            
+            assert.ok(artBundle);
+            assert.ok(reviewBundle);
+            assert.ok(testingBundle);
+        });
+
+        test('should skip directories without SKILL.md', async () => {
+            // Mock skills/ directory with one valid skill and one without SKILL.md
+            nock('https://api.github.com')
+                .get('/repos/test-owner/test-skills-repo/contents/skills')
+                .reply(200, [
+                    { name: 'valid-skill', path: 'skills/valid-skill', type: 'dir' },
+                    { name: 'invalid-skill', path: 'skills/invalid-skill', type: 'dir' }
+                ]);
+
+            // Valid skill with SKILL.md
+            nock('https://api.github.com')
+                .get('/repos/test-owner/test-skills-repo/contents/skills/valid-skill')
+                .reply(200, [
+                    { name: 'SKILL.md', path: 'skills/valid-skill/SKILL.md', type: 'file', download_url: 'https://raw.githubusercontent.com/test-owner/test-skills-repo/main/skills/valid-skill/SKILL.md' }
+                ]);
+
+            nock('https://raw.githubusercontent.com')
+                .get('/test-owner/test-skills-repo/main/skills/valid-skill/SKILL.md')
+                .reply(200, '---\nname: valid-skill\ndescription: A valid skill\n---\n\nInstructions');
+
+            // Invalid skill without SKILL.md
+            nock('https://api.github.com')
+                .get('/repos/test-owner/test-skills-repo/contents/skills/invalid-skill')
+                .reply(200, [
+                    { name: 'README.md', path: 'skills/invalid-skill/README.md', type: 'file' }
+                ]);
+
+            const adapter = new SkillsAdapter(mockSource);
+            const bundles = await adapter.fetchBundles();
+
+            assert.strictEqual(bundles.length, 1);
+            assert.strictEqual(bundles[0].name, 'valid-skill');
+        });
+    });
+
+    suite('validate()', () => {
+        test('should validate repository with skills/ directory', async () => {
+            setupValidationMocks();
+            setupSkillsStructureMocks({
+                skills: [{
+                    id: 'test-skill',
+                    name: 'test-skill',
+                    description: 'Test skill',
+                }]
+            });
+
+            const adapter = new SkillsAdapter(mockSource);
+            const result = await adapter.validate();
+
+            assert.strictEqual(result.valid, true);
+            assert.strictEqual(result.errors.length, 0);
+            assert.strictEqual(result.bundlesFound, 1);
+        });
+
+        test('should fail validation when skills/ directory is missing', async () => {
+            setupValidationMocks();
+            
+            // Mock 404 for skills directory
+            nock('https://api.github.com')
+                .get('/repos/test-owner/test-skills-repo/contents/skills')
+                .reply(404, { message: 'Not Found' });
+
+            const adapter = new SkillsAdapter(mockSource);
+            const result = await adapter.validate();
+
+            assert.strictEqual(result.valid, false);
+            assert.ok(result.errors.some(e => e.includes('skills')));
+        });
+
+        test('should warn when no valid skills found', async () => {
+            setupValidationMocks();
+            
+            // Empty skills directory - need to mock twice (once for validate check, once for scan)
+            nock('https://api.github.com')
+                .get('/repos/test-owner/test-skills-repo/contents/skills')
+                .reply(200, [])
+                .get('/repos/test-owner/test-skills-repo/contents/skills')
+                .reply(200, []);
+
+            const adapter = new SkillsAdapter(mockSource);
+            const result = await adapter.validate();
+
+            assert.strictEqual(result.valid, true);
+            assert.ok(result.warnings.some(w => w.includes('No valid skills')));
+        });
+    });
+
+    suite('getManifestUrl()', () => {
+        test('should return correct manifest URL for skill', () => {
+            const adapter = new SkillsAdapter(mockSource);
+            const url = adapter.getManifestUrl('skills-test-owner-test-skills-repo-algorithmic-art');
+            
+            assert.strictEqual(url, 'https://raw.githubusercontent.com/test-owner/test-skills-repo/main/skills/algorithmic-art/SKILL.md');
+        });
+    });
+
+    suite('getDownloadUrl()', () => {
+        test('should return repository archive URL', () => {
+            const adapter = new SkillsAdapter(mockSource);
+            const url = adapter.getDownloadUrl('skills-test-owner-test-skills-repo-algorithmic-art');
+            
+            assert.strictEqual(url, 'https://github.com/test-owner/test-skills-repo/archive/refs/heads/main.zip');
+        });
+    });
+});


### PR DESCRIPTION
## Description

Enable the addition of Skills repositories as registry source. For example you can now add [Anthropic Skills](https://github.com/anthropics/skills), or [Huggingface Skills](https://github.com/huggingface/skills).

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Related Issues

#82 

Closes #
Fixes #
Relates to #



## Testing

Unit tests and manual tests

### Test Coverage

- [x] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass


### Tested On

- [x] macOS

- [x] VS Code Stable
- [x] VS Code Insiders

## Screenshots
<img width="592" height="301" alt="image" src="https://github.com/user-attachments/assets/feeb033e-ba06-48b7-a800-a2d4fe6c0079" />
<img width="760" height="704" alt="image" src="https://github.com/user-attachments/assets/06112e3c-0a17-4125-9f14-26bf0f0af92e" />

