### PR TITLE
fix(schema): allow spaces and dots in profile path pattern and add engagement config

### DIFF
--- a/schemas/hub-config.schema.json
+++ b/schemas/hub-config.schema.json
@@ -258,7 +258,7 @@
               "type": "string",
               "minLength": 1,
               "maxLength": 50,
-              "pattern": "^[a-zA-Z0-9-_]+$"
+              "pattern": "^[a-zA-Z0-9-_. ]+$"
             }
           }
         }
@@ -282,6 +282,97 @@
         "strictMode": {
           "type": "boolean",
           "description": "Enable strict validation and security checks"
+        }
+      }
+    },
+    "engagement": {
+      "type": "object",
+      "description": "Engagement features configuration (telemetry, ratings, feedback)",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable engagement features for this hub"
+        },
+        "backend": {
+          "type": "object",
+          "description": "Backend configuration for engagement data storage",
+          "required": ["type"],
+          "additionalProperties": true,
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "Backend type for engagement data",
+              "enum": ["file", "github-issues", "github-discussions", "api"]
+            },
+            "repository": {
+              "type": "string",
+              "description": "GitHub repository in owner/repo format (for github-issues or github-discussions backends)",
+              "pattern": "^[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$"
+            },
+            "apiUrl": {
+              "type": "string",
+              "description": "API endpoint URL (for api backend)",
+              "format": "uri"
+            }
+          }
+        },
+        "telemetry": {
+          "type": "object",
+          "description": "Telemetry configuration",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable telemetry collection"
+            },
+            "anonymize": {
+              "type": "boolean",
+              "description": "Anonymize telemetry data"
+            }
+          }
+        },
+        "ratings": {
+          "type": "object",
+          "description": "Rating configuration",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable rating features"
+            },
+            "ratingsUrl": {
+              "type": "string",
+              "description": "URL to pre-computed ratings.json file (static hosting)",
+              "format": "uri"
+            }
+          }
+        },
+        "feedback": {
+          "type": "object",
+          "description": "Feedback configuration",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable feedback features"
+            },
+            "requireRating": {
+              "type": "boolean",
+              "description": "Require rating when submitting feedback"
+            },
+            "maxLength": {
+              "type": "number",
+              "description": "Maximum feedback comment length",
+              "minimum": 100,
+              "maximum": 10000
+            },
+            "feedbackUrl": {
+              "type": "string",
+              "description": "URL to pre-computed feedbacks.json file (static hosting)",
+              "format": "uri"
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
## Description

Fix hub import validation error where profile path elements containing spaces or dots are incorrectly rejected. Also adds the `engagement` configuration section to the hub schema in preparation for future telemetry, ratings, and feedback features.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test coverage improvement
- [ ] 🔧 Configuration/build changes

## Related Issues

Fixes #156 

## Changes Made

- Updated `path` pattern in `hub-config.schema.json` from `^[a-zA-Z0-9-_]+$` to `^[a-zA-Z0-9-_. ]+$` to allow spaces and dots in profile path hierarchy elements
- Added `engagement` configuration section to `hub-config.schema.json` with support for:
  - Backend configuration (file, github-issues, github-discussions, api)
  - Telemetry settings (enabled, anonymize)
  - Ratings configuration (enabled, ratingsUrl)
  - Feedback configuration (enabled, requireRating, maxLength, feedbackUrl)
- Added comprehensive TDD tests for path validation with spaces and dots
- Added tests for engagement configuration validation (backend types, repository format, maxLength constraints)

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

### Manual Testing Steps

1. Import a hub configuration with profile paths containing spaces (e.g., `["Amadeus Airlines", "Solutions"]`)
2. Verify the hub imports successfully without validation errors
3. Verify existing hub configurations still work correctly

### Tested On

- [ ] macOS
- [ ] Windows
- [x] Linux

- [x] VS Code Stable
- [ ] VS Code Insiders

## Screenshots

N/A - Schema validation fix

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Documentation

- [ ] README.md updated
- [x] JSDoc comments added/updated (schema descriptions)
- [ ] No documentation changes needed

## Additional Notes

This fix was retrofitted from the `feature/telemetry-feedback-rating-clean` branch where the engagement features are being developed. The schema changes are forward-compatible and prepare the hub configuration for future engagement features.

The path pattern change is backward-compatible - all previously valid paths remain valid, and the change only allows additional characters (spaces and dots).

## Reviewer Guidelines

Please pay special attention to:

- The regex pattern change in `hub-config.schema.json` - verify it correctly allows spaces and dots while still rejecting problematic characters like slashes
- The engagement schema structure - verify it matches the intended design for telemetry/ratings/feedback features
- Test coverage for edge cases in path validation

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**
