### PR TITLE
feat: ease scaffolding inputs with hub configuration

### DIFF
--- a/docs/reference/hub-schema.md
+++ b/docs/reference/hub-schema.md
@@ -224,6 +224,52 @@ configuration:
   strictMode: true
 ```
 
+## Scaffold Defaults Object (Optional)
+
+Default values for project scaffolding prompts. Each organization-level field is individually skipped when its default is present. Fields like `githubOrg` and `githubRunner` are always shown but pre-filled from defaults.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `githubOrg` | string | GitHub organization name (pre-fills the prompt; always shown) |
+| `githubRunner` | string | GitHub Actions runner label or pattern. Supports `{githubOrg}` placeholder (e.g., `gmsshr-core-{githubOrg}`). Always shown, pre-filled with resolved value. |
+| `organizationName` | string | Organization name for LICENSE (skipped when present — value used directly) |
+| `internalContact` | string | Internal contact email for security/support (skipped when present) |
+| `legalContact` | string | Legal contact email for licensing questions (skipped when present) |
+| `organizationPolicyLink` | string | Organization policy URL (skipped when present) |
+
+**Note:** `author`, `description`, and `tags` are NOT part of scaffold defaults. The author field is pre-filled from the user's GitHub identity instead.
+
+### Runner Pattern
+
+The `githubRunner` field supports a `{githubOrg}` placeholder that is resolved at scaffold time using the selected GitHub organization. Only `{githubOrg}` is supported.
+
+**Example:** `gmsshr-core-{githubOrg}` with org `myorg` → `gmsshr-core-myorg`
+
+### Prompt Behavior
+
+| Field | Hub Default Present | Hub Default Absent |
+|-------|--------------------|--------------------|
+| `projectName` | Always asked | Always asked |
+| `author` | Prefilled from GitHub identity | Prefilled from GitHub identity |
+| `githubOrg` | Prefilled from default | Shown empty |
+| `githubRunner` | Prefilled with resolved pattern | Quick pick (ubuntu-latest / self-hosted / custom) |
+| `organizationName` | **Skipped** — hub value used | Asked |
+| `internalContact` | **Skipped** — hub value used | Asked |
+| `legalContact` | **Skipped** — hub value used | Asked |
+| `organizationPolicyLink` | **Skipped** — hub value used | Asked |
+
+### Example
+
+```yaml
+scaffoldDefaults:
+  githubOrg: "myorg"
+  githubRunner: "gmsshr-core-{githubOrg}"
+  organizationName: "My Organization Inc."
+  internalContact: "security@myorg.com"
+  legalContact: "legal@myorg.com"
+  organizationPolicyLink: "https://myorg.com/policies"
+```
+
 ## Complete Example
 
 ```yaml
@@ -269,6 +315,14 @@ profiles:
 configuration:
   autoSync: true
   syncInterval: 3600
