### PR TITLE
fix(lib): include MCP servers in generated deployment manifest

### DIFF
--- a/lib/bin/generate-manifest.js
+++ b/lib/bin/generate-manifest.js
@@ -117,6 +117,9 @@ try {
       .replace(/^@[^/]+\//, '');
   }
 
+  // Extract MCP servers from either 'mcp.items' or 'mcpServers' field (matching AwesomeCopilotAdapter)
+  const mcpServers = collection.mcpServers || (collection.mcp && collection.mcp.items);
+
   // Create deployment manifest
   const manifest = {
     id: manifestId,
@@ -130,6 +133,7 @@ try {
     repository: packageJson.repository?.url?.replace(/^git\+/, '').replace(/\.git$/, '') || '',
     prompts: prompts,
     dependencies: [],
+    ...(mcpServers && Object.keys(mcpServers).length > 0 ? { mcpServers } : {}),
   };
 
   // Write deployment manifest
@@ -150,6 +154,11 @@ try {
     const typeLabel = type.charAt(0).toUpperCase() + type.slice(1) + 's';
     console.log(`    ${typeLabel}: ${typesCounts[type]}`);
   });
+
+  // Log MCP servers count if present
+  if (mcpServers && Object.keys(mcpServers).length > 0) {
+    console.log(`  MCP Servers: ${Object.keys(mcpServers).length}`);
+  }
 } catch (error) {
   console.error('❌ Error generating deployment manifest:', error.message);
   process.exit(1);

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prompt-registry/collection-scripts",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Shared scripts for building, validating, and publishing Copilot prompt collections",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/lib/test/generate-manifest.test.ts
+++ b/lib/test/generate-manifest.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Generate Manifest Script Tests
+ * 
+ * Tests for the generate-manifest.js CLI script that creates deployment manifests
+ * from collection YAML files.
+ */
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import * as yaml from 'js-yaml';
+import { spawnSync } from 'child_process';
+
+function createTempDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function writeFile(root: string, relativePath: string, content: string): void {
+  const fullPath = path.join(root, relativePath);
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+  fs.writeFileSync(fullPath, content);
+}
+
+function cleanup(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+describe('Generate Manifest Script', () => {
+  let tempDir: string;
+  const scriptPath = path.join(__dirname, '../bin/generate-manifest.js');
+
+  beforeEach(() => {
+    tempDir = createTempDir('generate-manifest-test-');
+  });
+
+  afterEach(() => {
+    cleanup(tempDir);
+  });
+
+  describe('MCP Servers', () => {
+    it('should include MCP servers from mcp.items field', () => {
+      // Create collection with MCP servers in mcp.items format (schema format)
+      const collectionYaml = `
+id: test-collection
+name: Test Collection
+description: A test collection with MCP servers
+version: "1.0.0"
+items:
+  - path: prompts/test.prompt.md
+    kind: prompt
+mcp:
+  items:
+    test-server:
+      command: node
+      args:
+        - server.js
+      env:
+        API_KEY: test-key
+    another-server:
+      command: python
+      args:
+        - mcp_server.py
+`;
+
+      writeFile(tempDir, 'collections/test.collection.yml', collectionYaml);
+      writeFile(tempDir, 'prompts/test.prompt.md', '# Test Prompt\n\nTest content');
+
+      const outFile = path.join(tempDir, 'deployment-manifest.yml');
+
+      // Run the generate-manifest script
+      const result = spawnSync('node', [scriptPath, '1.0.0', '--collection-file', 'collections/test.collection.yml', '--out', outFile], {
+        cwd: tempDir,
+        encoding: 'utf8'
+      });
+
+      assert.strictEqual(result.status, 0, `Script failed: ${result.stderr}`);
+      assert.ok(fs.existsSync(outFile), 'Manifest file should be created');
+
+      // Parse the generated manifest
+      const manifestContent = fs.readFileSync(outFile, 'utf8');
+      const manifest = yaml.load(manifestContent) as any;
+
+      // Verify MCP servers are included
+      assert.ok(manifest.mcpServers, 'Manifest should include mcpServers field');
+      assert.strictEqual(Object.keys(manifest.mcpServers).length, 2, 'Should have 2 MCP servers');
+      assert.ok(manifest.mcpServers['test-server'], 'Should include test-server');
+      assert.ok(manifest.mcpServers['another-server'], 'Should include another-server');
+      
+      // Verify server configuration
+      assert.strictEqual(manifest.mcpServers['test-server'].command, 'node');
+      assert.deepStrictEqual(manifest.mcpServers['test-server'].args, ['server.js']);
+      assert.deepStrictEqual(manifest.mcpServers['test-server'].env, { API_KEY: 'test-key' });
+    });
+
+    it('should include MCP servers from mcpServers field (legacy format)', () => {
+      // Create collection with MCP servers in mcpServers format (manifest format)
+      const collectionYaml = `
+id: legacy-collection
+name: Legacy Collection
+description: A collection with legacy mcpServers format
+version: "1.0.0"
+items:
+  - path: prompts/test.prompt.md
+    kind: prompt
+mcpServers:
+  legacy-server:
+    command: npx
+    args:
+      - legacy-mcp
+`;
+
+      writeFile(tempDir, 'collections/legacy.collection.yml', collectionYaml);
+      writeFile(tempDir, 'prompts/test.prompt.md', '# Test Prompt\n\nTest content');
+
+      const outFile = path.join(tempDir, 'deployment-manifest.yml');
+
+      const result = spawnSync('node', [scriptPath, '1.0.0', '--collection-file', 'collections/legacy.collection.yml', '--out', outFile], {
+        cwd: tempDir,
+        encoding: 'utf8'
+      });
+
+      assert.strictEqual(result.status, 0, `Script failed: ${result.stderr}`);
+
+      const manifestContent = fs.readFileSync(outFile, 'utf8');
+      const manifest = yaml.load(manifestContent) as any;
+
+      assert.ok(manifest.mcpServers, 'Manifest should include mcpServers field');
+      assert.ok(manifest.mcpServers['legacy-server'], 'Should include legacy-server');
+      assert.strictEqual(manifest.mcpServers['legacy-server'].command, 'npx');
+    });
+
+    it('should not include mcpServers field when no MCP servers defined', () => {
+      const collectionYaml = `
+id: no-mcp-collection
+name: No MCP Collection
+description: A collection without MCP servers
+version: "1.0.0"
+items:
+  - path: prompts/test.prompt.md
+    kind: prompt
+`;
+
+      writeFile(tempDir, 'collections/no-mcp.collection.yml', collectionYaml);
+      writeFile(tempDir, 'prompts/test.prompt.md', '# Test Prompt\n\nTest content');
+
+      const outFile = path.join(tempDir, 'deployment-manifest.yml');
+
+      const result = spawnSync('node', [scriptPath, '1.0.0', '--collection-file', 'collections/no-mcp.collection.yml', '--out', outFile], {
+        cwd: tempDir,
+        encoding: 'utf8'
+      });
+
+      assert.strictEqual(result.status, 0, `Script failed: ${result.stderr}`);
+
+      const manifestContent = fs.readFileSync(outFile, 'utf8');
+      const manifest = yaml.load(manifestContent) as any;
+
+      assert.strictEqual(manifest.mcpServers, undefined, 'Manifest should not include mcpServers field when none defined');
+    });
+
+    it('should log MCP servers count when present', () => {
+      const collectionYaml = `
+id: logged-collection
+name: Logged Collection
+description: A collection to test logging
+version: "1.0.0"
+items:
+  - path: prompts/test.prompt.md
+    kind: prompt
+mcp:
+  items:
+    server-one:
+      command: node
+      args: [server.js]
+    server-two:
+      command: python
+      args: [server.py]
+    server-three:
+      command: npx
+      args: [mcp-server]
+`;
+
+      writeFile(tempDir, 'collections/logged.collection.yml', collectionYaml);
+      writeFile(tempDir, 'prompts/test.prompt.md', '# Test Prompt\n\nTest content');
+
+      const outFile = path.join(tempDir, 'deployment-manifest.yml');
+
+      const result = spawnSync('node', [scriptPath, '1.0.0', '--collection-file', 'collections/logged.collection.yml', '--out', outFile], {
+        cwd: tempDir,
+        encoding: 'utf8'
+      });
+
+      assert.strictEqual(result.status, 0, `Script failed: ${result.stderr}`);
+      assert.ok(result.stdout.includes('MCP Servers: 3'), 'Should log MCP servers count in output');
+    });
+  });
+
+  describe('Basic Manifest Generation', () => {
+    it('should generate valid manifest from collection', () => {
+      const collectionYaml = `
+id: basic-collection
+name: Basic Collection
+description: A basic test collection
+version: "1.0.0"
+items:
+  - path: prompts/test.prompt.md
+    kind: prompt
+`;
+
+      writeFile(tempDir, 'collections/basic.collection.yml', collectionYaml);
+      writeFile(tempDir, 'prompts/test.prompt.md', '# Test Prompt\n\nTest content');
+
+      const outFile = path.join(tempDir, 'deployment-manifest.yml');
+
+      const result = spawnSync('node', [scriptPath, '1.0.0', '--collection-file', 'collections/basic.collection.yml', '--out', outFile], {
+        cwd: tempDir,
+        encoding: 'utf8'
+      });
+
+      assert.strictEqual(result.status, 0, `Script failed: ${result.stderr}`);
+      assert.ok(fs.existsSync(outFile), 'Manifest file should be created');
+
+      const manifestContent = fs.readFileSync(outFile, 'utf8');
+      const manifest = yaml.load(manifestContent) as any;
+
+      assert.strictEqual(manifest.id, 'basic-collection');
+      assert.strictEqual(manifest.version, '1.0.0');
+      assert.strictEqual(manifest.name, 'Basic Collection');
+      assert.ok(Array.isArray(manifest.prompts));
+      assert.strictEqual(manifest.prompts.length, 1);
+    });
+  });
+});


### PR DESCRIPTION
## Description

MCP servers defined in collection files were not being installed when bundles were installed from GitHub Releases. The `lib/bin/generate-manifest.js` script, which generates the `deployment-manifest.yml` during CI/CD bundle builds, was not copying the `mcp` or `mcpServers` field from the collection YAML to the generated manifest. This resulted in GitHub Release bundles having no MCP server definitions, causing the extension to skip MCP installation entirely.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔧 Configuration/build changes

## Related Issues

Fixes #129 

## Changes Made

- Modified `lib/bin/generate-manifest.js` to extract MCP servers from collection files
- Added support for both `collection.mcpServers` and `collection.mcp.items` formats (matching AwesomeCopilotAdapter behavior)
- Included `mcpServers` field in the generated deployment manifest when present
- Added logging output for MCP servers count during manifest generation

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

### Manual Testing Steps

1. Run lib tests: `cd lib && npm test` → 102 passing
2. Run extension unit tests: `LOG_LEVEL=ERROR npm run test:unit` → 2180 passing
3. Run full validation: `.github/workflows/scripts/validate-locally.sh` → All 11 steps passed
4. Verify manifest generation includes MCP servers (will be visible in CI logs after merge)

### Tested On

- [x] Linux
- [ ] macOS
- [ ] Windows

- [x] VS Code Insiders
- [ ] VS Code Stable

## Screenshots

N/A - This is a build-time fix affecting manifest generation

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Documentation

- [ ] README.md updated
- [ ] JSDoc comments added/updated
- [x] No documentation changes needed

## Additional Notes

**Important:** Existing GitHub Release bundles will need to be **rebuilt and republished** for this fix to take effect. The fix only applies to newly generated bundles created after this change is merged.

**Root Cause:** The collection schema (`schemas/collection.schema.json`) defines MCP servers under `mcp.items`, but the manifest generation script was only copying `prompts`, `tags`, and basic metadata fields. The `mcpServers` field was completely omitted from the generated `deployment-manifest.yml`.

**Verification:** The fix has been validated with:
- 102 lib tests passing
- 2180 extension unit tests passing
- Full local validation suite (11 steps)

## Reviewer Guidelines

Please pay special attention to:

- The logic for extracting MCP servers from both `collection.mcpServers` and `collection.mcp.items` (lines 120-121)
- The conditional inclusion in the manifest using spread operator (line 136)
- The logging output for MCP servers count (lines 158-161)
- Consistency with how `AwesomeCopilotAdapter` handles the same fields

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**
