### PR TITLE
fix: repo-scope skill installation

### DIFF
--- a/src/adapters/SkillsAdapter.ts
+++ b/src/adapters/SkillsAdapter.ts
@@ -667,7 +667,8 @@ export class SkillsAdapter extends RepositoryAdapter {
                     id: skill.id,
                     name: skill.name,
                     description: skill.description,
-                    file: `SKILL.md`,
+                    // Use skills/<skill-id>/SKILL.md so repository scope can map and install
+                    file: `skills/${skill.id}/SKILL.md`,
                     type: 'skill',
                     tags: ['skill', 'anthropic']
                 }


### PR DESCRIPTION
## Description

Repository-scope skill installs now sync into `.github/skills` instead of the global `~/.copilot/skills` path. Skills bundles at user/workspace scope still install directly to the Copilot skills directory. Manifest generation for skills now points to `skills/<id>/SKILL.md`, and a regression test ensures repository-scope skills route through [RepositoryScopeService](cci:2://file:///Users/sahmed/workspace/GenAI/prompt-registry/src/services/RepositoryScopeService.ts:71:0-1008:1).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test coverage improvement
- [ ] 🔧 Configuration/build changes

## Related Issues

Closes #159

## Changes Made

- Route skills bundles at repository scope through the standard sync/lockfile flow (no direct install to `~/.copilot/skills`).
- Keep direct Copilot skills installation for user/workspace scopes only.
- Emit manifest entries for skills as `skills/<id>/SKILL.md` to support repo sync.
- Add regression test ensuring repository-scope skills use [RepositoryScopeService](cci:2://file:///Users/sahmed/workspace/GenAI/prompt-registry/src/services/RepositoryScopeService.ts:71:0-1008:1) (and not user scope).

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

### Manual Testing Steps

1. Configure a skills source (Anthropic-style) and run "Install Bundle" selecting scope `repository`.
2. Verify `.github/skills/<skill-id>/SKILL.md` exists in the workspace and lockfile updates reference the repository paths.
3. Confirm `~/.copilot/skills/<skill-id>` is unchanged for repository scope installs.


### Tested On

- [x] macOS
- [ ] Windows
- [ ] Linux

- [x] VS Code Stable
- [ ] VS Code Insiders

## Screenshots

_N/A_

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Documentation

- [ ] README.md updated
- [ ] JSDoc comments added/updated
- [x] No documentation changes needed

## Additional Notes

- Repository-scope skills now mirror collections behavior and update the lockfile via `.github/skills` installs. User/workspace flows remain unchanged.

## Reviewer Guidelines

Please pay special attention to:

- Skills routing in BundleInstaller (repo scope should flow to .github/skills; user/workspace still go to Copilot).
- Manifest `file` path (`skills/<id>/SKILL.md`) so repo sync grabs skill files.