### PR TITLE
fix: UI cleanup and sync notification improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -381,6 +381,18 @@
         "icon": "$(star)"
       },
       {
+        "command": "promptRegistry.showFavoritesView",
+        "title": "Show Favorites",
+        "category": "Prompt Registry",
+        "icon": "$(star)"
+      },
+      {
+        "command": "promptRegistry.hideFavoritesView",
+        "title": "Show All Profiles",
+        "category": "Prompt Registry",
+        "icon": "$(star-full)"
+      },
+      {
         "command": "promptRegistry.toggleProfileFavorite",
         "title": "Toggle Favorite",
         "category": "Prompt Registry",
@@ -475,8 +487,13 @@
       ],
       "view/title": [
         {
-          "command": "promptRegistry.toggleProfileView",
-          "when": "view == promptRegistryExplorer",
+          "command": "promptRegistry.showFavoritesView",
+          "when": "view == promptRegistryExplorer && !promptRegistry.favoritesViewActive",
+          "group": "navigation@0"
+        },
+        {
+          "command": "promptRegistry.hideFavoritesView",
+          "when": "view == promptRegistryExplorer && promptRegistry.favoritesViewActive",
           "group": "navigation@0"
         },
         {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -429,7 +429,10 @@ export class PromptRegistryExtension {
         
         // Create tree provider
         this.treeProvider = new RegistryTreeProvider(this.registryManager, this.hubManager!);
-        
+
+        // Initialize favorites view context (starts in 'all' mode)
+        vscode.commands.executeCommand('setContext', 'promptRegistry.favoritesViewActive', false);
+
         // Register tree view
         const treeView = vscode.window.createTreeView('promptRegistryExplorer', {
             treeDataProvider: this.treeProvider,
@@ -444,6 +447,12 @@ export class PromptRegistryExtension {
                 this.treeProvider?.refresh();
             }),
             vscode.commands.registerCommand('promptRegistry.toggleProfileView', () => {
+                this.treeProvider?.toggleViewMode();
+            }),
+            vscode.commands.registerCommand('promptRegistry.showFavoritesView', () => {
+                this.treeProvider?.toggleViewMode();
+            }),
+            vscode.commands.registerCommand('promptRegistry.hideFavoritesView', () => {
                 this.treeProvider?.toggleViewMode();
             }),
         ];
@@ -1260,7 +1269,7 @@ export class PromptRegistryExtension {
             // Sync all sources from the active hub in the background (non-blocking)
             // This allows the extension to finish activation quickly so the webview can resolve
             // and show cached bundles while sync happens progressively
-            sourceCommands.syncAllSources().then(() => {
+            sourceCommands.syncAllSources({ silent: true }).then(() => {
                 this.logger.info('Active hub synchronized successfully on activation');
                 // Refresh tree view after sync completes
                 vscode.commands.executeCommand('promptRegistry.refresh');
@@ -1395,7 +1404,7 @@ export class PromptRegistryExtension {
                 
                 // Sync all sources from the newly imported hub in the background (non-blocking)
                 // This allows the UI to be responsive while sync happens progressively
-                this.sourceCommands!.syncAllSources().then(() => {
+                this.sourceCommands!.syncAllSources({ silent: true }).then(() => {
                     this.logger.info('Sources synchronized successfully');
                     vscode.commands.executeCommand('promptRegistry.refresh');
                 }).catch((syncError) => {

--- a/src/ui/MarketplaceViewProvider.ts
+++ b/src/ui/MarketplaceViewProvider.ts
@@ -1733,28 +1733,6 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
             border-color: var(--vscode-gitDecoration-addedResourceForeground);
         }
 
-        .curated-badge {
-            position: absolute;
-            top: 12px;
-            right: 12px;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-            color: white;
-            padding: 4px 10px;
-            border-radius: 12px;
-            font-size: 11px;
-            font-weight: 600;
-            display: flex;
-            align-items: center;
-            gap: 4px;
-            box-shadow: 0 2px 8px rgba(102, 126, 234, 0.3);
-            z-index: 2;
-        }
-
-        .curated-badge::before {
-            content: "✨";
-            font-size: 12px;
-        }
-
         .installed-badge {
             position: absolute;
             top: 12px;
@@ -2465,7 +2443,6 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
             marketplace.innerHTML = filteredBundles.map(bundle => \`
                 <div class="bundle-card \${bundle.installed ? 'installed' : ''}" data-bundle-id="\${bundle.id}" onclick="openDetails('\${bundle.id}')">
                     \${bundle.installed && bundle.autoUpdateEnabled ? '<div class="installed-badge">🔄 Auto-Update</div>' : bundle.installed ? '<div class="installed-badge">✓ Installed</div>' : ''}
-                    \${bundle.isCurated ? '<div class="curated-badge" title="From curated hub: ' + (bundle.hubName || 'Unknown') + '">' + (bundle.hubName || 'Curated') + '</div>' : ''}
                     
                     <div class="bundle-header">
                         <div class="bundle-title">\${bundle.name}</div>

--- a/src/ui/RegistryTreeProvider.ts
+++ b/src/ui/RegistryTreeProvider.ts
@@ -294,6 +294,7 @@ export class RegistryTreeProvider implements vscode.TreeDataProvider<RegistryTre
      */
     toggleViewMode(): void {
         this.viewMode = this.viewMode === 'all' ? 'favorites' : 'all';
+        vscode.commands.executeCommand('setContext', 'promptRegistry.favoritesViewActive', this.viewMode === 'favorites');
         this.refresh();
     }
 


### PR DESCRIPTION
## Description

UI polish pass: removes the purple curated badge overlay from marketplace bundle cards, fixes the favorites/all-profiles toggle so the toolbar icon reflects the current state, and silences source sync notifications when triggered automatically on extension activation or hub import.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [x] 🔧 Configuration/build changes

## Related Issues

## Changes Made

- **Remove curated badge overlay (MarketplaceViewProvider):** Deleted the `.curated-badge` CSS and its HTML rendering from bundle cards. The purple gradient badge was overlapping collection titles in the marketplace.
- **Fix favorites toggle icon (package.json, extension.ts, RegistryTreeProvider):** Replaced the single `toggleProfileView` toolbar button with two context-aware commands (`showFavoritesView` / `hideFavoritesView`) gated by `promptRegistry.favoritesViewActive`. The star icon now correctly switches between filled and outline states. Context is initialized on activation and updated on each toggle.
- **Silence auto-sync notifications (SourceCommands, extension.ts):** Added an optional `{ silent: boolean }` parameter to `syncAllSources()`. When `silent: true`, the method skips the progress notification, completion/warning/error toasts, and adapter cache clearing. Both auto-sync call sites (activation and hub import) now pass `{ silent: true }`. Manual sync via command palette is unchanged.
- **Simplify unit test glob (package.json):** Replaced the explicit folder list with `test-dist/test/**/*.test.js --ignore test-dist/test/suite/**/*.test.js` for easier maintenance.

## Testing

### Test Coverage

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

### Manual Testing Steps

1. Open the Prompt Marketplace and verify the purple "Official Amadeus Prompt Collections from GitHub" badge no longer appears on bundle cards
2. In the Explorer sidebar, click the favorites star icon and verify it toggles between filled and outline states correctly
3. Restart VS Code and verify no sync notification toast appears during activation; then manually trigger "Sync All Sources" from the command palette and verify the notification still appears

### Tested On

- [x] macOS
- [ ] Windows
- [ ] Linux

- [x] VS Code Stable
- [ ] VS Code Insiders

## Screenshots

Before:
<img width="1090" height="410" alt="image" src="https://github.com/user-attachments/assets/fd09d6c7-6ece-4d7c-a334-56ede3bf6b67" />
<img width="953" height="260" alt="image" src="https://github.com/user-attachments/assets/2eb71f5a-68a7-458c-819c-2b105ad25a88" />
<img width="549" height="161" alt="image" src="https://github.com/user-attachments/assets/be1e2dab-042f-461a-9a5e-998791f3dd51" />


After:
<img width="1092" height="408" alt="image" src="https://github.com/user-attachments/assets/991962f6-989f-4412-a9fc-8ddac1b4d7e6" />
<img width="1118" height="253" alt="image" src="https://github.com/user-attachments/assets/70d93e45-47ad-4d0a-9138-170cd3a30a1f" />
<img width="630" height="201" alt="image" src="https://github.com/user-attachments/assets/e4cca515-91e9-4c19-95f5-c018cbcd15d7" />


## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Documentation

- [x] No documentation changes needed

## Additional Notes

The `isCurated` property remains in the data model (`types/registry.ts`) and is still computed in `MarketplaceViewProvider`. Only the visual rendering was removed. This avoids unnecessary churn if the property is needed for other purposes in the future.

## Reviewer Guidelines

Please pay special attention to:

- The `silent` path in `syncAllSources()` — verify the batch sync logic is equivalent to the non-silent path minus notifications
- The `when` clause conditions for `showFavoritesView` / `hideFavoritesView` to ensure no edge cases where both or neither appear

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**
