### PR TITLE
fix: separate local-only bundles into dedicated lockfile

### DIFF
--- a/schemas/lockfile.schema.json
+++ b/schemas/lockfile.schema.json
@@ -82,7 +82,6 @@
         "sourceId",
         "sourceType",
         "installedAt",
-        "commitMode",
         "files"
       ],
       "properties": {
@@ -122,7 +121,7 @@
         },
         "commitMode": {
           "type": "string",
-          "description": "Whether files are committed to Git or excluded",
+          "description": "DEPRECATED: Commit mode is now implicit based on which lockfile contains the entry. Bundles in prompt-registry.lock.json are implicitly 'commit' mode, bundles in prompt-registry.local.lock.json are implicitly 'local-only' mode. This field is retained for backward compatibility but should not be included in new entries.",
           "enum": [
             "commit",
             "local-only"

--- a/src/types/lockfile.ts
+++ b/src/types/lockfile.ts
@@ -43,8 +43,14 @@ export interface LockfileBundleEntry {
     sourceType: string;
     /** ISO timestamp when bundle was installed */
     installedAt: string;
-    /** Whether files are committed to Git or excluded */
-    commitMode: RepositoryCommitMode;
+    /** 
+     * Whether files are committed to Git or excluded.
+     * DEPRECATED: This field is now implicit based on which lockfile contains the entry.
+     * - Entries in prompt-registry.lock.json are implicitly 'commit' mode
+     * - Entries in prompt-registry.local.lock.json are implicitly 'local-only' mode
+     * This field may still be present in existing lockfiles for backward compatibility.
+     */
+    commitMode?: RepositoryCommitMode;
     /** Optional checksum of the bundle archive */
     checksum?: string;
     /** List of installed files with their checksums */

--- a/test/services/RepositoryScopeService.test.ts
+++ b/test/services/RepositoryScopeService.test.ts
@@ -110,7 +110,13 @@ suite('RepositoryScopeService', () => {
      * The unsyncBundle method now reads from LockfileManager instead of RegistryStorage
      */
     const createLockfile = (bundleId: string, commitMode: RepositoryCommitMode = 'commit', files: Array<{ path: string; checksum: string }> = []) => {
-        const lockfilePath = path.join(workspaceRoot, 'prompt-registry.lock.json');
+        // Write to the correct lockfile based on commitMode
+        // - 'commit' mode: write to prompt-registry.lock.json
+        // - 'local-only' mode: write to prompt-registry.local.lock.json
+        const lockfileName = commitMode === 'local-only' 
+            ? 'prompt-registry.local.lock.json' 
+            : 'prompt-registry.lock.json';
+        const lockfilePath = path.join(workspaceRoot, lockfileName);
         const lockfile = {
             $schema: 'https://github.com/AmadeusITGroup/prompt-registry/schemas/lockfile.schema.json',
             version: '1.0.0',
@@ -122,7 +128,7 @@ suite('RepositoryScopeService', () => {
                     sourceId: 'test-source',
                     sourceType: 'github',
                     installedAt: new Date().toISOString(),
-                    commitMode: commitMode,
+                    // Note: commitMode is NOT included in bundle entries (implicit based on file location)
                     files: files
                 }
             },


### PR DESCRIPTION
## Description

Implements dual-lockfile architecture to separate local-only bundles from committed bundles. Local-only bundles are now stored in `prompt-registry.local.lock.json` (auto-excluded from Git) instead of modifying the shared `prompt-registry.lock.json`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test coverage improvement
- [ ] 🔧 Configuration/build changes

## Related Issues

Fixes #123

## Changes Made

- Implemented dual-lockfile routing: `prompt-registry.lock.json` for committed bundles, `prompt-registry.local.lock.json` for local-only bundles
- Made commit mode implicit based on file location (no longer stored in bundle entries)
- Added automatic Git exclusion management for local lockfile via `.git/info/exclude`
- Implemented atomic commit mode switching with bundle migration between lockfiles
- Added conflict detection when same bundle ID exists in both lockfiles
- Updated `LockfileManager` with dual-lockfile read/write/merge logic
- Enhanced `RepositoryScopeService` to handle both lockfile types
- Removed explicit commit mode handling from `RegistryManager`
- Updated lockfile schema to make `commitMode` optional (backward compatible)
- Added comprehensive test coverage including property-based tests

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

### Manual Testing Steps

1. Install a bundle in repository scope with commit mode
2. Verify bundle appears in `prompt-registry.lock.json`
3. Switch bundle to local-only mode
4. Verify bundle moves to `prompt-registry.local.lock.json` and local lockfile is added to `.git/info/exclude`
5. Verify main lockfile is deleted if it becomes empty
6. Switch bundle back to commit mode
7. Verify bundle moves back to main lockfile and local lockfile is deleted
8. Do the same when other packages are installed make sure behavior is consistent

### Tested On

- [x] macOS
- [ ] Windows
- [ ] Linux

- [ ] VS Code Stable
- [x] VS Code Insiders

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Documentation

- [ ] README.md updated
- [ ] JSDoc comments added/updated
- [x] Documentation updated in `docs/contributor-guide/architecture/installation-flow.md`
- [x] Documentation updated in `docs/user-guide/repository-installation.md`

## Additional Notes

**Backward Compatibility:** Existing lockfiles with `commitMode` field continue to work. The field is read but no longer written to new entries.

**Key Design Decision:** Commit mode is now implicit based on which lockfile contains the bundle entry, eliminating the need to store it explicitly and preventing inconsistencies.

## Reviewer Guidelines

Please pay special attention to:

- Dual-lockfile routing logic in `LockfileManager.createOrUpdate()` and `getInstalledBundles()`
- Conflict detection and error handling when bundle exists in both lockfiles

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**
