### PR TITLE
fix(utils): prevent duplicate extensions in symlink filenames

### DIFF
--- a/src/utils/copilotFileTypeUtils.ts
+++ b/src/utils/copilotFileTypeUtils.ts
@@ -167,7 +167,7 @@ export function determineFileType(fileName: string, tags?: string[]): CopilotFil
 
 /**
  * Generate the target file name for a given ID and file type.
- * 
+ *
  * @param id - The prompt/agent/etc. identifier
  * @param type - The Copilot file type
  * @returns The target file name with appropriate extension
@@ -176,6 +176,13 @@ export function getTargetFileName(id: string, type: CopilotFileType): string {
     // Skills use SKILL.md as the main file
     if (type === 'skill') {
         return 'SKILL.md';
+    }
+
+    // Strip existing type suffix from ID to prevent duplicate extensions
+    // e.g., "my-bundle.prompt" with type "prompt" should become "my-bundle.prompt.md", not "my-bundle.prompt.prompt.md"
+    const extensionWithoutMd = FILE_EXTENSIONS[type].replace('.md', ''); // e.g., '.prompt' from '.prompt.md'
+    if (id.toLowerCase().endsWith(extensionWithoutMd.toLowerCase())) {
+        id = id.slice(0, -extensionWithoutMd.length);
     }
 
     return `${id}${FILE_EXTENSIONS[type]}`;

--- a/test/utils/copilotFileTypeUtils.test.ts
+++ b/test/utils/copilotFileTypeUtils.test.ts
@@ -169,6 +169,21 @@ suite('copilotFileTypeUtils', () => {
         test('should handle IDs with special characters', () => {
             assert.strictEqual(getTargetFileName('my_prompt-v1', 'prompt'), 'my_prompt-v1.prompt.md');
         });
+
+        test('should strip existing type suffix to prevent duplicate extensions', () => {
+            // Regression test: IDs from manifests often already contain type suffix (e.g., ".prompt", ".agent")
+            // which would result in duplicate extensions like "name.prompt.prompt.md"
+            assert.strictEqual(getTargetFileName('my-bundle.prompt', 'prompt'), 'my-bundle.prompt.md');
+            assert.strictEqual(getTargetFileName('my-bundle.agent', 'agent'), 'my-bundle.agent.md');
+            assert.strictEqual(getTargetFileName('my-bundle.instructions', 'instructions'), 'my-bundle.instructions.md');
+            assert.strictEqual(getTargetFileName('my-bundle.chatmode', 'chatmode'), 'my-bundle.chatmode.md');
+        });
+
+        test('should handle edge cases with dots in ID', () => {
+            // Dots that are NOT type suffixes should be preserved
+            assert.strictEqual(getTargetFileName('bundle.v1.prompt', 'prompt'), 'bundle.v1.prompt.md');
+            assert.strictEqual(getTargetFileName('my.bundle.agent', 'agent'), 'my.bundle.agent.md');
+        });
     });
 
     suite('getRepositoryTargetDirectory', () => {


### PR DESCRIPTION
## Description

Fixes duplicate file extensions in symlink names during bundle installation. When prompt IDs already contain type suffixes (e.g., `my-bundle.prompt`), the resulting symlink was named `my-bundle.prompt.prompt.md` instead of `my-bundle.prompt.md`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #184

## Changes Made

- Modified `getTargetFileName()` in `src/utils/copilotFileTypeUtils.ts` to strip existing type suffix before appending extension
- Added case-insensitive suffix matching for robustness
- Added regression tests for duplicate extension prevention

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [x] All existing tests pass

### Manual Testing Steps

1. Install bundle with prompts containing type suffixes in IDs (e.g., `.prompt`, `.agent`)
2. Verify symlinks in `~/.config/Code/User/prompts/` have correct single extension
3. Examples: `name.prompt.md` instead of `name.prompt.prompt.md`

### Tested On

- [x] Linux
- [x] VS Code Insiders

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes (2,538 passing)

## Documentation

- [x] No documentation changes needed

## Additional Notes

The fix handles edge cases where dots exist in IDs that are NOT type suffixes (e.g., `bundle.v1.prompt` correctly becomes `bundle.v1.prompt.md`).

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**