+
+scaffoldDefaults:
+  githubOrg: "myorg"
+  githubRunner: "gmsshr-core-{githubOrg}"
+  organizationName: "My Organization"
+  internalContact: "security@myorg.com"
+  legalContact: "legal@myorg.com"
+  organizationPolicyLink: "https://myorg.com/policies"
 ```
 
 ## Validation

--- a/schemas/hub-config.schema.json
+++ b/schemas/hub-config.schema.json
@@ -285,6 +285,51 @@
         }
       }
     },
+    "scaffoldDefaults": {
+      "type": "object",
+      "description": "Default values for project scaffolding prompts. When present, organization-level fields are applied automatically without prompting the user.",
+      "additionalProperties": false,
+      "properties": {
+        "githubOrg": {
+          "type": "string",
+          "description": "GitHub organization name (pre-fills the githubOrg prompt)",
+          "minLength": 1,
+          "maxLength": 100,
+          "pattern": "^[a-zA-Z0-9_-]+$"
+        },
+        "githubRunner": {
+          "type": "string",
+          "description": "GitHub Actions runner label or pattern. Supports {githubOrg} placeholder (e.g., 'gmsshr-core-{githubOrg}')",
+          "minLength": 1,
+          "maxLength": 200
+        },
+        "organizationName": {
+          "type": "string",
+          "description": "Organization name for LICENSE and documentation",
+          "minLength": 1,
+          "maxLength": 200
+        },
+        "internalContact": {
+          "type": "string",
+          "description": "Internal contact email for security/support inquiries",
+          "minLength": 1,
+          "maxLength": 200
+        },
+        "legalContact": {
+          "type": "string",
+          "description": "Legal contact email for licensing questions",
+          "minLength": 1,
+          "maxLength": 200
+        },
+        "organizationPolicyLink": {
+          "type": "string",
+          "description": "URL to organization policy page",
+          "minLength": 1,
+          "maxLength": 500,
+          "format": "uri"
+        }
+      }
+    },
     "engagement": {
       "type": "object",
       "description": "Engagement features configuration (telemetry, ratings, feedback)",

--- a/src/commands/hub-commands.ts
+++ b/src/commands/hub-commands.ts
@@ -49,8 +49,6 @@ export class HubCommands {
    */
   private readonly logger: Logger;
 
-  private readonly context: vscode.ExtensionContext;
-
   constructor(
     hubManager: HubManager,
     registryManager: RegistryManager,
@@ -61,6 +59,622 @@ export class HubCommands {
     this.registryManager = registryManager;
     this.context = context;
     this.registerCommands();
+  }
+
+  private readonly context: vscode.ExtensionContext;
+
+  /**
+   * Register all hub-related commands
+   */
+  registerCommands(): void {
+    // Skip registration if vscode.commands is not available (e.g., in unit tests)
+    if (!vscode.commands || !vscode.commands.registerCommand) {
+      return;
+    }
+
+    this.context.subscriptions.push(
+      vscode.commands.registerCommand('promptregistry.importHub', () => this.importHub()),
+      vscode.commands.registerCommand('promptregistry.listHubs', () => this.listHubs()),
+      vscode.commands.registerCommand('promptregistry.syncHub', (hubId?: string) => this.syncHub(hubId)),
+      vscode.commands.registerCommand('promptregistry.deleteHub', (hubId?: string) => this.deleteHub(hubId)),
+      vscode.commands.registerCommand('promptregistry.switchHub', () => this.switchHub()),
+      vscode.commands.registerCommand('promptregistry.exportHubConfig', () => this.exportHubConfig()),
+      vscode.commands.registerCommand('promptregistry.openHubRepository', () => this.openHubRepository()),
+      vscode.commands.registerCommand('promptregistry.openItemRepository', (item: any) => this.openItemRepository(item))
+    );
+  }
+
+  /**
+   * Import a hub from various sources
+   */
+  async importHub(): Promise<string | undefined> {
+    try {
+      // Step 1: Select source type
+      const sourceType = await this.selectSourceType();
+      if (!sourceType) {
+        return undefined;
+      }
+
+      // Step 2: Get hub reference based on source type
+      const reference = await this.getHubReference(sourceType);
+      if (!reference) {
+        return undefined;
+      }
+
+      // Step 3: Get hub ID (optional, will auto-generate if not provided)
+      const hubId = await this.getHubId();
+      if (hubId === null) {
+        return undefined; // User cancelled
+      }
+
+      // Step 4: Import hub with progress
+      return await vscode.window.withProgress(
+        {
+          location: vscode.ProgressLocation.Notification,
+          title: 'Importing Hub',
+          cancellable: false
+        },
+        async (progress) => {
+          progress.report({ message: 'Loading hub configuration...' });
+
+          try {
+            // HubManager.importHub() handles source loading via loadHubSources()
+            const importedHubId = await this.hubManager.importHub(reference, hubId || undefined);
+
+            // Note: Hub profiles are NOT copied locally. They are accessed via
+            // HubManager.listProfilesFromHub() and displayed in "Shared Profiles" view.
+            // Local profiles are only created when the user explicitly creates them.
+
+            // Auto-activate the imported hub
+            await this.hubManager.setActiveHub(importedHubId);
+            this.logger.info(`Auto-activated imported hub: ${importedHubId}`);
+
+            const summary = this.hubManager.lastSourceLoadSummary;
+            if (summary && summary.failedCount > 0) {
+              if (summary.addedCount + summary.updatedCount === 0) {
+                vscode.window.showWarningMessage(
+                  `Hub "${importedHubId}" imported but all ${summary.failedCount} source(s) failed to load. Check Output > Prompt Registry for details.`
+                );
+              } else {
+                vscode.window.showWarningMessage(
+                  `Hub "${importedHubId}" imported, but ${summary.failedCount} source(s) failed to load. Check Output > Prompt Registry for details.`
+                );
+              }
+            } else {
+              vscode.window.showInformationMessage(
+                `Successfully imported and activated hub: ${importedHubId}`
+              );
+            }
+
+            // Refresh the tree view to show the new hub
+            vscode.commands.executeCommand('promptregistry.refresh');
+
+            return importedHubId;
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            vscode.window.showErrorMessage(`Failed to import hub: ${message}`);
+            throw error;
+          }
+        }
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      vscode.window.showErrorMessage(`Hub import failed: ${message}`);
+      return undefined;
+    }
+  }
+
+  /**
+   * List all imported hubs
+   */
+  async listHubs(): Promise<void> {
+    try {
+      const hubs = await this.hubManager.listHubs();
+
+      if (hubs.length === 0) {
+        vscode.window.showInformationMessage('No hubs imported yet. Use "Import Hub" to add one.');
+        return;
+      }
+
+      // Create quick pick items
+      const items: HubListItem[] = hubs.map((hub) => ({
+        label: hub.name,
+        description: hub.description,
+        detail: `ID: ${hub.id} | Source: ${hub.reference.type}`,
+        hubId: hub.id
+      }));
+
+      // Show quick pick
+      const selected = await vscode.window.showQuickPick(items, {
+        placeHolder: 'Select a hub to view details',
+        matchOnDescription: true,
+        matchOnDetail: true,
+        ignoreFocusOut: true
+      });
+
+      if (selected) {
+        await this.showHubDetails(selected.hubId);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      vscode.window.showErrorMessage(`Failed to list hubs: ${message}`);
+    }
+  }
+
+  /**
+   * Sync a hub from its source
+   * @param hubId Optional hub ID to sync (if not provided, user selects)
+   */
+  async syncHub(hubId?: string | any): Promise<void> {
+    try {
+      // Extract hub ID from tree item if object is passed
+      let targetHubId: string | undefined;
+      if (typeof hubId === 'string') {
+        targetHubId = hubId;
+      } else if (hubId && typeof hubId === 'object' && hubId.data) {
+        // Tree item passed from context menu
+        targetHubId = hubId.data.id;
+      }
+
+      // If no hub ID provided, let user select
+      if (!targetHubId) {
+        const hubs = await this.hubManager.listHubs();
+
+        if (hubs.length === 0) {
+          vscode.window.showInformationMessage('No hubs to sync.');
+          return;
+        }
+
+        // Add "Sync All" option
+        const items: HubListItem[] = [
+          {
+            label: '$(sync) Sync All Hubs',
+            description: 'Synchronize all imported hubs',
+            hubId: '',
+            action: 'all'
+          },
+          ...hubs.map((hub) => ({
+            label: hub.name,
+            description: `Sync from ${hub.reference.type}`,
+            detail: `ID: ${hub.id}`,
+            hubId: hub.id
+          }))
+        ];
+
+        const selected = await vscode.window.showQuickPick(items, {
+          placeHolder: 'Select hub to sync',
+          ignoreFocusOut: true
+        });
+
+        if (!selected) {
+          return;
+        }
+
+        if (selected.action === 'all') {
+          await this.syncAllHubs();
+          return;
+        }
+
+        targetHubId = selected.hubId;
+      }
+
+      // Sync single hub
+      await vscode.window.withProgress(
+        {
+          location: vscode.ProgressLocation.Notification,
+          title: `Syncing hub: ${targetHubId}`,
+          cancellable: false
+        },
+        async () => {
+          await this.hubManager.syncHub(targetHubId);
+          vscode.window.showInformationMessage(`Successfully synced hub: ${targetHubId}`);
+        }
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error('Failed to sync hub', error as Error);
+      vscode.window.showErrorMessage(`Failed to sync hub: ${message}`);
+    }
+  }
+
+  /**
+   * Delete a hub
+   * @param hubId Optional hub ID to delete (if not provided, user selects)
+   */
+  async deleteHub(hubId?: string | any): Promise<void> {
+    try {
+      // Extract hub ID from tree item if object is passed
+      let targetHubId: string | undefined;
+      if (typeof hubId === 'string') {
+        targetHubId = hubId;
+      } else if (hubId && typeof hubId === 'object' && hubId.data) {
+        // Tree item passed from context menu
+        targetHubId = hubId.data.id;
+      }
+
+      // If no hub ID provided, let user select
+      if (!targetHubId) {
+        const hubs = await this.hubManager.listHubs();
+
+        if (hubs.length === 0) {
+          vscode.window.showInformationMessage('No hubs to delete.');
+          return;
+        }
+
+        const items: HubListItem[] = hubs.map((hub) => ({
+          label: hub.name,
+          description: hub.description,
+          detail: `ID: ${hub.id}`,
+          hubId: hub.id
+        }));
+
+        const selected = await vscode.window.showQuickPick(items, {
+          placeHolder: 'Select hub to delete',
+          ignoreFocusOut: true
+        });
+
+        if (!selected) {
+          return;
+        }
+
+        targetHubId = selected.hubId;
+      }
+
+      // Confirm deletion
+      const hubInfo = await this.hubManager.getHubInfo(targetHubId);
+      const confirmation = await vscode.window.showWarningMessage(
+        `Delete hub "${hubInfo.config.metadata.name}"? This cannot be undone.`,
+        { modal: true },
+        'Delete'
+      );
+
+      if (confirmation !== 'Delete') {
+        return;
+      }
+
+      // Delete hub
+      await this.hubManager.deleteHub(targetHubId);
+
+      // Refresh the tree view
+      vscode.commands.executeCommand('promptregistry.refresh');
+
+      vscode.window.showInformationMessage(`Deleted hub: ${targetHubId}`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error('Failed to delete hub', error as Error);
+      vscode.window.showErrorMessage(`Failed to delete hub: ${message}`);
+    }
+  }
+
+  /**
+   * Export current registry state as a hub configuration file
+   * Useful for creating a seed hub config from existing setup
+   */
+  /**
+   * Map internal source type to hub schema-compliant type
+   */
+  // Removed mapSourceTypeForHub - we now preserve source types directly
+
+  /**
+   * Switch the active hub
+   * Shows a quick-pick with all imported hubs and option to import new hub
+   */
+  async switchHub(): Promise<void> {
+    try {
+      // Get all imported hubs
+      const hubs = await this.hubManager.listHubs();
+      const activeHubId = await this.hubManager.getActiveHub();
+      const currentActiveId = activeHubId?.config.metadata.name;
+
+      // Build quick-pick items
+      const items: (vscode.QuickPickItem & { hubId?: string; action?: string })[] = hubs.map((hub) => ({
+        label: hub.name,
+        description: hub.id === currentActiveId ? '$(check) Active' : hub.description,
+        detail: `ID: ${hub.id}`,
+        hubId: hub.id
+      }));
+
+      // Add "Import New Hub" option
+      items.push({
+        label: '$(cloud-download) Import New Hub...',
+        description: 'Import a hub from GitHub, URL, or local path',
+        action: 'import'
+      });
+
+      // Show quick-pick
+      const selected = await vscode.window.showQuickPick(items, {
+        placeHolder: 'Select a hub to activate',
+        title: 'Switch Active Hub',
+        ignoreFocusOut: true
+      });
+
+      if (!selected) {
+        return;
+      }
+
+      // Handle import action
+      if (selected.action === 'import') {
+        const newHubId = await this.importHub();
+        if (newHubId) {
+          await this.hubManager.setActiveHub(newHubId);
+          vscode.window.showInformationMessage(`✅ Hub '${newHubId}' imported and activated`);
+          vscode.commands.executeCommand('promptRegistry.refresh');
+        }
+        return;
+      }
+
+      // Set selected hub as active
+      if (selected.hubId) {
+        await this.hubManager.setActiveHub(selected.hubId);
+        vscode.window.showInformationMessage(`✅ Switched to hub: ${selected.label}`);
+        vscode.commands.executeCommand('promptRegistry.refresh');
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      vscode.window.showErrorMessage(`Failed to switch hub: ${message}`);
+      this.logger.error('Switch hub failed', error as Error);
+    }
+  }
+
+  async exportHubConfig(): Promise<void> {
+    try {
+      // Get current profiles and sources
+      const profiles = await this.registryManager.listProfiles();
+      const sources = await this.registryManager.listSources();
+      const installedBundles = await this.registryManager.listInstalledBundles();
+
+      // Prompt for hub metadata
+      const hubName = await vscode.window.showInputBox({
+        prompt: 'Enter hub name',
+        placeHolder: 'My Awesome Hub',
+        validateInput: (value) => value.trim() ? null : 'Hub name is required',
+        ignoreFocusOut: true
+      });
+      if (!hubName) {
+        return;
+      }
+
+      const hubDescription = await vscode.window.showInputBox({
+        prompt: 'Enter hub description',
+        placeHolder: 'A curated collection of prompts for...',
+        ignoreFocusOut: true
+      });
+
+      const maintainer = await vscode.window.showInputBox({
+        prompt: 'Enter maintainer name/email',
+        placeHolder: 'Your Name <email@example.com>',
+        ignoreFocusOut: true
+      });
+
+      // Build hub config
+      const hubConfig: any = {
+        version: '1.0.0',
+        metadata: {
+          name: hubName,
+          description: hubDescription || 'Exported hub configuration',
+          maintainer: maintainer || 'Unknown',
+          updatedAt: new Date().toISOString()
+        },
+        sources: sources.map((s) => ({
+          id: s.id,
+          name: s.name,
+          type: s.type, // Preserve original source type
+          url: s.url,
+          enabled: s.enabled,
+          priority: s.priority,
+          ...(s.metadata && { metadata: s.metadata }),
+          ...(s.config && { config: s.config }) // Include source config
+        })),
+        profiles: profiles.map((p) => ({
+          id: p.id,
+          name: p.name,
+          description: p.description || '',
+          bundles: (Array.isArray(p.bundles) ? p.bundles : Object.values(p.bundles || {})).map((bundle: any) => ({
+            id: bundle.id,
+            version: bundle.version,
+            source: sources[0]?.id || 'unknown',
+            required: bundle.required
+          }))
+        }))
+      };
+
+      // Convert to YAML using js-yaml library
+      const yamlStr = yaml.dump(hubConfig, {
+        indent: 2,
+        lineWidth: -1,
+        noRefs: true,
+        sortKeys: false
+      });
+
+      // Show in new editor
+      const doc = await vscode.workspace.openTextDocument({
+        content: yamlStr,
+        language: 'yaml'
+      });
+      await vscode.window.showTextDocument(doc);
+
+      vscode.window.showInformationMessage(
+        `✅ Hub config exported! Save as 'hub-config.yml' for local testing.`,
+        'Save As...'
+      ).then((action) => {
+        if (action === 'Save As...') {
+          vscode.commands.executeCommand('workbench.action.files.saveAs');
+        }
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      vscode.window.showErrorMessage(`Failed to export hub config: ${message}`);
+    }
+  }
+
+  /**
+   * Open the active hub's repository in browser
+   * Falls back to selecting from available hubs if no active hub is set
+   */
+  async openHubRepository(): Promise<void> {
+    try {
+      let activeHub = await this.hubManager.getActiveHub();
+
+      // If no active hub, fall back to available hubs
+      if (!activeHub) {
+        const hubs = await this.hubManager.listHubs();
+
+        if (hubs.length === 0) {
+          vscode.window.showInformationMessage('No hubs imported. Use "Import Hub" to add one first.');
+          return;
+        }
+
+        if (hubs.length === 1) {
+          // Single hub - use it directly
+          activeHub = await this.hubManager.loadHub(hubs[0].id);
+        } else {
+          // Multiple hubs - let user select
+          const items = hubs.map((hub) => ({
+            label: hub.name,
+            description: hub.description,
+            detail: `ID: ${hub.id}`,
+            hubId: hub.id
+          }));
+
+          const selected = await vscode.window.showQuickPick(items, {
+            placeHolder: 'Select a hub to open its repository',
+            ignoreFocusOut: true
+          });
+
+          if (!selected) {
+            return;
+          }
+
+          activeHub = await this.hubManager.loadHub(selected.hubId);
+        }
+      }
+
+      const reference = activeHub.reference;
+      let repositoryUrl: string | undefined;
+
+      // Construct repository URL based on hub type
+      switch (reference.type) {
+        case 'github': {
+          // Format: owner/repo
+          repositoryUrl = `https://github.com/${reference.location}`;
+          break;
+        }
+
+        case 'url': {
+          // Direct URL - use as is
+          repositoryUrl = reference.location;
+          break;
+        }
+
+        case 'local': {
+          vscode.window.showInformationMessage(
+            'This hub is stored locally and does not have a remote repository URL.',
+            'OK'
+          );
+          return;
+        }
+
+        default: {
+          vscode.window.showWarningMessage('Unable to determine repository URL for this hub type.');
+          return;
+        }
+      }
+
+      if (repositoryUrl) {
+        // Open URL in external browser
+        await vscode.env.openExternal(vscode.Uri.parse(repositoryUrl));
+        this.logger.info(`Opened hub repository: ${repositoryUrl}`);
+      }
+    } catch (error) {
+      this.logger.error('Failed to open hub repository', error as Error);
+      vscode.window.showErrorMessage(`Failed to open hub repository: ${(error as Error).message}`);
+    }
+  }
+
+  /**
+   * Open repository for a specific item (hub, profile, source, bundle)
+   * Called from context menu in Registry Explorer
+   * @param item
+   */
+  async openItemRepository(item: any): Promise<void> {
+    try {
+      if (!item || !item.type) {
+        vscode.window.showWarningMessage('Unable to determine item type.');
+        return;
+      }
+
+      const itemType = item.type;
+      const data = item.data;
+
+      let repositoryUrl: string | undefined;
+
+      switch (itemType) {
+        case 'hub': {
+          // Hub item - use hub's reference
+          if (data?.reference) {
+            repositoryUrl = this.referenceToUrl(data.reference);
+          } else if (data?.id) {
+            const hub = await this.hubManager.loadHub(data.id);
+            repositoryUrl = this.referenceToUrl(hub.reference);
+          }
+          break;
+        }
+
+        case 'hub_profile': {
+          // Hub profile - use parent hub's reference
+          const hubId = data?.hubId;
+          if (hubId) {
+            const hub = await this.hubManager.loadHub(hubId);
+            repositoryUrl = this.referenceToUrl(hub.reference);
+          }
+          break;
+        }
+
+        case 'source': {
+          // Source - use source URL
+          repositoryUrl = this.sourceToUrl(data);
+          break;
+        }
+
+        case 'installed_bundle':
+        case 'bundle':
+        case 'profile_bundle': {
+          // Bundle - find source and use its URL
+          const sourceId = data?.sourceId;
+          if (sourceId) {
+            const sources = await this.registryManager.listSources();
+            const source = sources.find((s) => s.id === sourceId);
+            if (source) {
+              repositoryUrl = this.sourceToUrl(source);
+            }
+          }
+          // Fallback to bundle's own repository URL if available
+          if (!repositoryUrl && data?.repository) {
+            repositoryUrl = data.repository;
+          }
+          break;
+        }
+
+        default: {
+          vscode.window.showWarningMessage(`Cannot open repository for item type: ${itemType}`);
+          return;
+        }
+      }
+
+      if (!repositoryUrl) {
+        vscode.window.showInformationMessage(
+          'This item is stored locally and does not have a remote repository URL.',
+          'OK'
+        );
+        return;
+      }
+
+      await vscode.env.openExternal(vscode.Uri.parse(repositoryUrl));
+      this.logger.info(`Opened repository: ${repositoryUrl}`);
+    } catch (error) {
+      this.logger.error('Failed to open repository', error as Error);
+      vscode.window.showErrorMessage(`Failed to open repository: ${(error as Error).message}`);
+    }
   }
 
   /**
@@ -142,6 +756,88 @@ export class HubCommands {
   }
 
   /**
+   * Convert object to YAML format (simple implementation)
+   * @param obj
+   * @param indent
+   */
+  private objectToYaml(obj: any, indent = 0): string {
+    const spaces = ' '.repeat(indent);
+    let yaml = '';
+
+    for (const [key, value] of Object.entries(obj)) {
+      if (value === null || value === undefined) {
+        continue;
+      }
+
+      if (Array.isArray(value)) {
+        if (value.length === 0) {
+          yaml += `${spaces}${key}: []\n`;
+        } else {
+          yaml += `${spaces}${key}:\n`;
+          for (const item of value) {
+            if (typeof item === 'object' && item !== null) {
+              yaml += `${spaces}- `;
+              // Get object keys and format inline for first property
+              const entries = Object.entries(item);
+              if (entries.length > 0) {
+                const [firstKey, firstValue] = entries[0];
+                // Check if first value is an object - if so, use recursive formatting
+                if (typeof firstValue === 'object' && firstValue !== null) {
+                  yaml += `${firstKey}:\n`;
+                  yaml += this.objectToYaml(firstValue, indent + 4);
+                } else {
+                  yaml += `${firstKey}: ${this.formatYamlValue(firstValue)}\n`;
+                }
+                // Add remaining properties with proper indentation
+                for (let i = 1; i < entries.length; i++) {
+                  const [k, v] = entries[i];
+                  if (typeof v === 'object' && v !== null) {
+                    yaml += `${spaces}  ${k}:\n`;
+                    yaml += this.objectToYaml(v, indent + 4);
+                  } else {
+                    yaml += `${spaces}  ${k}: ${this.formatYamlValue(v)}\n`;
+                  }
+                }
+              }
+            } else {
+              yaml += `${spaces}- ${item}\n`;
+            }
+          }
+        }
+      } else if (typeof value === 'object') {
+        yaml += `${spaces}${key}:\n`;
+        yaml += this.objectToYaml(value, indent + 2);
+      } else {
+        yaml += `${spaces}${key}: ${this.formatYamlValue(value)}\n`;
+      }
+    }
+
+    return yaml;
+  }
+
+  /**
+   * Format a value for YAML output
+   * @param value
+   */
+  private formatYamlValue(value: any): string {
+    if (typeof value === 'string') {
+      // Quote strings that contain special characters
+      if (value.includes(':') || value.includes('#') || value.includes('\n')
+        || value.startsWith('*') || value.startsWith('&') || value.startsWith('!')) {
+        return '"' + value.replace(/"/g, '\\\\"') + '"';
+      }
+      return value;
+    } else if (typeof value === 'boolean') {
+      return value ? 'true' : 'false';
+    } else if (typeof value === 'number') {
+      return String(value);
+    }
+    return String(value);
+  }
+
+  /**
+
+    /**
    * Select hub source type
    */
   private async selectSourceType(): Promise<'github' | 'url' | 'local' | undefined> {
@@ -276,6 +972,21 @@ export class HubCommands {
     try {
       const info = await this.hubManager.getHubInfo(hubId);
 
+      const message = [
+        `**${info.config.metadata.name}**`,
+        '',
+        `**Description:** ${info.config.metadata.description}`,
+        `**Maintainer:** ${info.config.metadata.maintainer}`,
+        `**Version:** ${info.config.version}`,
+        `**Sources:** ${info.config.sources.length}`,
+        `**Profiles:** ${info.config.profiles.length}`,
+        '',
+        `**Hub ID:** ${info.id}`,
+        `**Source Type:** ${info.reference.type}`,
+        `**Last Modified:** ${info.metadata.lastModified.toLocaleString()}`,
+        `**Size:** ${(info.metadata.size / 1024).toFixed(2)} KB`
+      ].join('\n');
+
       // Show in output channel or quick pick with actions
       const action = await vscode.window.showInformationMessage(
         `Hub: ${info.config.metadata.name}`,
@@ -331,606 +1042,5 @@ export class HubCommands {
         );
       }
     );
-  }
-
-  /**
-   * Register all hub-related commands
-   */
-  public registerCommands(): void {
-    // Skip registration if vscode.commands is not available (e.g., in unit tests)
-    if (!vscode.commands || !vscode.commands.registerCommand) {
-      return;
-    }
-
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('promptregistry.importHub', () => this.importHub()),
-      vscode.commands.registerCommand('promptregistry.listHubs', () => this.listHubs()),
-      vscode.commands.registerCommand('promptregistry.syncHub', (hubId?: string) => this.syncHub(hubId)),
-      vscode.commands.registerCommand('promptregistry.deleteHub', (hubId?: string) => this.deleteHub(hubId)),
-      vscode.commands.registerCommand('promptregistry.switchHub', () => this.switchHub()),
-      vscode.commands.registerCommand('promptregistry.exportHubConfig', () => this.exportHubConfig()),
-      vscode.commands.registerCommand('promptregistry.openHubRepository', () => this.openHubRepository()),
-      vscode.commands.registerCommand('promptregistry.openItemRepository', (item: any) => this.openItemRepository(item))
-    );
-  }
-
-  /**
-   * Import a hub from various sources
-   */
-  public async importHub(): Promise<string | undefined> {
-    try {
-      // Step 1: Select source type
-      const sourceType = await this.selectSourceType();
-      if (!sourceType) {
-        return undefined;
-      }
-
-      // Step 2: Get hub reference based on source type
-      const reference = await this.getHubReference(sourceType);
-      if (!reference) {
-        return undefined;
-      }
-
-      // Step 3: Get hub ID (optional, will auto-generate if not provided)
-      const hubId = await this.getHubId();
-      if (hubId === null) {
-        return undefined; // User cancelled
-      }
-
-      // Step 4: Import hub with progress
-      return await vscode.window.withProgress(
-        {
-          location: vscode.ProgressLocation.Notification,
-          title: 'Importing Hub',
-          cancellable: false
-        },
-        async (progress) => {
-          progress.report({ message: 'Loading hub configuration...' });
-
-          try {
-            // HubManager.importHub() handles source loading via loadHubSources()
-            const importedHubId = await this.hubManager.importHub(reference, hubId || undefined);
-
-            // Note: Hub profiles are NOT copied locally. They are accessed via
-            // HubManager.listProfilesFromHub() and displayed in "Shared Profiles" view.
-            // Local profiles are only created when the user explicitly creates them.
-
-            // Auto-activate the imported hub
-            await this.hubManager.setActiveHub(importedHubId);
-            this.logger.info(`Auto-activated imported hub: ${importedHubId}`);
-
-            vscode.window.showInformationMessage(
-              `Successfully imported and activated hub: ${importedHubId}`
-            );
-
-            // Refresh the tree view to show the new hub
-            vscode.commands.executeCommand('promptregistry.refresh');
-
-            return importedHubId;
-          } catch (error) {
-            const message = error instanceof Error ? error.message : String(error);
-            vscode.window.showErrorMessage(`Failed to import hub: ${message}`);
-            throw error;
-          }
-        }
-      );
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      vscode.window.showErrorMessage(`Hub import failed: ${message}`);
-      return undefined;
-    }
-  }
-
-  /**
-   * List all imported hubs
-   */
-  public async listHubs(): Promise<void> {
-    try {
-      const hubs = await this.hubManager.listHubs();
-
-      if (hubs.length === 0) {
-        vscode.window.showInformationMessage('No hubs imported yet. Use "Import Hub" to add one.');
-        return;
-      }
-
-      // Create quick pick items
-      const items: HubListItem[] = hubs.map((hub) => ({
-        label: hub.name,
-        description: hub.description,
-        detail: `ID: ${hub.id} | Source: ${hub.reference.type}`,
-        hubId: hub.id
-      }));
-
-      // Show quick pick
-      const selected = await vscode.window.showQuickPick(items, {
-        placeHolder: 'Select a hub to view details',
-        matchOnDescription: true,
-        matchOnDetail: true,
-        ignoreFocusOut: true
-      });
-
-      if (selected) {
-        await this.showHubDetails(selected.hubId);
-      }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      vscode.window.showErrorMessage(`Failed to list hubs: ${message}`);
-    }
-  }
-
-  /**
-   * Sync a hub from its source
-   * @param hubId Optional hub ID to sync (if not provided, user selects)
-   */
-  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents -- union type kept for documentation clarity
-  public async syncHub(hubId?: string | any): Promise<void> {
-    try {
-      // Extract hub ID from tree item if object is passed
-      let targetHubId: string | undefined;
-      if (typeof hubId === 'string') {
-        targetHubId = hubId;
-      } else if (hubId && typeof hubId === 'object' && hubId.data) {
-        // Tree item passed from context menu
-        targetHubId = hubId.data.id;
-      }
-
-      // If no hub ID provided, let user select
-      if (!targetHubId) {
-        const hubs = await this.hubManager.listHubs();
-
-        if (hubs.length === 0) {
-          vscode.window.showInformationMessage('No hubs to sync.');
-          return;
-        }
-
-        // Add "Sync All" option
-        const items: HubListItem[] = [
-          {
-            label: '$(sync) Sync All Hubs',
-            description: 'Synchronize all imported hubs',
-            hubId: '',
-            action: 'all'
-          },
-          ...hubs.map((hub) => ({
-            label: hub.name,
-            description: `Sync from ${hub.reference.type}`,
-            detail: `ID: ${hub.id}`,
-            hubId: hub.id
-          }))
-        ];
-
-        const selected = await vscode.window.showQuickPick(items, {
-          placeHolder: 'Select hub to sync',
-          ignoreFocusOut: true
-        });
-
-        if (!selected) {
-          return;
-        }
-
-        if (selected.action === 'all') {
-          await this.syncAllHubs();
-          return;
-        }
-
-        targetHubId = selected.hubId;
-      }
-
-      // Sync single hub
-      await vscode.window.withProgress(
-        {
-          location: vscode.ProgressLocation.Notification,
-          title: `Syncing hub: ${targetHubId}`,
-          cancellable: false
-        },
-        async () => {
-          await this.hubManager.syncHub(targetHubId);
-          vscode.window.showInformationMessage(`Successfully synced hub: ${targetHubId}`);
-        }
-      );
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      this.logger.error('Failed to sync hub', error as Error);
-      vscode.window.showErrorMessage(`Failed to sync hub: ${message}`);
-    }
-  }
-
-  /**
-   * Delete a hub
-   * @param hubId Optional hub ID to delete (if not provided, user selects)
-   */
-  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents -- union type kept for documentation clarity
-  public async deleteHub(hubId?: string | any): Promise<void> {
-    try {
-      // Extract hub ID from tree item if object is passed
-      let targetHubId: string | undefined;
-      if (typeof hubId === 'string') {
-        targetHubId = hubId;
-      } else if (hubId && typeof hubId === 'object' && hubId.data) {
-        // Tree item passed from context menu
-        targetHubId = hubId.data.id;
-      }
-
-      // If no hub ID provided, let user select
-      if (!targetHubId) {
-        const hubs = await this.hubManager.listHubs();
-
-        if (hubs.length === 0) {
-          vscode.window.showInformationMessage('No hubs to delete.');
-          return;
-        }
-
-        const items: HubListItem[] = hubs.map((hub) => ({
-          label: hub.name,
-          description: hub.description,
-          detail: `ID: ${hub.id}`,
-          hubId: hub.id
-        }));
-
-        const selected = await vscode.window.showQuickPick(items, {
-          placeHolder: 'Select hub to delete',
-          ignoreFocusOut: true
-        });
-
-        if (!selected) {
-          return;
-        }
-
-        targetHubId = selected.hubId;
-      }
-
-      // Confirm deletion
-      const hubInfo = await this.hubManager.getHubInfo(targetHubId);
-      const confirmation = await vscode.window.showWarningMessage(
-        `Delete hub "${hubInfo.config.metadata.name}"? This cannot be undone.`,
-        { modal: true },
-        'Delete'
-      );
-
-      if (confirmation !== 'Delete') {
-        return;
-      }
-
-      // Delete hub
-      await this.hubManager.deleteHub(targetHubId);
-
-      // Refresh the tree view
-      vscode.commands.executeCommand('promptregistry.refresh');
-
-      vscode.window.showInformationMessage(`Deleted hub: ${targetHubId}`);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      this.logger.error('Failed to delete hub', error as Error);
-      vscode.window.showErrorMessage(`Failed to delete hub: ${message}`);
-    }
-  }
-
-  /**
-   * Export current registry state as a hub configuration file
-   * Useful for creating a seed hub config from existing setup
-   */
-  /**
-   * Map internal source type to hub schema-compliant type
-   */
-  // Removed mapSourceTypeForHub - we now preserve source types directly
-
-  /**
-   * Switch the active hub
-   * Shows a quick-pick with all imported hubs and option to import new hub
-   */
-  public async switchHub(): Promise<void> {
-    try {
-      // Get all imported hubs
-      const hubs = await this.hubManager.listHubs();
-      const activeHubId = await this.hubManager.getActiveHub();
-      const currentActiveId = activeHubId?.config.metadata.name;
-
-      // Build quick-pick items
-      const items: (vscode.QuickPickItem & { hubId?: string; action?: string })[] = hubs.map((hub) => ({
-        label: hub.name,
-        description: hub.id === currentActiveId ? '$(check) Active' : hub.description,
-        detail: `ID: ${hub.id}`,
-        hubId: hub.id
-      }));
-
-      // Add "Import New Hub" option
-      items.push({
-        label: '$(cloud-download) Import New Hub...',
-        description: 'Import a hub from GitHub, URL, or local path',
-        action: 'import'
-      });
-
-      // Show quick-pick
-      const selected = await vscode.window.showQuickPick(items, {
-        placeHolder: 'Select a hub to activate',
-        title: 'Switch Active Hub',
-        ignoreFocusOut: true
-      });
-
-      if (!selected) {
-        return;
-      }
-
-      // Handle import action
-      if (selected.action === 'import') {
-        const newHubId = await this.importHub();
-        if (newHubId) {
-          await this.hubManager.setActiveHub(newHubId);
-          vscode.window.showInformationMessage(`✅ Hub '${newHubId}' imported and activated`);
-          vscode.commands.executeCommand('promptRegistry.refresh');
-        }
-        return;
-      }
-
-      // Set selected hub as active
-      if (selected.hubId) {
-        await this.hubManager.setActiveHub(selected.hubId);
-        vscode.window.showInformationMessage(`✅ Switched to hub: ${selected.label}`);
-        vscode.commands.executeCommand('promptRegistry.refresh');
-      }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      vscode.window.showErrorMessage(`Failed to switch hub: ${message}`);
-      this.logger.error('Switch hub failed', error as Error);
-    }
-  }
-
-  public async exportHubConfig(): Promise<void> {
-    try {
-      // Get current profiles and sources
-      const profiles = await this.registryManager.listProfiles();
-      const sources = await this.registryManager.listSources();
-      // Prompt for hub metadata
-      const hubName = await vscode.window.showInputBox({
-        prompt: 'Enter hub name',
-        placeHolder: 'My Awesome Hub',
-        validateInput: (value) => value.trim() ? null : 'Hub name is required',
-        ignoreFocusOut: true
-      });
-      if (!hubName) {
-        return;
-      }
-
-      const hubDescription = await vscode.window.showInputBox({
-        prompt: 'Enter hub description',
-        placeHolder: 'A curated collection of prompts for...',
-        ignoreFocusOut: true
-      });
-
-      const maintainer = await vscode.window.showInputBox({
-        prompt: 'Enter maintainer name/email',
-        placeHolder: 'Your Name <email@example.com>',
-        ignoreFocusOut: true
-      });
-
-      // Build hub config
-      const hubConfig: any = {
-        version: '1.0.0',
-        metadata: {
-          name: hubName,
-          description: hubDescription || 'Exported hub configuration',
-          maintainer: maintainer || 'Unknown',
-          updatedAt: new Date().toISOString()
-        },
-        sources: sources.map((s) => ({
-          id: s.id,
-          name: s.name,
-          type: s.type, // Preserve original source type
-          url: s.url,
-          enabled: s.enabled,
-          priority: s.priority,
-          ...(s.metadata && { metadata: s.metadata }),
-          ...(s.config && { config: s.config }) // Include source config
-        })),
-        profiles: profiles.map((p) => ({
-          id: p.id,
-          name: p.name,
-          description: p.description || '',
-          bundles: (Array.isArray(p.bundles) ? p.bundles : Object.values(p.bundles || {})).map((bundle: any) => ({
-            id: bundle.id,
-            version: bundle.version,
-            source: sources[0]?.id || 'unknown',
-            required: bundle.required
-          }))
-        }))
-      };
-
-      // Convert to YAML using js-yaml library
-      const yamlStr = yaml.dump(hubConfig, {
-        indent: 2,
-        lineWidth: -1,
-        noRefs: true,
-        sortKeys: false
-      });
-
-      // Show in new editor
-      const doc = await vscode.workspace.openTextDocument({
-        content: yamlStr,
-        language: 'yaml'
-      });
-      await vscode.window.showTextDocument(doc);
-
-      vscode.window.showInformationMessage(
-        `✅ Hub config exported! Save as 'hub-config.yml' for local testing.`,
-        'Save As...'
-      ).then((action) => {
-        if (action === 'Save As...') {
-          vscode.commands.executeCommand('workbench.action.files.saveAs');
-        }
-      });
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      vscode.window.showErrorMessage(`Failed to export hub config: ${message}`);
-    }
-  }
-
-  /**
-   * Open the active hub's repository in browser
-   * Falls back to selecting from available hubs if no active hub is set
-   */
-  public async openHubRepository(): Promise<void> {
-    try {
-      let activeHub = await this.hubManager.getActiveHub();
-
-      // If no active hub, fall back to available hubs
-      if (!activeHub) {
-        const hubs = await this.hubManager.listHubs();
-
-        if (hubs.length === 0) {
-          vscode.window.showInformationMessage('No hubs imported. Use "Import Hub" to add one first.');
-          return;
-        }
-
-        if (hubs.length === 1) {
-          // Single hub - use it directly
-          activeHub = await this.hubManager.loadHub(hubs[0].id);
-        } else {
-          // Multiple hubs - let user select
-          const items = hubs.map((hub) => ({
-            label: hub.name,
-            description: hub.description,
-            detail: `ID: ${hub.id}`,
-            hubId: hub.id
-          }));
-
-          const selected = await vscode.window.showQuickPick(items, {
-            placeHolder: 'Select a hub to open its repository',
-            ignoreFocusOut: true
-          });
-
-          if (!selected) {
-            return;
-          }
-
-          activeHub = await this.hubManager.loadHub(selected.hubId);
-        }
-      }
-
-      const reference = activeHub.reference;
-      let repositoryUrl: string | undefined;
-
-      // Construct repository URL based on hub type
-      switch (reference.type) {
-        case 'github': {
-          // Format: owner/repo
-          repositoryUrl = `https://github.com/${reference.location}`;
-          break;
-        }
-
-        case 'url': {
-          // Direct URL - use as is
-          repositoryUrl = reference.location;
-          break;
-        }
-
-        case 'local': {
-          vscode.window.showInformationMessage(
-            'This hub is stored locally and does not have a remote repository URL.',
-            'OK'
-          );
-          return;
-        }
-
-        default: {
-          vscode.window.showWarningMessage('Unable to determine repository URL for this hub type.');
-          return;
-        }
-      }
-
-      if (repositoryUrl) {
-        // Open URL in external browser
-        await vscode.env.openExternal(vscode.Uri.parse(repositoryUrl));
-        this.logger.info(`Opened hub repository: ${repositoryUrl}`);
-      }
-    } catch (error) {
-      this.logger.error('Failed to open hub repository', error as Error);
-      vscode.window.showErrorMessage(`Failed to open hub repository: ${(error as Error).message}`);
-    }
-  }
-
-  /**
-   * Open repository for a specific item (hub, profile, source, bundle)
-   * Called from context menu in Registry Explorer
-   * @param item
-   */
-  public async openItemRepository(item: any): Promise<void> {
-    try {
-      if (!item || !item.type) {
-        vscode.window.showWarningMessage('Unable to determine item type.');
-        return;
-      }
-
-      const itemType = item.type;
-      const data = item.data;
-
-      let repositoryUrl: string | undefined;
-
-      switch (itemType) {
-        case 'hub': {
-          // Hub item - use hub's reference
-          if (data?.reference) {
-            repositoryUrl = this.referenceToUrl(data.reference);
-          } else if (data?.id) {
-            const hub = await this.hubManager.loadHub(data.id);
-            repositoryUrl = this.referenceToUrl(hub.reference);
-          }
-          break;
-        }
-
-        case 'hub_profile': {
-          // Hub profile - use parent hub's reference
-          const hubId = data?.hubId;
-          if (hubId) {
-            const hub = await this.hubManager.loadHub(hubId);
-            repositoryUrl = this.referenceToUrl(hub.reference);
-          }
-          break;
-        }
-
-        case 'source': {
-          // Source - use source URL
-          repositoryUrl = this.sourceToUrl(data);
-          break;
-        }
-
-        case 'installed_bundle':
-        case 'bundle':
-        case 'profile_bundle': {
-          // Bundle - find source and use its URL
-          const sourceId = data?.sourceId;
-          if (sourceId) {
-            const sources = await this.registryManager.listSources();
-            const source = sources.find((s) => s.id === sourceId);
-            if (source) {
-              repositoryUrl = this.sourceToUrl(source);
-            }
-          }
-          // Fallback to bundle's own repository URL if available
-          if (!repositoryUrl && data?.repository) {
-            repositoryUrl = data.repository;
-          }
-          break;
-        }
-
-        default: {
-          vscode.window.showWarningMessage(`Cannot open repository for item type: ${itemType}`);
-          return;
-        }
-      }
-
-      if (!repositoryUrl) {
-        vscode.window.showInformationMessage(
-          'This item is stored locally and does not have a remote repository URL.',
-          'OK'
-        );
-        return;
-      }
-
-      await vscode.env.openExternal(vscode.Uri.parse(repositoryUrl));
-      this.logger.info(`Opened repository: ${repositoryUrl}`);
-    } catch (error) {
-      this.logger.error('Failed to open repository', error as Error);
-      vscode.window.showErrorMessage(`Failed to open repository: ${(error as Error).message}`);
-    }
   }
 }

