### PR TITLE
fix(adapters): parallelize skill directory fetching in SkillsAdapter

### DIFF
--- a/test/adapters/SkillsAdapter.test.ts
+++ b/test/adapters/SkillsAdapter.test.ts
@@ -197,6 +197,29 @@ Instructions for ${skill.name}
             assert.ok(testingBundle);
         });
 
+        test('should handle many skills efficiently', async () => {
+            // Create 10 skills to verify the adapter handles multiple skills correctly
+            const manySkills = Array.from({ length: 10 }, (_, i) => ({
+                id: `skill-${i}`,
+                name: `Skill ${i}`,
+                description: `Description for skill ${i}`,
+            }));
+
+            setupSkillsStructureMocks({ skills: manySkills });
+
+            const adapter = new SkillsAdapter(mockSource);
+            const bundles = await adapter.fetchBundles();
+
+            assert.strictEqual(bundles.length, 10);
+            
+            // Verify all skills were discovered
+            for (let i = 0; i < 10; i++) {
+                const bundle = bundles.find(b => b.name === `Skill ${i}`);
+                assert.ok(bundle, `Should find skill-${i}`);
+                assert.strictEqual(bundle.description, `Description for skill ${i}`);
+            }
+        });
+
         test('should skip directories without SKILL.md', async () => {
             // Mock skills/ directory with one valid skill and one without SKILL.md
             nock('https://api.github.com')


### PR DESCRIPTION
## Description

This PR fixes a performance issue in the `SkillsAdapter` where skill directories were being processed sequentially, causing very slow synchronization times for repositories with many skills. The fix implements parallel fetching with a concurrency limit, matching the pattern already used in `AwesomeCopilotAdapter`.

**Performance Impact:**
- **Before**: 29 skills processed sequentially (~24 seconds based on ~800ms per skill)
- **After**: 29 skills processed in 6 parallel batches of 5 (~5 seconds estimated)

This is a **~80% reduction in sync time** for repositories with many skills.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Code refactoring (no functional changes)
- [x] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔧 Configuration/build changes

## Related Issues

Relates to recent performance optimization work in commit `ac06c1c` (AwesomeCopilotAdapter parallelization)

## Changes Made

- **`src/adapters/SkillsAdapter.ts`**: Replaced sequential `for` loop in `scanSkillsDirectory()` with parallel `Promise.all` processing
  - Added concurrency limit of 5 to avoid overwhelming the GitHub API
  - Skills are now processed in chunks of 5 simultaneously instead of one-by-one
  - Error handling preserved - failed skill directories are logged and skipped without blocking others
  - Added debug logging for chunk processing progress

- **`test/adapters/SkillsAdapter.test.ts`**: Added test case `'should handle many skills efficiently'`
  - Verifies correct behavior with 10 skills
  - Tests observable behavior (all skills discovered) rather than implementation details
  - Follows project testing guidelines from `test/AGENTS.md`

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

### Manual Testing Steps

1. Run `npm run test:one -- test/adapters/SkillsAdapter.test.ts` - all 11 tests pass
2. Run `LOG_LEVEL=ERROR npm run test:one -- test/adapters/` - all 284 adapter tests pass
3. Verified no regressions in existing test cases

### Tested On

- [x] Linux

- [x] VS Code Stable

## Screenshots

N/A - Performance optimization with no UI changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Documentation

- [ ] README.md updated
- [x] JSDoc comments added/updated (updated method docstring)
- [ ] No documentation changes needed

## Additional Notes

This fix follows the exact pattern used in `AwesomeCopilotAdapter` (commit `ac06c1c`), ensuring consistency across adapters. The concurrency limit of 5 is a conservative choice that balances performance with API rate limits.

The implementation preserves all existing error handling behavior - if a skill directory fails to process, it's logged as a warning and skipped without blocking other skills.

## Reviewer Guidelines

Please pay special attention to:

- Verify the parallel processing logic correctly handles errors without losing data
- Confirm the concurrency limit of 5 is appropriate for GitHub API rate limits
- Check that the test case adequately covers the new behavior

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**