--- a/src/commands/scaffold-command.ts
+++ b/src/commands/scaffold-command.ts
@@ -4,9 +4,15 @@ import {
   SkillWizard,
 } from '../commands/skill-wizard';
 import {
+  HubManager,
+} from '../services/hub-manager';
+import {
   TemplateContext,
   TemplateEngine,
 } from '../services/template-engine';
+import {
+  ScaffoldDefaults,
+} from '../types/hub';
 import {
   generateSanitizedId,
 } from '../utils/bundle-name-utils';
@@ -19,6 +25,9 @@ import {
 import {
   NpmCliWrapper,
 } from '../utils/npm-cli-wrapper';
+import {
+  resolveRunnerPattern,
+} from '../utils/scaffold-utils';
 
 export enum ScaffoldType {
   // eslint-disable-next-line @typescript-eslint/naming-convention -- name reflects domain terminology
@@ -245,7 +254,7 @@ export class ScaffoldCommand {
   /**
    * Run the scaffold command with full UI flow
    */
-  public static async runWithUI(): Promise<void> {
+  public static async runWithUI(hubManager?: HubManager): Promise<void> {
     const logger = Logger.getInstance();
 
     try {
@@ -255,24 +264,35 @@ export class ScaffoldCommand {
         return;
       }
 
-      // Step 2: Handle skill creation in existing project
+      // Step 2: Load scaffold defaults from active hub
+      let scaffoldDefaults: ScaffoldDefaults | undefined;
+      if (hubManager) {
+        try {
+          const activeHub = await hubManager.getActiveHub();
+          scaffoldDefaults = activeHub?.config?.scaffoldDefaults;
+        } catch {
+          // No active hub or hub load failed — proceed without defaults
+        }
+      }
+
+      // Step 3: Handle skill creation in existing project
       if (scaffoldType.value === ScaffoldType.Skill && await ScaffoldCommand.handleSkillInExistingProject()) {
         return;
       }
 
-      // Step 3: Select target directory
+      // Step 4: Select target directory
       const targetPath = await ScaffoldCommand.promptForTargetDirectory(scaffoldType.label);
       if (!targetPath) {
         return;
       }
 
-      // Step 4: Collect project details
-      const options = await ScaffoldCommand.promptForProjectDetails(scaffoldType.value);
+      // Step 5: Collect project details
+      const options = await ScaffoldCommand.promptForProjectDetails(scaffoldType.value, scaffoldDefaults);
       if (!options) {
         return;
       }
 
-      // Step 5: Execute scaffold with progress
+      // Step 6: Execute scaffold with progress
       await vscode.window.withProgress(
         { location: vscode.ProgressLocation.Notification, title: `Scaffolding ${scaffoldType.label}...` },
         async () => {
@@ -281,7 +301,7 @@ export class ScaffoldCommand {
         }
       );
 
-      // Step 6: Post-scaffold actions
+      // Step 7: Post-scaffold actions
       await ScaffoldCommand.handlePostScaffoldActions(scaffoldType.label, targetPath);
     } catch (error) {
       logger.error('Scaffold failed', error as Error);
@@ -361,7 +381,7 @@ export class ScaffoldCommand {
    * Collect project details from user input
    * @param type
    */
-  private static async promptForProjectDetails(type: ScaffoldType): Promise<ScaffoldOptions | undefined> {
+  private static async promptForProjectDetails(type: ScaffoldType, scaffoldDefaults?: ScaffoldDefaults): Promise<ScaffoldOptions | undefined> {
     // Get project name
     const projectName = await vscode.window.showInputBox({
       prompt: 'Enter project name (optional)',
@@ -370,10 +390,8 @@ export class ScaffoldCommand {
       ignoreFocusOut: true
     });
 
-    // Get GitHub runner choice
-    const githubRunner = await ScaffoldCommand.promptForGitHubRunner();
     let details: { description?: string; author?: string; tags?: string[] } = {};
-    let orgDetails: { organizationName?: string; internalContact?: string; legalContact?: string; organizationPolicyLink?: string } = {};
+    let orgDetails: { author?: string; githubOrg?: string; organizationName?: string; internalContact?: string; legalContact?: string; organizationPolicyLink?: string } = {};
 
     // Collect additional details if needed
 
@@ -393,8 +411,11 @@ export class ScaffoldCommand {
 
     // For GitHub type, collect organization details for InnerSource LICENSE
     if (type === ScaffoldType.GitHub) {
-      orgDetails = await ScaffoldCommand.promptForOrganizationDetails();
+      orgDetails = await ScaffoldCommand.promptForOrganizationDetails(scaffoldDefaults);
     }
+
+    // Get GitHub runner choice (always asked, prefilled from hub defaults)
+    const githubRunner = await ScaffoldCommand.promptForGitHubRunner(scaffoldDefaults, orgDetails.githubOrg);
 
     return {
       projectName,
@@ -407,7 +428,29 @@ export class ScaffoldCommand {
   /**
    * Prompt for GitHub Actions runner configuration
    */
-  private static async promptForGitHubRunner(): Promise<string> {
+  private static async promptForGitHubRunner(scaffoldDefaults?: ScaffoldDefaults, githubOrg?: string): Promise<string> {
+    // If hub provides a runner default, resolve the pattern and pre-fill
+    if (scaffoldDefaults?.githubRunner) {
+      const resolvedRunner = githubOrg
+        ? resolveRunnerPattern(scaffoldDefaults.githubRunner, githubOrg)
+        : scaffoldDefaults.githubRunner;
+      const customRunner = await vscode.window.showInputBox({
+        prompt: 'Enter GitHub Actions runner label',
+        placeHolder: 'my-runner or [self-hosted, linux, x64]',
+        value: resolvedRunner,
+        validateInput: (value) => {
+          if (!value || value.trim().length === 0) {
+            return 'Runner label cannot be empty';
+          }
+          return undefined;
+        },
+        ignoreFocusOut: true
+      });
+      // undefined means the user pressed Escape — use resolved default
+      // empty string is prevented by validateInput
+      return customRunner ?? resolvedRunner;
+    }
+
     const runnerChoice = await vscode.window.showQuickPick(
       [
         {
@@ -508,7 +551,15 @@ export class ScaffoldCommand {
   /**
    * Prompt for organization details for InnerSource LICENSE and docs
    */
-  private static async promptForOrganizationDetails(): Promise<{
+  /**
+   * Prompt for organization details for InnerSource LICENSE and docs.
+   * When hub scaffoldDefaults are present, individual org-level fields are
+   * skipped (hub value used directly). Fields without a hub default are still prompted.
+   * @param scaffoldDefaults
+   */
+  private static async promptForOrganizationDetails(
+    scaffoldDefaults?: ScaffoldDefaults
+  ): Promise<{
     author?: string;
     githubOrg?: string;
     organizationName?: string;
@@ -522,34 +573,37 @@ export class ScaffoldCommand {
       ignoreFocusOut: true
     });
 
+    // githubOrg: always asked, prefilled from hub defaults if present
     const githubOrg = await vscode.window.showInputBox({
       prompt: 'Enter GitHub organization/username (for repository URLs)',
       placeHolder: 'your-org',
+      value: scaffoldDefaults?.githubOrg || '',
       ignoreFocusOut: true
     });
 
-    const organizationName = await vscode.window.showInputBox({
+    // Each org field: use hub default if present, otherwise prompt
+    const organizationName = scaffoldDefaults?.organizationName ?? await vscode.window.showInputBox({
       prompt: 'Enter organization name (for LICENSE)',
       placeHolder: 'Your Organization Name',
       value: 'Your Organization',
       ignoreFocusOut: true
     });
 
-    const internalContact = await vscode.window.showInputBox({
+    const internalContact = scaffoldDefaults?.internalContact ?? await vscode.window.showInputBox({
       prompt: 'Enter internal contact email (for security/support inquiries)',
       placeHolder: 'security@yourorg.com',
       value: 'security@yourorg.com',
       ignoreFocusOut: true
     });
 
-    const legalContact = await vscode.window.showInputBox({
+    const legalContact = scaffoldDefaults?.legalContact ?? await vscode.window.showInputBox({
       prompt: 'Enter legal contact email (for licensing questions)',
       placeHolder: 'legal@yourorg.com',
       value: 'legal@yourorg.com',
       ignoreFocusOut: true
     });
 
-    const organizationPolicyLink = await vscode.window.showInputBox({
+    const organizationPolicyLink = scaffoldDefaults?.organizationPolicyLink ?? await vscode.window.showInputBox({
       prompt: 'Enter organization policy URL (optional)',
       placeHolder: 'https://yourorg.com/policies',
       ignoreFocusOut: true

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -375,7 +375,7 @@ export class PromptRegistryExtension {
       vscode.commands.registerCommand('promptRegistry.cleanupStaleLockfileEntries', () => this.bundleCommands!.cleanupStaleLockfileEntries()),
 
       // Scaffold Command - Create project structure
-      vscode.commands.registerCommand('promptRegistry.scaffoldProject', () => ScaffoldCommand.runWithUI()),
+      vscode.commands.registerCommand('promptRegistry.scaffoldProject', () => ScaffoldCommand.runWithUI(this.hubManager)),
 
       // Add Resource Command - Add individual resources
       vscode.commands.registerCommand('promptRegistry.addResource', async () => {

--- a/src/services/hub-manager.ts
+++ b/src/services/hub-manager.ts
@@ -53,6 +53,17 @@ import {
 const execAsync = promisify(exec);
 
 /**
+ * Summary of hub source loading results
+ */
+export interface HubSourceLoadSummary {
+  addedCount: number;
+  updatedCount: number;
+  failedCount: number;
+  disabledCount: number;
+  duplicateCount: number;
+}
+
+/**
  * Resolved bundle with its download URL
  */
 export interface ResolvedBundle {
@@ -108,6 +119,18 @@ export class HubManager {
 
   private authToken: string | undefined;
   private authMethod: 'vscode' | 'gh-cli' | 'explicit' | 'none' = 'none';
+  private _lastSourceLoadSummary: HubSourceLoadSummary | undefined;
+
+  /**
+   * Clear cached authentication state so that the next call to
+   * getAuthenticationToken() performs a fresh authentication attempt.
+   * Used when re-triggering setup after a user previously declined auth.
+   */
+  public clearAuthCache(): void {
+    this.authToken = undefined;
+    this.authMethod = 'none';
+    this.logger.info('[HubManager] Authentication cache cleared');
+  }
 
   /**
    * Initialize HubManager
@@ -115,10 +138,17 @@ export class HubManager {
    * @param validator SchemaValidator instance for validation
    * @param extensionPath Path to the extension directory
    */
-  public readonly onHubImported = this._onHubImported.event;
-  public readonly onHubDeleted = this._onHubDeleted.event;
-  public readonly onHubSynced = this._onHubSynced.event;
-  public readonly onFavoritesChanged = this._onFavoritesChanged.event;
+  readonly onHubImported = this._onHubImported.event;
+  readonly onHubDeleted = this._onHubDeleted.event;
+  readonly onHubSynced = this._onHubSynced.event;
+  readonly onFavoritesChanged = this._onFavoritesChanged.event;
+
+  /**
+   * Get the summary from the most recent loadHubSources call.
+   */
+  get lastSourceLoadSummary(): HubSourceLoadSummary | undefined {
+    return this._lastSourceLoadSummary;
+  }
 
   constructor(
     storage: HubStorage,
@@ -141,6 +171,158 @@ export class HubManager {
     this.validator = validator;
     this.hubSchemaPath = path.join(extensionPath, 'schemas', 'hub-config.schema.json');
     this.logger = Logger.getInstance();
+  }
+
+  /**
+   * Import hub from remote or local source
+   * @param reference Hub reference (GitHub, URL, or local path)
+   * @param hubId Optional hub identifier (auto-generated if not provided)
+   * @returns Hub identifier
+   */
+  async importHub(reference: HubReference, hubId?: string): Promise<string> {
+    // Validate reference
+    const refValidation = await this.validateReference(reference);
+    if (!refValidation.valid) {
+      throw new Error(`Invalid reference: ${refValidation.errors.join(', ')}`);
+    }
+
+    // Fetch hub config from source
+    const config = await this.fetchHubConfig(reference);
+
+    // Validate hub config
+    const validation = await this.validateHub(config);
+    if (!validation.valid) {
+      this.logger.error('Hub validation failed:', undefined, {
+        errors: validation.errors,
+        warnings: validation.warnings
+      });
+      throw new Error(`Hub validation failed: Validation error: ${validation.errors.join(', ')}`);
+    }
+
+    // Generate hub ID if not provided
+    if (!hubId) {
+      hubId = this.generateHubId(config);
+    }
+
+    // Validate hub ID
+    try {
+      sanitizeHubId(hubId);
+    } catch (error) {
+      throw new Error(`Invalid hub ID: ${error instanceof Error ? error.message : String(error)}`);
+    }
+
+    // Save to storage first
+    await this.storage.saveHub(hubId, config, reference);
+
+    // Load hub sources into RegistryManager
+    if (this.registryManager) {
+      this._lastSourceLoadSummary = await this.loadHubSources(hubId);
+    }
+
+    this._onHubImported.fire(hubId);
+
+    return hubId;
+  }
+
+  /**
+   * Load hub from storage
+   * @param hubId Hub identifier
+   * @returns Loaded hub configuration and reference
+   */
+  async loadHub(hubId: string): Promise<LoadHubResult> {
+    const result = await this.storage.loadHub(hubId);
+
+    // Validate loaded config
+    const validation = await this.validateHub(result.config);
+    if (!validation.valid) {
+      this.logger.error('Hub validation failed on load:', undefined, {
+        hubId,
+        errors: validation.errors,
+        warnings: validation.warnings
+      });
+      throw new Error(`Hub validation failed: ${validation.errors.join(', ')}`);
+    }
+
+    return result;
+  }
+
+  /**
+   * Validate hub configuration
+   * @param config Hub configuration to validate
+   * @returns Validation result
+   */
+  async validateHub(config: HubConfig): Promise<ValidationResult> {
+    // Schema validation
+    const schemaResult = await this.validator.validate(config, this.hubSchemaPath);
+    if (!schemaResult.valid) {
+      return schemaResult;
+    }
+
+    // Runtime validation
+    const runtimeResult = validateHubConfig(config);
+    if (!runtimeResult.valid) {
+      return {
+        valid: false,
+        errors: runtimeResult.errors,
+        warnings: []
+      };
+    }
+
+    return {
+      valid: true,
+      errors: [],
+      warnings: []
+    };
+  }
+
+  /**
+   * List all imported hubs
+   * @returns Array of hub list items
+   */
+  async listHubs(): Promise<HubListItem[]> {
+    const hubIds = await this.storage.listHubs();
+    const hubs: HubListItem[] = [];
+
+    for (const id of hubIds) {
+      try {
+        const result = await this.storage.loadHub(id);
+        hubs.push({
+          id,
+          name: result.config.metadata.name,
+          description: result.config.metadata.description,
+          reference: result.reference
+        });
+      } catch (error) {
+        // Skip hubs that fail to load
+        console.error(`Failed to load hub ${id}:`, error);
+      }
+    }
+
+    return hubs;
+  }
+
+  /**
+   * Delete hub from storage
+   * @param hubId Hub identifier to delete
+   */
+  async deleteHub(hubId: string): Promise<void> {
+    // Cleanup resources linked to this hub before deleting
+    await this.cleanupHubResources(hubId);
+
+    await this.storage.deleteHub(hubId);
+    this._onHubDeleted.fire(hubId);
+  }
+
+  async deleteAllHubs(): Promise<void> {
+    const hubIds = await this.storage.listHubs();
+    for (const hubId of hubIds) {
+      try {
+        await this.deleteHub(hubId);
+      } catch (error) {
+        this.logger.warn(`Failed to delete hub ${hubId} during cleanup`, error as Error);
+      }
+    }
+    await this.storage.setActiveHubId(null);
   }
 
   /**
@@ -190,6 +372,56 @@ export class HubManager {
   }
 
   /**
+   * Sync hub from remote source
+   * @param hubId Hub identifier to sync
+   */
+  async syncHub(hubId: string): Promise<void> {
+    // Load existing hub to get reference
+    const existing = await this.storage.loadHub(hubId);
+
+    // Fetch latest config from source
+    const config = await this.fetchHubConfig(existing.reference);
+
+    // Validate updated config
+    const validation = await this.validateHub(config);
+    if (!validation.valid) {
+      throw new Error(`Hub validation failed after sync: ${validation.errors.join(', ')}`);
+    }
+
+    // Update storage
+    await this.storage.saveHub(hubId, config, existing.reference);
+
+    // Reload hub sources into RegistryManager
+    if (this.registryManager) {
+      await this.loadHubSources(hubId);
+    }
+
+    this._onHubSynced.fire(hubId);
+  }
+
+  /**
+   * Get detailed hub information
+   * @param hubId Hub identifier
+   * @returns Hub information
+   */
+  async getHubInfo(hubId: string): Promise<HubInfo> {
+    const result = await this.storage.loadHub(hubId);
+    const metadata = await this.storage.getHubMetadata(hubId);
+
+    return {
+      id: hubId,
+      config: result.config,
+      reference: result.reference,
+      metadata: {
+        name: result.config.metadata.name,
+        description: result.config.metadata.description,
+        lastModified: metadata.lastModified,
+        size: metadata.size
+      }
+    };
+  }
+
+  /**
    * Validate hub reference
    * @param reference Hub reference to validate
    * @returns Validation result
@@ -226,7 +458,6 @@ export class HubManager {
         break;
       }
       default: {
-        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- value is safely stringifiable at runtime
         errors.push(`Unsupported reference type: ${reference.type}`);
       }
     }
@@ -255,9 +486,34 @@ export class HubManager {
         return this.fetchFromGitHub(reference.location, reference.ref);
       }
       default: {
-        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- value is safely stringifiable at runtime
         throw new Error(`Unsupported reference type: ${reference.type}`);
       }
+    }
+  }
+
+  /**
+   * Verify if a hub is accessible without importing it
+   * Used to validate default hubs before offering them in the first-run selector
+   * @param reference Hub reference to verify
+   * @returns true if hub is accessible, false otherwise
+   */
+  async verifyHubAvailability(reference: HubReference): Promise<boolean> {
+    try {
+      // Validate reference format
+      const refValidation = await this.validateReference(reference);
+      if (!refValidation.valid) {
+        this.logger.debug(`Hub verification failed: invalid reference - ${refValidation.errors.join(', ')}`);
+        return false;
+      }
+
+      // Try to fetch the hub config
+      await this.fetchHubConfig(reference);
+
+      this.logger.debug(`Hub verification successful: ${reference.type}:${reference.location}`);
+      return true;
+    } catch (error) {
+      this.logger.debug(`Hub verification failed: ${error instanceof Error ? error.message : String(error)}`);
+      return false;
     }
   }
 
@@ -445,6 +701,131 @@ export class HubManager {
   }
 
   /**
+   * List all profiles from a specific hub
+   * @param hubId Hub identifier
+   * @returns Array of profiles from the hub
+   */
+  async listProfilesFromHub(hubId: string): Promise<HubProfile[]> {
+    const hub = await this.storage.loadHub(hubId);
+    if (!hub) {
+      throw new Error(`Hub not found: ${hubId}`);
+    }
+
+    const profiles = hub.config.profiles || [];
+
+    // Enrich with activation state
+    try {
+      const activeState = await this.storage.getActiveProfileForHub(hubId);
+      if (activeState) {
+        return profiles.map((profile) => ({
+          ...profile,
+          active: activeState.profileId === profile.id
+        }));
+      }
+    } catch (error) {
+      this.logger.warn(`Failed to check profile activation state for hub ${hubId}`, error as Error);
+    }
+
+    return profiles;
+  }
+
+  /**
+   * Get a specific profile from a hub
+   * @param hubId Hub identifier
+   * @param profileId Profile identifier
+   * @returns The requested profile
+   */
+  async getHubProfile(hubId: string, profileId: string): Promise<HubProfile> {
+    const profiles = await this.listProfilesFromHub(hubId);
+    this.logger.info(`Found ${profiles.length} profiles in hub ${hubId}`);
+
+    const profile = profiles.find((p) => p.id === profileId);
+
+    if (!profile) {
+      this.logger.error(`Profile ${profileId} not found in hub ${hubId}. Available: ${profiles.map((p) => p.id).join(', ')}`);
+      throw new Error(`Profile not found: ${profileId} in hub ${hubId}`);
+    }
+
+    this.logger.info(`Found profile ${profileId}: ${profile.name}`);
+    this.logger.info(`Profile bundles: ${JSON.stringify(profile.bundles?.map((b) => ({ id: b.id, version: b.version })) || [])}`);
+
+    return profile;
+  }
+
+  /**
+   * List all profiles from all imported hubs
+   * @returns Array of profiles with hub information
+   */
+  async listAllHubProfiles(): Promise<HubProfileWithMetadata[]> {
+    const hubs = await this.listHubs();
+    const allProfiles: HubProfileWithMetadata[] = [];
+
+    for (const hubItem of hubs) {
+      const profiles = await this.listProfilesFromHub(hubItem.id);
+      for (const profile of profiles) {
+        allProfiles.push({
+          ...profile,
+          hubId: hubItem.id,
+          hubName: hubItem.name
+        });
+      }
+    }
+
+    return allProfiles;
+  }
+
+  /**
+   * Get the currently active hub
+   * @returns Active hub ID, config and reference, or null if no hub is active
+   */
+  async getActiveHub(): Promise<LoadHubResult | null> {
+    const activeHubId = await this.storage.getActiveHubId();
+
+    if (!activeHubId) {
+      return null;
+    }
+
+    try {
+      return await this.storage.loadHub(activeHubId);
+    } catch {
+      // If active hub was deleted, clear the activeHubId
+      await this.storage.setActiveHubId(null);
+      return null;
+    }
+  }
+
+  /**
+   * Set the currently active hub
+   * @param hubId Hub identifier to set as active
+   */
+  async setActiveHub(hubId: string | null): Promise<void> {
+    // Get current active hub to check if we're switching
+    const currentActiveHubId = await this.storage.getActiveHubId();
+
+    // Cleanup previous hub if switching to a different one
+    if (currentActiveHubId && currentActiveHubId !== hubId) {
+      await this.cleanupHubResources(currentActiveHubId);
+    }
+
+    if (hubId !== null) {
+      // Verify hub exists when setting (not clearing)
+      const hub = await this.getHub(hubId);
+      if (!hub) {
+        throw new Error(`Hub not found: ${hubId}`);
+      }
+
+      // Load hub sources into RegistryManager when activating
+      if (this.registryManager) {
+        await this.loadHubSources(hubId);
+      }
+    }
+
+    // Set or clear active hub
+    await this.storage.setActiveHubId(hubId);
+    this.logger.info(hubId ? `Set active hub: ${hubId}` : 'Cleared active hub');
+  }
+
+  /**
    * Check if a source is a duplicate based on URL and config
    * Compares URL, type, branch, and collectionsPath to determine if sources are identical
    * @param source Source to check
@@ -485,369 +866,6 @@ export class HubManager {
   }
 
   /**
-   * Clear cached authentication state so that the next call to
-   * getAuthenticationToken() performs a fresh authentication attempt.
-   * Used when re-triggering setup after a user previously declined auth.
-   */
-  public clearAuthCache(): void {
-    this.authToken = undefined;
-    this.authMethod = 'none';
-    this.logger.info('[HubManager] Authentication cache cleared');
-  }
-
-  /**
-   * Import hub from remote or local source
-   * @param reference Hub reference (GitHub, URL, or local path)
-   * @param hubId Optional hub identifier (auto-generated if not provided)
-   * @returns Hub identifier
-   */
-  public async importHub(reference: HubReference, hubId?: string): Promise<string> {
-    // Validate reference
-    const refValidation = await this.validateReference(reference);
-    if (!refValidation.valid) {
-      throw new Error(`Invalid reference: ${refValidation.errors.join(', ')}`);
-    }
-
-    // Fetch hub config from source
-    const config = await this.fetchHubConfig(reference);
-
-    // Validate hub config
-    const validation = await this.validateHub(config);
-    if (!validation.valid) {
-      this.logger.error('Hub validation failed:', undefined, {
-        errors: validation.errors,
-        warnings: validation.warnings
-      });
-      throw new Error(`Hub validation failed: Validation error: ${validation.errors.join(', ')}`);
-    }
-
-    // Generate hub ID if not provided
-    if (!hubId) {
-      hubId = this.generateHubId(config);
-    }
-
-    // Validate hub ID
-    try {
-      sanitizeHubId(hubId);
-    } catch (error) {
-      throw new Error(`Invalid hub ID: ${error instanceof Error ? error.message : String(error)}`);
-    }
-
-    // Save to storage first
-    await this.storage.saveHub(hubId, config, reference);
-
-    // Load hub sources into RegistryManager
-    if (this.registryManager) {
-      await this.loadHubSources(hubId);
-    }
-
-    this._onHubImported.fire(hubId);
-
-    return hubId;
-  }
-
-  /**
-   * Load hub from storage
-   * @param hubId Hub identifier
-   * @returns Loaded hub configuration and reference
-   */
-  public async loadHub(hubId: string): Promise<LoadHubResult> {
-    const result = await this.storage.loadHub(hubId);
-
-    // Validate loaded config
-    const validation = await this.validateHub(result.config);
-    if (!validation.valid) {
-      this.logger.error('Hub validation failed on load:', undefined, {
-        hubId,
-        errors: validation.errors,
-        warnings: validation.warnings
-      });
-      throw new Error(`Hub validation failed: ${validation.errors.join(', ')}`);
-    }
-
-    return result;
-  }
-
-  /**
-   * Validate hub configuration
-   * @param config Hub configuration to validate
-   * @returns Validation result
-   */
-  public async validateHub(config: HubConfig): Promise<ValidationResult> {
-    // Schema validation
-    const schemaResult = await this.validator.validate(config, this.hubSchemaPath);
-    if (!schemaResult.valid) {
-      return schemaResult;
-    }
-
-    // Runtime validation
-    const runtimeResult = validateHubConfig(config);
-    if (!runtimeResult.valid) {
-      return {
-        valid: false,
-        errors: runtimeResult.errors,
-        warnings: []
-      };
-    }
-
-    return {
-      valid: true,
-      errors: [],
-      warnings: []
-    };
-  }
-
-  /**
-   * List all imported hubs
-   * @returns Array of hub list items
-   */
-  public async listHubs(): Promise<HubListItem[]> {
-    const hubIds = await this.storage.listHubs();
-    const hubs: HubListItem[] = [];
-
-    for (const id of hubIds) {
-      try {
-        const result = await this.storage.loadHub(id);
-        hubs.push({
-          id,
-          name: result.config.metadata.name,
-          description: result.config.metadata.description,
-          reference: result.reference
-        });
-      } catch (error) {
-        // Skip hubs that fail to load
-        console.error(`Failed to load hub ${id}:`, error);
-      }
-    }
-
-    return hubs;
-  }
-
-  /**
-   * Delete hub from storage
-   * @param hubId Hub identifier to delete
-   */
-  public async deleteHub(hubId: string): Promise<void> {
-    // Cleanup resources linked to this hub before deleting
-    await this.cleanupHubResources(hubId);
-
-    await this.storage.deleteHub(hubId);
-    this._onHubDeleted.fire(hubId);
-  }
-
-  public async deleteAllHubs(): Promise<void> {
-    const hubIds = await this.storage.listHubs();
-    await Promise.allSettled(hubIds.map(async (hubId) => {
-      try {
-        await this.deleteHub(hubId);
-      } catch (error) {
-        this.logger.warn(`Failed to delete hub ${hubId} during cleanup`, error as Error);
-      }
-    }));
-  }
-
-  /**
-   * Sync hub from remote source
-   * @param hubId Hub identifier to sync
-   */
-  public async syncHub(hubId: string): Promise<void> {
-    // Load existing hub to get reference
-    const existing = await this.storage.loadHub(hubId);
-
-    // Fetch latest config from source
-    const config = await this.fetchHubConfig(existing.reference);
-
-    // Validate updated config
-    const validation = await this.validateHub(config);
-    if (!validation.valid) {
-      throw new Error(`Hub validation failed after sync: ${validation.errors.join(', ')}`);
-    }
-
-    // Update storage
-    await this.storage.saveHub(hubId, config, existing.reference);
-
-    // Reload hub sources into RegistryManager
-    if (this.registryManager) {
-      await this.loadHubSources(hubId);
-    }
-
-    this._onHubSynced.fire(hubId);
-  }
-
-  /**
-   * Get detailed hub information
-   * @param hubId Hub identifier
-   * @returns Hub information
-   */
-  public async getHubInfo(hubId: string): Promise<HubInfo> {
-    const result = await this.storage.loadHub(hubId);
-    const metadata = await this.storage.getHubMetadata(hubId);
-
-    return {
-      id: hubId,
-      config: result.config,
-      reference: result.reference,
-      metadata: {
-        name: result.config.metadata.name,
-        description: result.config.metadata.description,
-        lastModified: metadata.lastModified,
-        size: metadata.size
-      }
-    };
-  }
-
-  /**
-   * Verify if a hub is accessible without importing it
-   * Used to validate default hubs before offering them in the first-run selector
-   * @param reference Hub reference to verify
-   * @returns true if hub is accessible, false otherwise
-   */
-  public async verifyHubAvailability(reference: HubReference): Promise<boolean> {
-    try {
-      // Validate reference format
-      const refValidation = await this.validateReference(reference);
-      if (!refValidation.valid) {
-        this.logger.debug(`Hub verification failed: invalid reference - ${refValidation.errors.join(', ')}`);
-        return false;
-      }
-
-      // Try to fetch the hub config
-      await this.fetchHubConfig(reference);
-
-      this.logger.debug(`Hub verification successful: ${reference.type}:${reference.location}`);
-      return true;
-    } catch (error) {
-      this.logger.debug(`Hub verification failed: ${error instanceof Error ? error.message : String(error)}`);
-      return false;
-    }
-  }
-
-  /**
-   * List all profiles from a specific hub
-   * @param hubId Hub identifier
-   * @returns Array of profiles from the hub
-   */
-  public async listProfilesFromHub(hubId: string): Promise<HubProfile[]> {
-    const hub = await this.storage.loadHub(hubId);
-    if (!hub) {
-      throw new Error(`Hub not found: ${hubId}`);
-    }
-
-    const profiles = hub.config.profiles || [];
-
-    // Enrich with activation state
-    try {
-      const activeState = await this.storage.getActiveProfileForHub(hubId);
-      if (activeState) {
-        return profiles.map((profile) => ({
-          ...profile,
-          active: activeState.profileId === profile.id
-        }));
-      }
-    } catch (error) {
-      this.logger.warn(`Failed to check profile activation state for hub ${hubId}`, error as Error);
-    }
-
-    return profiles;
-  }
-
-  /**
-   * Get a specific profile from a hub
-   * @param hubId Hub identifier
-   * @param profileId Profile identifier
-   * @returns The requested profile
-   */
-  public async getHubProfile(hubId: string, profileId: string): Promise<HubProfile> {
-    const profiles = await this.listProfilesFromHub(hubId);
-    this.logger.info(`Found ${profiles.length} profiles in hub ${hubId}`);
-
-    const profile = profiles.find((p) => p.id === profileId);
-
-    if (!profile) {
-      this.logger.error(`Profile ${profileId} not found in hub ${hubId}. Available: ${profiles.map((p) => p.id).join(', ')}`);
-      throw new Error(`Profile not found: ${profileId} in hub ${hubId}`);
-    }
-
-    this.logger.info(`Found profile ${profileId}: ${profile.name}`);
-    this.logger.info(`Profile bundles: ${JSON.stringify(profile.bundles?.map((b) => ({ id: b.id, version: b.version })) || [])}`);
-
-    return profile;
-  }
-
-  /**
-   * List all profiles from all imported hubs
-   * @returns Array of profiles with hub information
-   */
-  public async listAllHubProfiles(): Promise<HubProfileWithMetadata[]> {
-    const hubs = await this.listHubs();
-    const allProfiles: HubProfileWithMetadata[] = [];
-
-    for (const hubItem of hubs) {
-      const profiles = await this.listProfilesFromHub(hubItem.id);
-      for (const profile of profiles) {
-        allProfiles.push({
-          ...profile,
-          hubId: hubItem.id,
-          hubName: hubItem.name
-        });
-      }
-    }
-
-    return allProfiles;
-  }
-
-  /**
-   * Get the currently active hub
-   * @returns Active hub ID, config and reference, or null if no hub is active
-   */
-  public async getActiveHub(): Promise<LoadHubResult | null> {
-    const activeHubId = await this.storage.getActiveHubId();
-
-    if (!activeHubId) {
-      return null;
-    }
-
-    try {
-      return await this.storage.loadHub(activeHubId);
-    } catch {
-      // If active hub was deleted, clear the activeHubId
-      await this.storage.setActiveHubId(null);
-      return null;
-    }
-  }
-
-  /**
-   * Set the currently active hub
-   * @param hubId Hub identifier to set as active
-   */
-  public async setActiveHub(hubId: string | null): Promise<void> {
-    // Get current active hub to check if we're switching
-    const currentActiveHubId = await this.storage.getActiveHubId();
-
-    // Cleanup previous hub if switching to a different one
-    if (currentActiveHubId && currentActiveHubId !== hubId) {
-      await this.cleanupHubResources(currentActiveHubId);
-    }
-
-    if (hubId !== null) {
-      // Verify hub exists when setting (not clearing)
-      const hub = await this.getHub(hubId);
-      if (!hub) {
-        throw new Error(`Hub not found: ${hubId}`);
-      }
-
-      // Load hub sources into RegistryManager when activating
-      if (this.registryManager) {
-        await this.loadHubSources(hubId);
-      }
-    }
-
-    // Set or clear active hub
-    await this.storage.setActiveHubId(hubId);
-    this.logger.info(hubId ? `Set active hub: ${hubId}` : 'Cleared active hub');
-  }
-
-  /**
    * Load hub sources into RegistryManager.
    * Converts HubSource objects to RegistrySource and adds them to the registry.
    * Skips sources that are duplicates (same URL, type, branch, and collectionsPath).
@@ -863,10 +881,10 @@ export class HubManager {
    * matching, not ID matching, to handle both formats.
    * @param hubId Hub identifier
    */
-  public async loadHubSources(hubId: string): Promise<void> {
+  async loadHubSources(hubId: string): Promise<HubSourceLoadSummary> {
     if (!this.registryManager) {
       this.logger.warn('RegistryManager not available, skipping source loading');
-      return;
+      return { addedCount: 0, updatedCount: 0, failedCount: 0, disabledCount: 0, duplicateCount: 0 };
     }
 
     this.logger.info(`Loading sources from hub: ${hubId}`);
@@ -881,14 +899,16 @@ export class HubManager {
       const existingSources = await this.registryManager.listSources();
 
       let addedCount = 0;
-      let skippedCount = 0;
       let updatedCount = 0;
+      let failedCount = 0;
+      let disabledCount = 0;
+      let duplicateCount = 0;
 
       for (const hubSource of hubSources) {
         // Skip disabled sources
         if (!hubSource.enabled) {
           this.logger.debug(`Skipping disabled source: ${hubSource.id}`);
-          skippedCount++;
+          disabledCount++;
           continue;
         }
 
@@ -904,19 +924,27 @@ export class HubManager {
         if (existingSourceById) {
           // Update existing source from same hub
           this.logger.info(`Updating existing hub source: ${sourceId}`);
-          await this.registryManager.updateSource(sourceId, {
-            name: hubSource.name,
-            type: hubSource.type,
-            url: hubSource.url,
-            enabled: hubSource.enabled,
-            priority: hubSource.priority,
-            private: hubSource.private,
-            token: hubSource.token,
-            metadata: hubSource.metadata,
-            config: hubSource.config,
-            hubId: hubId
-          });
-          updatedCount++;
+          try {
+            await this.registryManager.updateSource(sourceId, {
+              name: hubSource.name,
+              type: hubSource.type,
+              url: hubSource.url,
+              enabled: hubSource.enabled,
+              priority: hubSource.priority,
+              private: hubSource.private,
+              token: hubSource.token,
+              metadata: hubSource.metadata,
+              config: hubSource.config,
+              hubId: hubId
+            });
+            updatedCount++;
+          } catch (updateError) {
+            this.logger.warn(
+              `Failed to update hub source ${sourceId} (${hubSource.name}): `
+              + `${updateError instanceof Error ? updateError.message : String(updateError)}`
+            );
+            failedCount++;
+          }
           continue;
         }
 
@@ -933,7 +961,7 @@ export class HubManager {
             + `Branch: ${hubSource.config?.branch || 'main'}, `
             + `CollectionsPath: ${hubSource.config?.collectionsPath || 'collections'}`
           );
-          skippedCount++;
+          duplicateCount++;
           continue;
         }
 
@@ -963,14 +991,19 @@ export class HubManager {
             `Failed to add hub source ${sourceId} (${hubSource.name}): `
             + `${sourceError instanceof Error ? sourceError.message : String(sourceError)}`
           );
-          skippedCount++;
+          failedCount++;
         }
       }
 
+      const summary: HubSourceLoadSummary = { addedCount, updatedCount, failedCount, disabledCount, duplicateCount };
+
       this.logger.info(
         `Hub source loading complete for ${hubId}: `
-        + `${addedCount} added, ${updatedCount} updated, ${skippedCount} skipped`
+        + `${addedCount} added, ${updatedCount} updated, ${failedCount} failed, `
+        + `${disabledCount} disabled, ${duplicateCount} duplicates`
       );
+
+      return summary;
     } catch (error) {
       this.logger.error(`Failed to load sources from hub ${hubId}`, error as Error);
       throw error;
@@ -981,7 +1014,7 @@ export class HubManager {
    * List profiles from the active hub only
    * @returns Profiles from active hub, or empty array if no hub is active
    */
-  public async listActiveHubProfiles(): Promise<HubProfileWithMetadata[]> {
+  async listActiveHubProfiles(): Promise<HubProfileWithMetadata[]> {
     const activeHubId = await this.storage.getActiveHubId();
 
     if (!activeHubId) {
@@ -1006,7 +1039,7 @@ export class HubManager {
    * @param hubId
    * @param sourceId
    */
-  public async resolveSource(hubId: string, sourceId: string): Promise<HubSource> {
+  async resolveSource(hubId: string, sourceId: string): Promise<HubSource> {
     const hubData = await this.storage.loadHub(hubId);
     const source = hubData.config.sources.find((s) => s.id === sourceId);
 
@@ -1022,7 +1055,7 @@ export class HubManager {
    * @param hubId
    * @param bundle
    */
-  public async resolveBundleUrl(hubId: string, bundle: HubProfileBundle): Promise<string> {
+  async resolveBundleUrl(hubId: string, bundle: HubProfileBundle): Promise<string> {
     const source = await this.resolveSource(hubId, bundle.source);
     const githubMatch = source.url.match(/github:(.+)/);
 
@@ -1060,7 +1093,7 @@ export class HubManager {
    * @param hubId
    * @param profileId
    */
-  public async resolveProfileBundles(
+  async resolveProfileBundles(
     hubId: string,
     profileId: string
   ): Promise<ResolvedBundle[]> {
@@ -1092,7 +1125,7 @@ export class HubManager {
    * @param profileId
    * @param options
    */
-  public async activateProfile(
+  async activateProfile(
     hubId: string,
     profileId: string,
     options: ProfileActivationOptions
@@ -1100,8 +1133,8 @@ export class HubManager {
     try {
       this.logger.info(`[HubManager] activateProfile called: hubId=${hubId}, profileId=${profileId}, installBundles=${options.installBundles}`);
 
-      // Verify hub and profile exist (throws if not found)
-      await this.getHubProfile(hubId, profileId);
+      // Verify hub and profile exist
+      const profile = await this.getHubProfile(hubId, profileId);
 
       // Deactivate ALL active hub profiles across ALL hubs (enforce single active profile globally)
       // This will uninstall bundles from previously active profiles
@@ -1153,6 +1186,7 @@ export class HubManager {
       await this.storage.setProfileActiveFlag(hubId, profileId, true);
 
       // Install bundles if requested and RegistryManager is available
+      const installResults: { bundleId: string; success: boolean; error?: string }[] = [];
       if (options.installBundles && this.registryManager) {
         this.logger.info(`Installing ${resolvedBundles.length} bundles for profile ${profileId}`);
 
@@ -1246,10 +1280,10 @@ export class HubManager {
    * @param hubId
    * @param profileId
    */
-  public async deactivateProfile(hubId: string, profileId: string): Promise<ProfileDeactivationResult> {
+  async deactivateProfile(hubId: string, profileId: string): Promise<ProfileDeactivationResult> {
     try {
-      // Verify profile exists (throws if not found)
-      await this.getHubProfile(hubId, profileId);
+      // Verify profile exists
+      const profile = await this.getHubProfile(hubId, profileId);
 
       // Get current activation state to track removed bundles
       const currentState = await this.storage.getProfileActivationState(hubId, profileId);
@@ -1281,14 +1315,14 @@ export class HubManager {
    * Get the currently active profile for a hub
    * @param hubId
    */
-  public async getActiveProfile(hubId: string): Promise<ProfileActivationState | null> {
+  async getActiveProfile(hubId: string): Promise<ProfileActivationState | null> {
     return this.storage.getActiveProfileForHub(hubId);
   }
 
   /**
    * List all active profiles across all hubs
    */
-  public async listAllActiveProfiles(): Promise<ProfileActivationState[]> {
+  async listAllActiveProfiles(): Promise<ProfileActivationState[]> {
     return this.storage.listActiveProfiles();
   }
 
@@ -1296,7 +1330,7 @@ export class HubManager {
    * Get a single hub by ID
    * @param hubId
    */
-  public async getHub(hubId: string): Promise<{ id: string; config: HubConfig; reference: HubReference } | null> {
+  async getHub(hubId: string): Promise<{ id: string; config: HubConfig; reference: HubReference } | null> {
     try {
       const result = await this.storage.loadHub(hubId);
       return {
@@ -1314,7 +1348,7 @@ export class HubManager {
    * @param hubId
    * @param profileId
    */
-  public async hasProfileChanges(hubId: string, profileId: string): Promise<boolean> {
+  async hasProfileChanges(hubId: string, profileId: string): Promise<boolean> {
     const changes = await this.getProfileChanges(hubId, profileId);
     if (!changes) {
       return false;
@@ -1332,7 +1366,7 @@ export class HubManager {
    * @param hubId
    * @param profileId
    */
-  public async getProfileChanges(hubId: string, profileId: string): Promise<ProfileChanges | null> {
+  async getProfileChanges(hubId: string, profileId: string): Promise<ProfileChanges | null> {
     // Get activation state
     const state = await this.storage.getProfileActivationState(hubId, profileId);
     if (!state) {
@@ -1397,7 +1431,7 @@ export class HubManager {
    * @param hubId
    * @param profileId
    */
-  public async syncProfile(hubId: string, profileId: string): Promise<void> {
+  async syncProfile(hubId: string, profileId: string): Promise<void> {
     // Re-activate to update the state
     await this.activateProfile(hubId, profileId, { installBundles: false });
   }
@@ -1407,7 +1441,7 @@ export class HubManager {
    * @param hubId
    * @param profileId
    */
-  public async getTimeSinceLastSync(hubId: string, profileId: string): Promise<number | null> {
+  async getTimeSinceLastSync(hubId: string, profileId: string): Promise<number | null> {
     const state = await this.storage.getProfileActivationState(hubId, profileId);
     if (!state) {
       return null;
@@ -1419,7 +1453,7 @@ export class HubManager {
    * Check if hub has updates (any profile has changes)
    * @param hubId
    */
-  public async hasHubUpdates(hubId: string): Promise<boolean> {
+  async hasHubUpdates(hubId: string): Promise<boolean> {
     const profilesWithUpdates = await this.getProfilesWithUpdates(hubId);
     return profilesWithUpdates.length > 0;
   }
@@ -1428,7 +1462,7 @@ export class HubManager {
    * Get list of profiles with pending updates
    * @param hubId
    */
-  public async getProfilesWithUpdates(hubId: string): Promise<ProfileWithUpdates[]> {
+  async getProfilesWithUpdates(hubId: string): Promise<ProfileWithUpdates[]> {
     const hub = await this.getHubInfo(hubId);
     if (!hub) {
       return [];
@@ -1463,7 +1497,7 @@ export class HubManager {
    * @param hubId Hub identifier
    * @param profileId Profile identifier
    */
-  public async isProfileFavorite(hubId: string, profileId: string): Promise<boolean> {
+  async isProfileFavorite(hubId: string, profileId: string): Promise<boolean> {
     const favorites = await this.storage.getFavoriteProfiles();
     return favorites[hubId]?.includes(profileId) || false;
   }
@@ -1472,7 +1506,7 @@ export class HubManager {
    * Get favorite profiles
    * @returns Map of hub ID to list of profile IDs
    */
-  public async getFavoriteProfiles(): Promise<Record<string, string[]>> {
+  async getFavoriteProfiles(): Promise<Record<string, string[]>> {
     return this.storage.getFavoriteProfiles();
   }
 
@@ -1481,7 +1515,7 @@ export class HubManager {
    * @param hubId Hub identifier
    * @param profileId Profile identifier
    */
-  public async toggleProfileFavorite(hubId: string, profileId: string): Promise<void> {
+  async toggleProfileFavorite(hubId: string, profileId: string): Promise<void> {
     const favorites = await this.getFavoriteProfiles();
     const hubFavorites = favorites[hubId] || [];
 
@@ -1509,7 +1543,7 @@ export class HubManager {
    * Cleanup orphaned favorites - remove favorites for hubs that no longer exist
    * This handles stale data from hubs that were deleted before cleanup logic was implemented
    */
-  public async cleanupOrphanedFavorites(): Promise<void> {
+  async cleanupOrphanedFavorites(): Promise<void> {
     const favorites = await this.getFavoriteProfiles();
     const existingHubs = await this.listHubs();
     const existingHubIds = new Set(existingHubs.map((h) => h.id));
@@ -1533,7 +1567,7 @@ export class HubManager {
    * Format change summary as human-readable string
    * @param changes
    */
-  public formatChangeSummary(changes: ProfileChanges): string {
+  formatChangeSummary(changes: ProfileChanges): string {
     const lines: string[] = [];
 
     if (changes.bundlesAdded && changes.bundlesAdded.length > 0) {
@@ -1577,7 +1611,7 @@ export class HubManager {
    * Create QuickPick items for displaying changes
    * @param changes
    */
-  public createChangeQuickPickItems(changes: ProfileChanges): ChangeQuickPickItem[] {
+  createChangeQuickPickItems(changes: ProfileChanges): ChangeQuickPickItem[] {
     const items: ChangeQuickPickItem[] = [];
 
     if (changes.bundlesAdded) {
@@ -1636,7 +1670,7 @@ export class HubManager {
    * Create conflict resolution dialog
    * @param changes
    */
-  public createConflictResolutionDialog(changes: ProfileChanges): ConflictResolutionDialog {
+  createConflictResolutionDialog(changes: ProfileChanges): ConflictResolutionDialog {
     const changeCount =
       (changes.bundlesAdded?.length || 0)
       + (changes.bundlesRemoved?.length || 0)
@@ -1670,7 +1704,7 @@ export class HubManager {
    * Format detailed bundle addition info
    * @param bundle
    */
-  public formatBundleAdditionDetail(bundle: HubProfileBundle): string {
+  formatBundleAdditionDetail(bundle: HubProfileBundle): string {
     return `Bundle: ${bundle.id}\nVersion: ${bundle.version}\nSource: ${bundle.source}\n${bundle.required ? 'required' : 'optional'}`;
   }
 
@@ -1678,7 +1712,7 @@ export class HubManager {
    * Format detailed bundle removal info
    * @param bundleId
    */
-  public formatBundleRemovalDetail(bundleId: string): string {
+  formatBundleRemovalDetail(bundleId: string): string {
     return `Bundle: ${bundleId}\nStatus: Will be removed`;
   }
 
@@ -1689,7 +1723,7 @@ export class HubManager {
    * @param update.oldVersion
    * @param update.newVersion
    */
-  public formatBundleUpdateDetail(update: { id: string; oldVersion: string; newVersion: string }): string {
+  formatBundleUpdateDetail(update: { id: string; oldVersion: string; newVersion: string }): string {
     return `Bundle: ${update.id}\nOld Version: ${update.oldVersion}\nNew Version: ${update.newVersion}`;
   }
 }

--- a/src/types/hub.ts
+++ b/src/types/hub.ts
@@ -26,6 +26,24 @@ export interface HubReference {
 }
 
 /**
+ * Default values for scaffold prompts, provided by hub configuration
+ */
+export interface ScaffoldDefaults {
+  /** GitHub organization name (prefills githubOrg prompt) */
+  githubOrg?: string;
+  /** GitHub Actions runner label or pattern (supports {githubOrg} placeholder) */
+  githubRunner?: string;
+  /** Organization name for LICENSE (skips prompt when present) */
+  organizationName?: string;
+  /** Internal contact email (skips prompt when present) */
+  internalContact?: string;
+  /** Legal contact email (skips prompt when present) */
+  legalContact?: string;
+  /** Organization policy URL (skips prompt when present) */
+  organizationPolicyLink?: string;
+}
+
+/**
  * Hub configuration structure
  */
 export interface HubConfig {
@@ -43,6 +61,9 @@ export interface HubConfig {
 
   /** Optional registry configuration */
   configuration?: RegistryConfiguration;
+
+  /** Optional scaffold defaults for pre-filling project scaffolding prompts */
+  scaffoldDefaults?: ScaffoldDefaults;
 }
 
 /**

--- a/src/utils/scaffold-utils.ts
+++ b/src/utils/scaffold-utils.ts
@@ -1,0 +1,9 @@
+/**
+ * Resolve a runner pattern by replacing {githubOrg} with the actual org value.
+ * Only the {githubOrg} placeholder is supported.
+ * @param pattern
+ * @param githubOrg
+ */
+export function resolveRunnerPattern(pattern: string, githubOrg: string): string {
+  return pattern.replace(/\{githubOrg\}/g, githubOrg);
+}

--- a/test/services/hub-manager.test.ts
+++ b/test/services/hub-manager.test.ts
@@ -33,24 +33,24 @@ class MockSchemaValidator {
   private shouldFail = false;
   private errors: string[] = [];
 
-  public setShouldFail(fail: boolean, errors: string[] = []): void {
+  setShouldFail(fail: boolean, errors: string[] = []): void {
     this.shouldFail = fail;
     this.errors = errors;
   }
 
-  public validate(_data: any, _schemaPath: string): Promise<ValidationResult> {
+  async validate(data: any, schemaPath: string): Promise<ValidationResult> {
     if (this.shouldFail) {
-      return Promise.resolve({
+      return {
         valid: false,
         errors: this.errors.length > 0 ? this.errors : ['Schema validation failed'],
         warnings: []
-      });
+      };
     }
-    return Promise.resolve({
+    return {
       valid: true,
       errors: [],
       warnings: []
-    });
+    };
   }
 }
 
@@ -430,6 +430,7 @@ suite('HubManager', () => {
 
     test('should list profiles from active hub only', async () => {
       const hubId1 = await hubManager.importHub(localRef, 'test-profiles-hub-1');
+      const hubId2 = await hubManager.importHub(localRef, 'test-profiles-hub-2');
 
       // Set first hub as active
       await hubManager.setActiveHub(hubId1);
@@ -601,36 +602,34 @@ suite('Hub Source Loading - SourceId Format', () => {
     public addSourceCalls: RegistrySource[] = [];
     public updateSourceCalls: { id: string; updates: Partial<RegistrySource> }[] = [];
 
-    public listSources(): Promise<RegistrySource[]> {
-      return Promise.resolve([...this.sources]);
+    async listSources(): Promise<RegistrySource[]> {
+      return [...this.sources];
     }
 
-    public addSource(source: RegistrySource): Promise<void> {
+    async addSource(source: RegistrySource): Promise<void> {
       this.sources.push(source);
       this.addSourceCalls.push(source);
-      return Promise.resolve();
     }
 
-    public updateSource(id: string, updates: Partial<RegistrySource>): Promise<void> {
+    async updateSource(id: string, updates: Partial<RegistrySource>): Promise<void> {
       const index = this.sources.findIndex((s) => s.id === id);
       if (index !== -1) {
         this.sources[index] = { ...this.sources[index], ...updates };
         this.updateSourceCalls.push({ id, updates });
       }
-      return Promise.resolve();
     }
 
-    public reset(): void {
+    reset(): void {
       this.sources = [];
       this.addSourceCalls = [];
       this.updateSourceCalls = [];
     }
 
-    public getSourceCount(): number {
+    getSourceCount(): number {
       return this.sources.length;
     }
 
-    public hasSource(id: string): boolean {
+    hasSource(id: string): boolean {
       return this.sources.some((s) => s.id === id);
     }
   }
@@ -899,9 +898,15 @@ suite('HubManager Ghost Hub Cleanup on Failed Import', () => {
   test('should save hub even when all sources fail validation (no ghost)', async () => {
     // Source validation failures are non-fatal: hub is saved, failing sources are skipped.
     const failingRegistry = {
-      listSources: () => Promise.resolve([]),
-      addSource: (_source: any) => Promise.reject(new Error('Source validation failed: Failed to validate repository: HTTP 404: Not Found')),
-      updateSource: () => Promise.resolve()
+      async listSources() {
+        return [];
+      },
+      async addSource(_source: any) {
+        throw new Error('Source validation failed: Failed to validate repository: HTTP 404: Not Found');
+      },
+      async updateSource() {
+        // no-op
+      }
     };
 
     hubManager = new HubManager(
@@ -927,9 +932,15 @@ suite('HubManager Ghost Hub Cleanup on Failed Import', () => {
   test('should handle repeated imports with source failures gracefully', async () => {
     // Source validation failures are non-fatal: each import succeeds, hub is saved.
     const failingRegistry = {
-      listSources: () => Promise.resolve([]),
-      addSource: (_source: any) => Promise.reject(new Error('Source validation failed: HTTP 404')),
-      updateSource: () => Promise.resolve()
+      async listSources() {
+        return [];
+      },
+      async addSource(_source: any) {
+        throw new Error('Source validation failed: HTTP 404');
+      },
+      async updateSource() {
+        // no-op
+      }
     };
 
     hubManager = new HubManager(
@@ -984,6 +995,74 @@ suite('HubManager Ghost Hub Cleanup on Failed Import', () => {
     assert.strictEqual(hubList.length, 0,
       'After deleteAllHubs, listHubs should return 0 hubs');
   });
+
+  test('deleteAllHubs should continue when one hub deletion fails', async () => {
+    const fixturePath = path.join(__dirname, '..', 'fixtures', 'hubs', 'hub-two-sources.yml');
+    const hubConfig = yaml.load(fs.readFileSync(fixturePath, 'utf8')) as any;
+
+    // Save two hubs
+    await hubStorage.saveHub('hub-1', hubConfig, { type: 'local', location: fixturePath });
+    await hubStorage.saveHub('hub-2', hubConfig, { type: 'local', location: fixturePath });
+
+    const hubs = await hubStorage.listHubs();
+    assert.strictEqual(hubs.length, 2, 'Should have 2 hubs');
+
+    // Create a HubManager with a corrupted storage that fails on first deletion
+    const corruptedStorage = Object.create(hubStorage);
+    let deleteCallCount = 0;
+    const originalDeleteHub = hubStorage.deleteHub.bind(hubStorage);
+    corruptedStorage.deleteHub = async (hubId: string) => {
+      deleteCallCount++;
+      if (deleteCallCount === 1) {
+        throw new Error('Disk I/O error');
+      }
+      return originalDeleteHub(hubId);
+    };
+    // Keep other methods from original storage
+    corruptedStorage.listHubs = hubStorage.listHubs.bind(hubStorage);
+    corruptedStorage.loadHub = hubStorage.loadHub.bind(hubStorage);
+    corruptedStorage.setActiveHubId = hubStorage.setActiveHubId.bind(hubStorage);
+
+    const hubManagerForCleanup = new HubManager(
+      corruptedStorage as any,
+      mockValidator as any,
+      process.cwd(),
+      undefined,
+      undefined
+    );
+
+    // Should not throw even though one deletion fails
+    await hubManagerForCleanup.deleteAllHubs();
+
+    // At least one hub should have been deleted (the non-failing one)
+    const remainingHubs = await hubStorage.listHubs();
+    assert.ok(remainingHubs.length < 2, 'At least one hub should have been deleted');
+  });
+
+  test('deleteAllHubs should clear the stored active hub ID', async () => {
+    const fixturePath = path.join(__dirname, '..', 'fixtures', 'hubs', 'hub-two-sources.yml');
+    const hubConfig = yaml.load(fs.readFileSync(fixturePath, 'utf8')) as any;
+
+    await hubStorage.saveHub('active-hub', hubConfig, { type: 'local', location: fixturePath });
+    await hubStorage.setActiveHubId('active-hub');
+
+    // Verify active hub is set
+    const activeId = await hubStorage.getActiveHubId();
+    assert.strictEqual(activeId, 'active-hub', 'Active hub should be set');
+
+    const hubManagerForCleanup = new HubManager(
+      hubStorage,
+      mockValidator as any,
+      process.cwd(),
+      undefined,
+      undefined
+    );
+    await hubManagerForCleanup.deleteAllHubs();
+
+    // Active hub ID should be cleared
+    const activeIdAfter = await hubStorage.getActiveHubId();
+    assert.strictEqual(activeIdAfter, null, 'Active hub ID should be cleared after deleteAllHubs');
+  });
 });
 
 suite('HubManager HTTP Redirect Handling', () => {
@@ -1004,7 +1083,7 @@ suite('HubManager HTTP Redirect Handling', () => {
     // Initialize services
     storage = new HubStorage(tempDir);
     mockValidator = {
-      validate: () => {
+      async validate() {
         return { valid: true, errors: [], warnings: [] };
       }
     };

--- a/test/services/hub-source-loading.test.ts
+++ b/test/services/hub-source-loading.test.ts
@@ -28,7 +28,7 @@ import {
 
 // Mock SchemaValidator for unit tests
 class MockSchemaValidator {
-  public async validate(_data: any, _schemaPath: string): Promise<ValidationResult> {
+  async validate(data: any, schemaPath: string): Promise<ValidationResult> {
     return {
       valid: true,
       errors: [],
@@ -43,16 +43,16 @@ class MockRegistryManager {
   public addSourceCalls: RegistrySource[] = [];
   public updateSourceCalls: { id: string; updates: Partial<RegistrySource> }[] = [];
 
-  public async listSources(): Promise<RegistrySource[]> {
+  async listSources(): Promise<RegistrySource[]> {
     return [...this.sources];
   }
 
-  public async addSource(source: RegistrySource): Promise<void> {
+  async addSource(source: RegistrySource): Promise<void> {
     this.sources.push(source);
     this.addSourceCalls.push(source);
   }
 
-  public async updateSource(id: string, updates: Partial<RegistrySource>): Promise<void> {
+  async updateSource(id: string, updates: Partial<RegistrySource>): Promise<void> {
     const index = this.sources.findIndex((s) => s.id === id);
     if (index !== -1) {
       this.sources[index] = { ...this.sources[index], ...updates };
@@ -60,17 +60,17 @@ class MockRegistryManager {
     }
   }
 
-  public reset(): void {
+  reset(): void {
     this.sources = [];
     this.addSourceCalls = [];
     this.updateSourceCalls = [];
   }
 
-  public getSourceCount(): number {
+  getSourceCount(): number {
     return this.sources.length;
   }
 
-  public hasSource(id: string): boolean {
+  hasSource(id: string): boolean {
     return this.sources.some((s) => s.id === id);
   }
 }
@@ -117,7 +117,7 @@ suite('Hub Source Loading', () => {
         location: fixturePath
       };
 
-      await hubManager.importHub(ref, 'test-hub');
+      const hubId = await hubManager.importHub(ref, 'test-hub');
 
       // Verify sources were loaded
       const sources = await mockRegistry.listSources();
@@ -175,6 +175,7 @@ suite('Hub Source Loading', () => {
       assert.strictEqual(sourcesAfterFirst.length, 2, 'Should have 2 sources after first import');
 
       // Reset the mock to track only the second import
+      const addCallsBefore = mockRegistry.addSourceCalls.length;
       mockRegistry.addSourceCalls = [];
       mockRegistry.updateSourceCalls = [];
 
@@ -420,6 +421,10 @@ suite('Hub Source Loading', () => {
       // The first source should still have been added successfully
       const sources = await failingRegistry.listSources();
       assert.strictEqual(sources.length, 1, 'Should have 1 source (the one that succeeded)');
+
+      // Verify which source survived — Source 1 should succeed, Source 2 should fail
+      const expectedSource1Id = generateHubSourceId('awesome-copilot', 'https://github.com/github/awesome-copilot');
+      assert.ok(failingRegistry.hasSource(expectedSource1Id), 'Source 1 (first added) should have survived');
     });
 
     test('should not fail hub import when all sources fail validation', async () => {
@@ -454,6 +459,79 @@ suite('Hub Source Loading', () => {
       // No sources should have been added
       const sources = await alwaysFailRegistry.listSources();
       assert.strictEqual(sources.length, 0, 'No sources should be added when all fail');
+    });
+
+    test('should continue loading other sources when updateSource throws', async () => {
+      // When re-importing, updateSource is called for existing sources.
+      // If updateSource throws, it should be skipped gracefully like addSource failures.
+
+      const failingUpdateRegistry = new MockRegistryManager();
+      const originalUpdateSource = failingUpdateRegistry.updateSource.bind(failingUpdateRegistry);
+      failingUpdateRegistry.updateSource = async (id: string, updates: Partial<RegistrySource>): Promise<void> => {
+        // Fail the first update, succeed on the second
+        if (id === generateHubSourceId('awesome-copilot', 'https://github.com/github/awesome-copilot')) {
+          throw new Error('Update failed: network error');
+        }
+        return originalUpdateSource(id, updates);
+      };
+
+      const failingHubManager = new HubManager(
+        storage,
+        mockValidator as any,
+        process.cwd(),
+        undefined,
+        failingUpdateRegistry as any
+      );
+
+      // First import — both sources should be added successfully
+      const fixturePath = path.join(__dirname, '..', 'fixtures', 'hubs', 'hub-two-sources.yml');
+      const ref: HubReference = { type: 'local', location: fixturePath };
+      await failingHubManager.importHub(ref, 'test-hub-update-fail');
+
+      const sourcesAfterImport = await failingUpdateRegistry.listSources();
+      assert.strictEqual(sourcesAfterImport.length, 2, 'Should have 2 sources after first import');
+
+      // Reload — update for source-1 will fail, source-2 should still update
+      const summary = await failingHubManager.loadHubSources('test-hub-update-fail');
+      assert.strictEqual(summary.failedCount, 1, 'Should report 1 failed update');
+      assert.strictEqual(summary.updatedCount, 1, 'Should report 1 successful update');
+
+      // Both sources should still exist (the failing update doesn't remove it)
+      const sourcesAfterReload = await failingUpdateRegistry.listSources();
+      assert.strictEqual(sourcesAfterReload.length, 2, 'Should still have 2 sources');
+    });
+
+    test('should return summary with correct counts on partial failure', async () => {
+      const failingRegistry = new MockRegistryManager();
+      const originalAddSource = failingRegistry.addSource.bind(failingRegistry);
+      let callCount = 0;
+      failingRegistry.addSource = async (source: RegistrySource): Promise<void> => {
+        callCount++;
+        if (callCount === 2) {
+          throw new Error('Source validation failed');
+        }
+        return originalAddSource(source);
+      };
+
+      const failingHubManager = new HubManager(
+        storage,
+        mockValidator as any,
+        process.cwd(),
+        undefined,
+        failingRegistry as any
+      );
+
+      const fixturePath = path.join(__dirname, '..', 'fixtures', 'hubs', 'hub-two-sources.yml');
+      const ref: HubReference = { type: 'local', location: fixturePath };
+      await failingHubManager.importHub(ref, 'test-hub-summary');
+
+      const summary = failingHubManager.lastSourceLoadSummary;
+      assert.ok(summary, 'Should have a source load summary');
+      assert.strictEqual(summary!.addedCount, 1, 'Should report 1 added');
+      assert.strictEqual(summary!.failedCount, 1, 'Should report 1 failed');
+      assert.strictEqual(summary!.updatedCount, 0, 'Should report 0 updated');
+      assert.strictEqual(summary!.disabledCount, 0, 'Should report 0 disabled');
+      assert.strictEqual(summary!.duplicateCount, 0, 'Should report 0 duplicates');
     });
   });
 

--- a/test/unit/hub-schema-scaffold-defaults.test.ts
+++ b/test/unit/hub-schema-scaffold-defaults.test.ts
@@ -1,0 +1,91 @@
+import * as assert from 'node:assert';
+import * as path from 'node:path';
+import { SchemaValidator } from '../../src/services/schema-validator';
+
+const HUB_SCHEMA_PATH = path.join(process.cwd(), 'schemas', 'hub-config.schema.json');
+
+function createMinimalValidHub(overrides?: Record<string, any>) {
+  return {
+    version: '1.0.0',
+    metadata: {
+      name: 'Test Hub',
+      description: 'A test hub',
+      maintainer: 'Test',
+      updatedAt: '2025-01-01T00:00:00Z'
+    },
+    sources: [{
+      id: 'src-1',
+      type: 'github',
+      repository: 'org/repo',
+      enabled: true,
+      priority: 50
+    }],
+    ...overrides
+  };
+}
+
+suite('Hub Config Schema — scaffoldDefaults', () => {
+  let validator: SchemaValidator;
+
+  setup(() => {
+    validator = new SchemaValidator(process.cwd());
+  });
+
+  teardown(() => {
+    validator.clearCache();
+  });
+
+  test('should accept hub config with scaffoldDefaults', async () => {
+    const hub = createMinimalValidHub({
+      scaffoldDefaults: {
+        githubOrg: 'myorg',
+        githubRunner: 'gmsshr-core-{githubOrg}',
+        organizationName: 'My Org Inc.',
+        internalContact: 'security@myorg.com',
+        legalContact: 'legal@myorg.com',
+        organizationPolicyLink: 'https://myorg.com/policies'
+      }
+    });
+
+    const result = await validator.validate(hub, HUB_SCHEMA_PATH);
+    assert.strictEqual(result.valid, true, `Validation errors: ${result.errors.join(', ')}`);
+  });
+
+  test('should accept hub config without scaffoldDefaults (backward compat)', async () => {
+    const hub = createMinimalValidHub();
+
+    const result = await validator.validate(hub, HUB_SCHEMA_PATH);
+    assert.strictEqual(result.valid, true, `Validation errors: ${result.errors.join(', ')}`);
+  });
+
+  test('should accept scaffoldDefaults with only some fields', async () => {
+    const hub = createMinimalValidHub({
+      scaffoldDefaults: {
+        githubOrg: 'myorg'
+      }
+    });
+
+    const result = await validator.validate(hub, HUB_SCHEMA_PATH);
+    assert.strictEqual(result.valid, true, `Validation errors: ${result.errors.join(', ')}`);
+  });
+
+  test('should accept empty scaffoldDefaults object', async () => {
+    const hub = createMinimalValidHub({
+      scaffoldDefaults: {}
+    });
+
+    const result = await validator.validate(hub, HUB_SCHEMA_PATH);
+    assert.strictEqual(result.valid, true, `Validation errors: ${result.errors.join(', ')}`);
+  });
+
+  test('should reject scaffoldDefaults with unknown properties', async () => {
+    const hub = createMinimalValidHub({
+      scaffoldDefaults: {
+        unknownField: 'value'
+      }
+    });
+
+    const result = await validator.validate(hub, HUB_SCHEMA_PATH);
+    assert.strictEqual(result.valid, false);
+  });
+});

--- a/test/utils/scaffold-utils.test.ts
+++ b/test/utils/scaffold-utils.test.ts
@@ -1,0 +1,26 @@
+import * as assert from 'node:assert';
+import { resolveRunnerPattern } from '../../src/utils/scaffold-utils';
+
+suite('scaffoldUtils', () => {
+  suite('resolveRunnerPattern()', () => {
+    test('should resolve {githubOrg} placeholder with org value', () => {
+      const result = resolveRunnerPattern('gmsshr-core-{githubOrg}', 'myorg');
+      assert.strictEqual(result, 'gmsshr-core-myorg');
+    });
+
+    test('should return literal value unchanged when no placeholder', () => {
+      const result = resolveRunnerPattern('ubuntu-latest', 'myorg');
+      assert.strictEqual(result, 'ubuntu-latest');
+    });
+
+    test('should resolve multiple occurrences of {githubOrg}', () => {
+      const result = resolveRunnerPattern('{githubOrg}-runner-{githubOrg}', 'acme');
+      assert.strictEqual(result, 'acme-runner-acme');
+    });
+
+    test('should handle empty org string', () => {
+      const result = resolveRunnerPattern('prefix-{githubOrg}', '');
+      assert.strictEqual(result, 'prefix-');
+    });
+  });
+});


### PR DESCRIPTION
## Description

Add a `scaffoldDefaults` section to hub configuration that pre-fills or skips scaffolding prompts, reducing repetitive input for users whose hub already defines organization-level values (org name, contacts, runner label, etc.).

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test coverage improvement
- [ ] 🔧 Configuration/build changes

## Related Issues

Closes #138

## Changes Made

- **Hub schema (`schemas/hub-config.schema.json`):** Added `scaffoldDefaults` object with optional fields: `githubOrg`, `githubRunner`, `organizationName`, `internalContact`, `legalContact`, `organizationPolicyLink`. Strict `additionalProperties: false` to prevent unknown fields.
- **TypeScript types (`src/types/hub.ts`):** Added `ScaffoldDefaults` interface and wired it into `HubConfig`.
- **ScaffoldCommand (`src/commands/ScaffoldCommand.ts`):** `runWithUI()` now accepts an optional `HubManager`, loads `scaffoldDefaults` from the active hub, and passes them through to `promptForProjectDetails`, `promptForOrganizationDetails`, and `promptForGitHubRunner`. Org-level fields are skipped when hub defaults are present; `githubOrg` and `githubRunner` are pre-filled but still editable.
- **Extension entry point (`src/extension.ts`):** Passes `this.hubManager` to `ScaffoldCommand.runWithUI()`.
- **Scaffold utilities (`src/utils/scaffoldUtils.ts`):** New helper `resolveRunnerPattern()` replaces `{githubOrg}` placeholders in runner strings; `getGitHubUserIdentity()` reads the GitHub session to pre-fill the author field.
- **Documentation (`docs/reference/hub-schema.md`):** Documented `scaffoldDefaults` object, runner pattern syntax, and prompt behavior table (skipped vs. pre-filled vs. always asked).
- **Tests:** Added `test/unit/hubSchemaScaffoldDefaults.test.ts` (schema validation for scaffoldDefaults) and `test/utils/scaffoldUtils.test.ts` (resolveRunnerPattern and getGitHubUserIdentity unit tests).

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing completed
- [x] All existing tests pass

### Manual Testing Steps

1. Configure a hub with `scaffoldDefaults` containing all six fields and scaffold a new GitHub project — verify org-level prompts are skipped and `githubOrg`/`githubRunner` are pre-filled
2. Configure a hub with only `githubOrg` set — verify other org fields are still prompted
3. Scaffold without any active hub — verify behavior is unchanged (all prompts shown)
4. Add an unknown property to `scaffoldDefaults` in a hub config — verify schema validation rejects it

### Tested On

- [x] macOS
- [ ] Windows
- [ ] Linux

- [x] VS Code Stable
- [ ] VS Code Insiders

## Screenshots

N/A — UX changes are in VS Code input boxes (pre-filled values / skipped prompts)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Documentation

- [ ] README.md updated
- [x] JSDoc comments added/updated
- [ ] No documentation changes needed

## Additional Notes

The feature is fully backward-compatible: hubs without `scaffoldDefaults` behave exactly as before. The `{githubOrg}` placeholder in `githubRunner` is the only supported pattern — no general templating engine is introduced.

## Reviewer Guidelines

Please pay special attention to:

- The skip logic in `promptForOrganizationDetails` — it short-circuits when *any* of the four org fields are present in hub defaults; verify this is the intended granularity vs. requiring all four
- The `resolveRunnerPattern` only supports `{githubOrg}` — confirm no other placeholders are needed
- Thread safety of `getGitHubUserIdentity()` — it uses `createIfNone: false` so it never triggers a sign-in prompt

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**
