### PR TITLE
feat: add periodic hub sync and auto source sync after hub sync

### DIFF
--- a/src/commands/hub-profile-activation-commands.ts
+++ b/src/commands/hub-profile-activation-commands.ts
@@ -15,7 +15,7 @@ import {
 export async function activateHubProfile(hubManager: HubManager, item?: any): Promise<void> {
   try {
     // Get the active hub ID first
-    const activeHubId = await (hubManager as any).storage.getActiveHubId();
+    const activeHubId = await hubManager.getActiveHubId();
 
     if (!activeHubId) {
       vscode.window.showWarningMessage('No active hub configured. Please configure a hub first.');
@@ -122,7 +122,7 @@ export async function activateHubProfile(hubManager: HubManager, item?: any): Pr
 export async function deactivateHubProfile(hubManager: HubManager, item?: any): Promise<void> {
   try {
     // Get the active hub ID first
-    const activeHubId = await (hubManager as any).storage.getActiveHubId();
+    const activeHubId = await hubManager.getActiveHubId();
 
     if (!activeHubId) {
       vscode.window.showWarningMessage('No active hub configured. Please configure a hub first.');
@@ -203,7 +203,7 @@ export async function deactivateHubProfile(hubManager: HubManager, item?: any): 
 export async function showActiveProfiles(hubManager: HubManager): Promise<void> {
   try {
     // Get the active hub ID first
-    const activeHubId = await (hubManager as any).storage.getActiveHubId();
+    const activeHubId = await hubManager.getActiveHubId();
 
     if (!activeHubId) {
       vscode.window.showWarningMessage('No active hub configured. Please configure a hub first.');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -80,6 +80,9 @@ import {
   HubManager,
 } from './services/hub-manager';
 import {
+  HubSyncScheduler,
+} from './services/hub-sync-scheduler';
+import {
   InstallationManager,
 } from './services/installation-manager';
 import {
@@ -172,6 +175,9 @@ export class PromptRegistryExtension {
   private validateApmCommand: ValidateApmCommand | undefined;
   private createCollectionCommand: CreateCollectionCommand | undefined;
   private copilotIntegration: CopilotIntegration | undefined;
+
+  // Hub sync scheduler
+  private hubSyncScheduler: HubSyncScheduler | undefined;
 
   // Update notification services
   private updateScheduler: UpdateScheduler | undefined;
@@ -273,6 +279,12 @@ export class PromptRegistryExtension {
       // Always sync active hub on activation to keep it up-to-date
       await this.syncActiveHub();
 
+      // Start periodic hub sync scheduler (24h interval)
+      if (this.hubManager) {
+        this.hubSyncScheduler = new HubSyncScheduler(this.context, this.hubManager);
+        this.hubSyncScheduler.initialize();
+      }
+
       // Ensure only one profile is active (cleanup any multi-active state)
       await this.ensureSingleActiveProfile();
 
@@ -303,6 +315,9 @@ export class PromptRegistryExtension {
 
       // Dispose telemetry event subscriptions
       this.telemetryService?.dispose();
+
+      // Dispose hub sync scheduler
+      this.hubSyncScheduler?.dispose();
 
       // Dispose update scheduler
       this.updateScheduler?.dispose();
@@ -379,6 +394,32 @@ export class PromptRegistryExtension {
     this.hubCommands = new HubCommands(this.hubManager, this.registryManager, this.context);
     this.hubIntegrationCommands = new HubIntegrationCommands(this.hubManager, this.context);
     this.hubProfileCommands = new HubProfileCommands(this.context);
+
+    // Wire onHubSynced → syncAllSources so every hub sync (manual, periodic, activation)
+    // automatically refreshes sources. This single wiring replaces ad-hoc calls.
+    // Uses a coalescing guard so rapid-fire events (e.g. syncAllHubs iterating N hubs)
+    // collapse into a single syncAllSources call.
+    let sourceSyncPending = false;
+    const hubSyncDisposable = this.hubManager.onHubSynced(() => {
+      if (!this.sourceCommands || sourceSyncPending) {
+        return;
+      }
+      sourceSyncPending = true;
+      // Defer to next microtask so multiple synchronous onHubSynced fires coalesce
+      Promise.resolve().then(async () => {
+        try {
+          await this.sourceCommands!.syncAllSources({ silent: true });
+          this.logger.info('Sources synced after hub sync');
+          vscode.commands.executeCommand('promptRegistry.refresh');
+        } catch (error) {
+          this.logger.warn('Failed to sync sources after hub sync', error as Error);
+        } finally {
+          sourceSyncPending = false;
+        }
+      });
+    });
+    this.disposables.push(hubSyncDisposable);
+
     // Note: scaffoldCommand is registered inline in command handler
     const addResourceCommand = new AddResourceCommand(this.context.extensionPath);
     const githubAuthCommand = new GitHubAuthCommand(this.registryManager);
@@ -1496,39 +1537,24 @@ export class PromptRegistryExtension {
         return;
       }
 
-      // Check if there's an active hub
-      const activeHub = await hubManager.getActiveHub();
-      if (!activeHub) {
+      const activeHubId = await hubManager.getActiveHubId();
+      if (!activeHubId) {
         this.logger.info('No active hub configured, skipping auto-sync');
         return;
       }
 
-      // Get active hub ID
-      const activeProfiles = await hubManager.listActiveHubProfiles();
-      if (activeProfiles.length === 0 || !activeProfiles[0].hubId) {
-        this.logger.warn('Active hub has no profiles or hub ID, skipping auto-sync');
+      // Validate hub still exists (clears stale activeHubId if hub was deleted)
+      const activeHub = await hubManager.getActiveHub();
+      if (!activeHub) {
+        this.logger.info('Active hub no longer exists, cleared stale reference');
         return;
       }
 
-      const activeHubId = activeProfiles[0].hubId;
       this.logger.info(`Auto-syncing active hub: ${activeHubId}`);
-
-      // Sync hub configuration
+      // syncHub fires onHubSynced → triggers syncAllSources via event wiring
       await hubManager.syncHub(activeHubId);
-
-      // Sync all sources from the active hub in the background (non-blocking)
-      // This allows the extension to finish activation quickly so the webview can resolve
-      // and show cached bundles while sync happens progressively
-      sourceCommands.syncAllSources({ silent: true }).then(() => {
-        this.logger.info('Active hub synchronized successfully on activation');
-        // Refresh tree view after sync completes
-        vscode.commands.executeCommand('promptRegistry.refresh');
-      }).catch((error) => {
-        this.logger.warn('Background sync failed', error as Error);
-      });
     } catch (error) {
       this.logger.warn('Failed to auto-sync active hub on activation', error as Error);
-      // Don't fail extension activation if sync fails
     }
   }
 

--- a/src/services/hub-manager.ts
+++ b/src/services/hub-manager.ts
@@ -155,6 +155,14 @@ export class HubManager {
   }
 
   /**
+   * Get the active hub ID from storage
+   * @returns Active hub ID or null if no hub is active
+   */
+  async getActiveHubId(): Promise<string | null> {
+    return this.storage.getActiveHubId();
+  }
+
+  /**
    * Import hub from remote or local source
    * @param reference Hub reference (GitHub, URL, or local path)
    * @param hubId Optional hub identifier (auto-generated if not provided)

--- a/src/services/hub-sync-scheduler.ts
+++ b/src/services/hub-sync-scheduler.ts
@@ -1,0 +1,126 @@
+/**
+ * Hub Sync Scheduler Service
+ * Periodically syncs the active hub configuration to keep sources up-to-date
+ */
+
+import * as vscode from 'vscode';
+import {
+  HUB_SYNC_CONSTANTS,
+} from '../utils/constants';
+import {
+  isTestEnvironment,
+} from '../utils/environment';
+import {
+  Logger,
+} from '../utils/logger';
+import {
+  HubManager,
+} from './hub-manager';
+
+/**
+ * Periodically syncs the active hub so that new sources/profiles
+ * published to the hub appear without a VS Code restart.
+ */
+export class HubSyncScheduler {
+  private readonly logger: Logger;
+  private readonly isTestEnvironment: boolean;
+  private syncTimer?: NodeJS.Timeout;
+  private isInitialized = false;
+  private isCheckInProgress = false;
+
+  constructor(
+    context: vscode.ExtensionContext,
+    private readonly hubManager: HubManager
+  ) {
+    this.logger = Logger.getInstance();
+    this.isTestEnvironment = isTestEnvironment('HUB_SYNC_SCHEDULER_ALLOW_TIMERS_IN_TESTS');
+
+    if (context?.subscriptions) {
+      context.subscriptions.push({
+        dispose: () => this.dispose()
+      });
+    }
+  }
+
+  /**
+   * Schedule the next periodic sync after SYNC_INTERVAL_MS.
+   */
+  private scheduleNextSync(): void {
+    if (this.syncTimer) {
+      clearTimeout(this.syncTimer);
+      this.syncTimer = undefined;
+    }
+
+    this.syncTimer = setTimeout(async () => {
+      await this.performSync();
+      // Reschedule after completion
+      if (this.isInitialized) {
+        this.scheduleNextSync();
+      }
+    }, HUB_SYNC_CONSTANTS.SYNC_INTERVAL_MS);
+  }
+
+  /**
+   * Initialize the scheduler.
+   * Starts the first periodic timer (no startup delay — activation already syncs).
+   */
+  public initialize(): void {
+    if (this.isInitialized) {
+      this.logger.debug('HubSyncScheduler already initialized');
+      return;
+    }
+
+    this.logger.info('Initializing HubSyncScheduler');
+
+    if (this.isTestEnvironment) {
+      this.logger.debug('Test environment detected, skipping hub sync timers');
+    } else {
+      this.scheduleNextSync();
+    }
+
+    this.isInitialized = true;
+    this.logger.info('HubSyncScheduler initialized successfully');
+  }
+
+  /**
+   * Perform a hub sync.
+   * Guards against overlapping syncs and handles errors gracefully.
+   */
+  public async performSync(): Promise<void> {
+    if (this.isCheckInProgress) {
+      this.logger.debug('Hub sync already in progress, skipping');
+      return;
+    }
+
+    this.isCheckInProgress = true;
+    try {
+      const activeHubId = await this.hubManager.getActiveHubId();
+      if (!activeHubId) {
+        this.logger.debug('No active hub configured, skipping periodic sync');
+        return;
+      }
+
+      this.logger.info(`Performing periodic hub sync: ${activeHubId}`);
+      await this.hubManager.syncHub(activeHubId);
+      this.logger.info('Periodic hub sync completed successfully');
+    } catch (error) {
+      this.logger.warn('Periodic hub sync failed', error as Error);
+    } finally {
+      this.isCheckInProgress = false;
+    }
+  }
+
+  /**
+   * Cleanup timers and reset state.
+   */
+  public dispose(): void {
+    this.logger.debug('Disposing HubSyncScheduler');
+
+    if (this.syncTimer) {
+      clearTimeout(this.syncTimer);
+      this.syncTimer = undefined;
+    }
+
+    this.isInitialized = false;
+  }
+}

--- a/src/services/update-scheduler.ts
+++ b/src/services/update-scheduler.ts
@@ -13,6 +13,12 @@ import {
   UpdateCheckFrequency,
 } from '../utils/config-type-guards';
 import {
+  UPDATE_CONSTANTS,
+} from '../utils/constants';
+import {
+  isTestEnvironment,
+} from '../utils/environment';
+import {
   Logger,
 } from '../utils/logger';
 import {
@@ -35,16 +41,6 @@ export interface UpdateSchedulerConfig {
   frequency: UpdateCheckFrequency;
   startupCheckDelay: number; // milliseconds
 }
-
-/**
- * Update scheduler constants
- */
-const SCHEDULER_CONSTANTS = {
-  STARTUP_CHECK_DELAY_MS: 5000, // 5 seconds per requirements
-  DAILY_INTERVAL_MS: 24 * 60 * 60 * 1000, // 24 hours
-  WEEKLY_INTERVAL_MS: 7 * 24 * 60 * 60 * 1000, // 7 days
-  UPDATE_CHECK_TIMEOUT_MS: 30_000 // 30 seconds timeout for update checks
-} as const;
 
 /**
  * Update scheduler service
@@ -78,21 +74,7 @@ export class UpdateScheduler {
     this.autoUpdateService = autoUpdateService;
     this.logger = Logger.getInstance();
 
-    // Test Environment Detection
-    // ---------------------------
-    // This detection exists because Node.js timers (setTimeout/setInterval) keep the
-    // process alive, causing test runners to hang. While dependency injection for a
-    // TimerStrategy interface would be more "pure", this pragmatic approach:
-    // 1. Avoids adding complexity for a single use case
-    // 2. Is well-tested via property tests (UpdateScheduler.property.test.ts)
-    // 3. Allows opt-in via UPDATE_SCHEDULER_ALLOW_TIMERS_IN_TESTS for integration tests
-    // 4. Uses explicit detection rather than mocking internals
-    const isNodeTestEnvironment =
-      process.env.NODE_ENV === 'test'
-      || process.argv.some((arg) => arg.includes('mocha'))
-      || process.argv.some((arg) => arg.includes('test'));
-    const allowTimersOverride = process.env.UPDATE_SCHEDULER_ALLOW_TIMERS_IN_TESTS === 'true';
-    this.isTestEnvironment = isNodeTestEnvironment && !allowTimersOverride;
+    this.isTestEnvironment = isTestEnvironment('UPDATE_SCHEDULER_ALLOW_TIMERS_IN_TESTS');
 
     // Load configuration
     this.config = this.loadConfiguration();
@@ -252,7 +234,7 @@ export class UpdateScheduler {
       const timeoutPromise = new Promise<never>((_, reject) => {
         timeoutHandle = setTimeout(
           () => reject(new Error('Update check timed out')),
-          SCHEDULER_CONSTANTS.UPDATE_CHECK_TIMEOUT_MS
+          UPDATE_CONSTANTS.UPDATE_CHECK_TIMEOUT_MS
         );
       });
 
@@ -341,10 +323,10 @@ export class UpdateScheduler {
   private getCheckInterval(): number {
     switch (this.config.frequency) {
       case 'daily': {
-        return SCHEDULER_CONSTANTS.DAILY_INTERVAL_MS;
+        return UPDATE_CONSTANTS.DAILY_INTERVAL_MS;
       }
       case 'weekly': {
-        return SCHEDULER_CONSTANTS.WEEKLY_INTERVAL_MS;
+        return UPDATE_CONSTANTS.WEEKLY_INTERVAL_MS;
       }
       default: {
         return 0;
@@ -372,7 +354,7 @@ export class UpdateScheduler {
     return {
       enabled: config.get<boolean>('enabled', true),
       frequency,
-      startupCheckDelay: SCHEDULER_CONSTANTS.STARTUP_CHECK_DELAY_MS
+      startupCheckDelay: UPDATE_CONSTANTS.STARTUP_CHECK_DELAY_MS
     };
   }
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -107,6 +107,14 @@ export const UPDATE_CONSTANTS = {
 } as const;
 
 /**
+ * Hub sync constants
+ */
+export const HUB_SYNC_CONSTANTS = {
+  /** Interval for periodic hub sync (24 hours) */
+  SYNC_INTERVAL_MS: 24 * 60 * 60 * 1000,
+} as const;
+
+/**
  * UI constants
  */
 export const UI_CONSTANTS = {

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -1,0 +1,27 @@
+/**
+ * Environment detection utilities
+ */
+
+/**
+ * Detect whether the current process is running inside a test runner.
+ *
+ * Schedulers and other timer-based services use this to skip creating
+ * long-lived Node.js timers that would keep the process alive and cause
+ * test hangs.
+ *
+ * @param allowTimersEnvVar - Optional env-var name that, when set to
+ *   `'true'`, overrides the detection and allows timers even in tests
+ *   (useful for property / integration tests that need real scheduling).
+ */
+export function isTestEnvironment(allowTimersEnvVar?: string): boolean {
+  const isTest =
+    process.env.NODE_ENV === 'test'
+    || process.argv.some((arg) => arg.includes('mocha'))
+    || process.argv.some((arg) => arg.includes('test'));
+
+  if (allowTimersEnvVar && process.env[allowTimersEnvVar] === 'true') {
+    return false;
+  }
+
+  return isTest;
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,4 +1,7 @@
 import * as vscode from 'vscode';
+import {
+  isTestEnvironment,
+} from './environment';
 
 /**
  * Log levels for filtering
@@ -22,9 +25,7 @@ export class Logger {
 
   private constructor() {
     // Detect test environment
-    this.isTestEnvironment = process.env.NODE_ENV === 'test'
-      || process.argv.some((arg) => arg.includes('mocha'))
-      || process.argv.some((arg) => arg.includes('test'));
+    this.isTestEnvironment = isTestEnvironment();
 
     // Check for LOG_LEVEL environment variable
     const envLogLevel = process.env.LOG_LEVEL?.toUpperCase();

--- a/test/services/hub-sync-event-wiring.test.ts
+++ b/test/services/hub-sync-event-wiring.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests for the onHubSynced → syncAllSources event wiring in extension.ts
+ *
+ * These tests validate the coalescing event handler that triggers source sync
+ * after every hub sync, ensuring:
+ * - syncAllSources is called with { silent: true }
+ * - promptRegistry.refresh is executed on success
+ * - Rapid-fire onHubSynced events coalesce into a single syncAllSources call
+ * - Errors are handled gracefully
+ */
+import * as assert from 'node:assert';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+
+suite('onHubSynced → syncAllSources event wiring', () => {
+  let sandbox: sinon.SinonSandbox;
+  let emitter: vscode.EventEmitter<string>;
+  let syncAllSourcesStub: sinon.SinonStub;
+  let executeCommandStub: sinon.SinonStub;
+  let disposables: vscode.Disposable[];
+
+  /**
+   * Replicate the production wiring from extension.ts registerCommands()
+   * so we can test the coalescing event handler in isolation.
+   */
+  function wireHandler(sourceCommands: { syncAllSources: sinon.SinonStub } | undefined) {
+    let sourceSyncPending = false;
+    const disposable = emitter.event(() => {
+      if (!sourceCommands || sourceSyncPending) {
+        return;
+      }
+      sourceSyncPending = true;
+      Promise.resolve().then(async () => {
+        try {
+          await sourceCommands.syncAllSources({ silent: true });
+          vscode.commands.executeCommand('promptRegistry.refresh');
+        } catch {
+          // Errors logged in production; swallowed here for test
+        } finally {
+          sourceSyncPending = false;
+        }
+      });
+    });
+    disposables.push(disposable);
+  }
+
+  setup(() => {
+    sandbox = sinon.createSandbox();
+    emitter = new vscode.EventEmitter<string>();
+    disposables = [];
+    syncAllSourcesStub = sandbox.stub().resolves();
+    executeCommandStub = sandbox.stub(vscode.commands, 'executeCommand').resolves();
+  });
+
+  teardown(() => {
+    disposables.forEach((d) => d.dispose());
+    emitter.dispose();
+    sandbox.restore();
+  });
+
+  test('should call syncAllSources({ silent: true }) when onHubSynced fires', async () => {
+    wireHandler({ syncAllSources: syncAllSourcesStub });
+
+    emitter.fire('hub-1');
+    // Wait for microtask to resolve
+    await new Promise((r) => setTimeout(r, 0));
+
+    assert.ok(syncAllSourcesStub.calledOnce);
+    assert.deepStrictEqual(syncAllSourcesStub.firstCall.args[0], { silent: true });
+  });
+
+  test('should execute promptRegistry.refresh after successful sync', async () => {
+    wireHandler({ syncAllSources: syncAllSourcesStub });
+
+    emitter.fire('hub-1');
+    await new Promise((r) => setTimeout(r, 0));
+
+    assert.ok(executeCommandStub.calledWith('promptRegistry.refresh'));
+  });
+
+  test('should coalesce rapid-fire events into a single syncAllSources call', async () => {
+    wireHandler({ syncAllSources: syncAllSourcesStub });
+
+    // Fire 5 events synchronously (simulates syncAllHubs with 5 hubs)
+    emitter.fire('hub-1');
+    emitter.fire('hub-2');
+    emitter.fire('hub-3');
+    emitter.fire('hub-4');
+    emitter.fire('hub-5');
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    assert.strictEqual(syncAllSourcesStub.callCount, 1,
+      'Should coalesce into a single syncAllSources call');
+  });
+
+  test('should allow subsequent syncs after first completes', async () => {
+    wireHandler({ syncAllSources: syncAllSourcesStub });
+
+    // First event batch
+    emitter.fire('hub-1');
+    await new Promise((r) => setTimeout(r, 0));
+
+    // Second event (after first completed)
+    emitter.fire('hub-2');
+    await new Promise((r) => setTimeout(r, 0));
+
+    assert.strictEqual(syncAllSourcesStub.callCount, 2,
+      'Should allow a new sync after the first completes');
+  });
+
+  test('should not throw when syncAllSources rejects', async () => {
+    syncAllSourcesStub.rejects(new Error('Network error'));
+    wireHandler({ syncAllSources: syncAllSourcesStub });
+
+    emitter.fire('hub-1');
+    await new Promise((r) => setTimeout(r, 0));
+
+    // Should not throw — verify guard is reset for next event
+    emitter.fire('hub-2');
+    await new Promise((r) => setTimeout(r, 0));
+
+    assert.strictEqual(syncAllSourcesStub.callCount, 2,
+      'Should reset pending flag after error');
+  });
+
+  test('should skip if sourceCommands is undefined', async () => {
+    wireHandler(undefined);
+
+    emitter.fire('hub-1');
+    await new Promise((r) => setTimeout(r, 0));
+
+    assert.ok(syncAllSourcesStub.notCalled);
+  });
+});

--- a/test/services/hub-sync-scheduler.test.ts
+++ b/test/services/hub-sync-scheduler.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Unit tests for HubSyncScheduler
+ * Tests periodic hub sync scheduling, overlap guard, and disposal
+ */
+import * as assert from 'node:assert';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import {
+  HubManager,
+} from '../../src/services/hub-manager';
+import {
+  HubSyncScheduler,
+} from '../../src/services/hub-sync-scheduler';
+import {
+  HUB_SYNC_CONSTANTS,
+} from '../../src/utils/constants';
+
+suite('HubSyncScheduler', () => {
+  let sandbox: sinon.SinonSandbox;
+  let mockContext: vscode.ExtensionContext;
+  let mockHubManager: sinon.SinonStubbedInstance<HubManager>;
+  let subscriptions: vscode.Disposable[];
+
+  setup(() => {
+    sandbox = sinon.createSandbox();
+    subscriptions = [];
+
+    mockContext = {
+      subscriptions,
+      globalStorageUri: vscode.Uri.file('/mock/storage'),
+      extensionPath: '/mock/path'
+    } as any;
+
+    mockHubManager = {
+      getActiveHubId: sandbox.stub(),
+      syncHub: sandbox.stub()
+    } as any;
+  });
+
+  teardown(() => {
+    sandbox.restore();
+  });
+
+  suite('constructor and initialize()', () => {
+    test('should detect test environment and skip timers', () => {
+      const scheduler = new HubSyncScheduler(mockContext, mockHubManager as any);
+      scheduler.initialize();
+
+      // In test environment, no timers should be created
+      // Verify by checking that dispose doesn't error
+      scheduler.dispose();
+    });
+
+    test('should be idempotent - second initialize() is a no-op', () => {
+      const scheduler = new HubSyncScheduler(mockContext, mockHubManager as any);
+      scheduler.initialize();
+      scheduler.initialize(); // Should not throw or create duplicate timers
+
+      scheduler.dispose();
+    });
+
+    test('should register itself for disposal via context.subscriptions', () => {
+      const scheduler = new HubSyncScheduler(mockContext, mockHubManager as any);
+
+      // The constructor should add a dispose handler to context.subscriptions
+      assert.ok(subscriptions.length > 0, 'Should register a disposable');
+
+      scheduler.dispose();
+    });
+  });
+
+  suite('performSync()', () => {
+    test('should call hubManager.syncHub() with the active hub ID', async () => {
+      mockHubManager.getActiveHubId.resolves('my-hub-123');
+      mockHubManager.syncHub.resolves();
+
+      const scheduler = new HubSyncScheduler(mockContext, mockHubManager as any);
+      await scheduler.performSync();
+
+      assert.ok(mockHubManager.getActiveHubId.calledOnce, 'Should call getActiveHubId');
+      assert.ok(mockHubManager.syncHub.calledOnce, 'Should call syncHub');
+      assert.strictEqual(mockHubManager.syncHub.firstCall.args[0], 'my-hub-123');
+
+      scheduler.dispose();
+    });
+
+    test('should skip sync when no active hub (getActiveHubId returns null)', async () => {
+      mockHubManager.getActiveHubId.resolves(null);
+
+      const scheduler = new HubSyncScheduler(mockContext, mockHubManager as any);
+      await scheduler.performSync();
+
+      assert.ok(mockHubManager.getActiveHubId.calledOnce, 'Should call getActiveHubId');
+      assert.ok(mockHubManager.syncHub.notCalled, 'Should NOT call syncHub');
+
+      scheduler.dispose();
+    });
+
+    test('should prevent overlapping syncs (isCheckInProgress guard)', async () => {
+      // Make syncHub hang until we resolve it
+      let resolveSyncHub: () => void;
+      const syncHubPromise = new Promise<void>((resolve) => {
+        resolveSyncHub = resolve;
+      });
+      mockHubManager.getActiveHubId.resolves('my-hub');
+      mockHubManager.syncHub.returns(syncHubPromise as any);
+
+      const scheduler = new HubSyncScheduler(mockContext, mockHubManager as any);
+
+      // Start first sync (will hang)
+      const firstSync = scheduler.performSync();
+
+      // Start second sync while first is in progress
+      await scheduler.performSync();
+
+      // syncHub should only be called once (second call was skipped)
+      assert.strictEqual(mockHubManager.syncHub.callCount, 1, 'syncHub should only be called once');
+
+      // Resolve the first sync
+      resolveSyncHub!();
+      await firstSync;
+
+      scheduler.dispose();
+    });
+
+    test('should handle syncHub errors gracefully (logs, does not throw)', async () => {
+      mockHubManager.getActiveHubId.resolves('my-hub');
+      mockHubManager.syncHub.rejects(new Error('Network error'));
+
+      const scheduler = new HubSyncScheduler(mockContext, mockHubManager as any);
+
+      // Should not throw
+      await scheduler.performSync();
+
+      assert.ok(mockHubManager.syncHub.calledOnce, 'Should have attempted syncHub');
+
+      scheduler.dispose();
+    });
+
+    test('should reset isCheckInProgress after error', async () => {
+      mockHubManager.getActiveHubId.resolves('my-hub');
+      mockHubManager.syncHub.rejects(new Error('Network error'));
+
+      const scheduler = new HubSyncScheduler(mockContext, mockHubManager as any);
+      await scheduler.performSync();
+
+      // Second call should work (guard reset after error)
+      mockHubManager.syncHub.resolves();
+      await scheduler.performSync();
+
+      assert.strictEqual(mockHubManager.syncHub.callCount, 2, 'Should allow second sync after error');
+
+      scheduler.dispose();
+    });
+  });
+
+  suite('dispose()', () => {
+    test('should clear timers and reset state', () => {
+      const scheduler = new HubSyncScheduler(mockContext, mockHubManager as any);
+      scheduler.initialize();
+
+      scheduler.dispose();
+
+      // Should be safe to dispose multiple times
+      scheduler.dispose();
+    });
+  });
+
+  suite('scheduling with fake timers', () => {
+    let clock: sinon.SinonFakeTimers;
+
+    const originalAllowTimersEnv = process.env.HUB_SYNC_SCHEDULER_ALLOW_TIMERS_IN_TESTS;
+
+    setup(() => {
+      // Opt-in to real timer paths so we can test scheduling with fake timers
+      process.env.HUB_SYNC_SCHEDULER_ALLOW_TIMERS_IN_TESTS = 'true';
+      clock = sandbox.useFakeTimers();
+    });
+
+    teardown(() => {
+      clock.restore();
+      if (originalAllowTimersEnv === undefined) {
+        delete process.env.HUB_SYNC_SCHEDULER_ALLOW_TIMERS_IN_TESTS;
+      } else {
+        process.env.HUB_SYNC_SCHEDULER_ALLOW_TIMERS_IN_TESTS = originalAllowTimersEnv;
+      }
+    });
+
+    test('should fire performSync after SYNC_INTERVAL_MS', async () => {
+      mockHubManager.getActiveHubId.resolves('my-hub');
+      mockHubManager.syncHub.resolves();
+
+      const scheduler = new HubSyncScheduler(mockContext, mockHubManager as any);
+      scheduler.initialize();
+
+      // Advance time just under the interval — nothing should fire yet
+      await clock.tickAsync(HUB_SYNC_CONSTANTS.SYNC_INTERVAL_MS - 1);
+      assert.ok(mockHubManager.syncHub.notCalled, 'Should not fire before interval');
+
+      // Advance the remaining tick
+      await clock.tickAsync(1);
+      assert.ok(mockHubManager.syncHub.calledOnce, 'Should fire after full interval');
+
+      scheduler.dispose();
+    });
+
+    test('should reschedule after sync completes', async () => {
+      mockHubManager.getActiveHubId.resolves('my-hub');
+      mockHubManager.syncHub.resolves();
+
+      const scheduler = new HubSyncScheduler(mockContext, mockHubManager as any);
+      scheduler.initialize();
+
+      // First cycle
+      await clock.tickAsync(HUB_SYNC_CONSTANTS.SYNC_INTERVAL_MS);
+      assert.strictEqual(mockHubManager.syncHub.callCount, 1);
+
+      // Second cycle
+      await clock.tickAsync(HUB_SYNC_CONSTANTS.SYNC_INTERVAL_MS);
+      assert.strictEqual(mockHubManager.syncHub.callCount, 2);
+
+      scheduler.dispose();
+    });
+
+    test('should stop scheduling after dispose', async () => {
+      mockHubManager.getActiveHubId.resolves('my-hub');
+      mockHubManager.syncHub.resolves();
+
+      const scheduler = new HubSyncScheduler(mockContext, mockHubManager as any);
+      scheduler.initialize();
+
+      scheduler.dispose();
+
+      await clock.tickAsync(HUB_SYNC_CONSTANTS.SYNC_INTERVAL_MS * 2);
+      assert.ok(mockHubManager.syncHub.notCalled, 'Should not fire after dispose');
+    });
+  });
+
+  suite('constants', () => {
+    test('SYNC_INTERVAL_MS should be 24 hours', () => {
+      assert.strictEqual(HUB_SYNC_CONSTANTS.SYNC_INTERVAL_MS, 86_400_000);
+    });
+  });
+});


### PR DESCRIPTION
Hub is only synced on extension activation and via manual command. If VS Code stays open for days, users won't see new sources/profiles published to the hub. This adds:

1. Periodic hub sync every 24h via HubSyncScheduler
2. Event-driven syncAllSources after every hub sync (onHubSynced), replacing ad-hoc wiring and ensuring manual/periodic syncs also trigger source refresh

## Description

  Add periodic hub sync (every 24h) and event-driven source sync after every hub sync, so users who keep VS Code open for days see new sources/profiles published to the hub without restarting.

  ## Type of Change

  - [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
  - [x] ✨ New feature (non-breaking change which adds functionality)
  - [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] 📝 Documentation update
  - [x] ♻️ Code refactoring (no functional changes)
  - [ ] ⚡ Performance improvement
  - [ ] 🧪 Test coverage improvement
  - [ ] 🔧 Configuration/build changes

  ## Related Issues

  N/A

  ## Changes Made

  - Added `HubSyncScheduler` service (`src/services/hub-sync-scheduler.ts`) following the `UpdateScheduler` pattern — schedules a 24h periodic hub sync with test-environment detection, overlap guard, and graceful error handling
  - Added `HUB_SYNC_CONSTANTS` to `src/utils/constants.ts` with `SYNC_INTERVAL_MS` (24h)
  - Added `getActiveHubId()` public method to `HubManager` to avoid the roundabout `listActiveHubProfiles()` approach
  - Wired `onHubSynced → syncAllSources` event subscription in `extension.ts`, replacing ad-hoc source sync calls and ensuring manual sync, periodic sync, and `syncAllHubs` all trigger source refresh
  - Simplified `syncActiveHub()` in `extension.ts` to use `getActiveHubId()` and rely on the event-driven source sync instead of explicit `syncAllSources` + `.then()` block
  - Initialized `HubSyncScheduler` in `activate()` and added disposal in `deactivate()`

  ## Testing

  ### Test Coverage

  - [x] Unit tests added/updated
  - [ ] Integration tests added/updated
  - [ ] Manual testing completed
  - [x] All existing tests pass

  ### Manual Testing Steps

  1. Open extension, check output logs for "Initializing HubSyncScheduler" on activation
  2. Trigger manual sync hub command, verify "Sources synced after hub sync" appears in logs
  3. Verify marketplace webview shows bundles after source sync (already wired via `onSourceSynced`)

  ### Tested On

  - [x] macOS
  - [ ] Windows
  - [ ] Linux

  - [ ] VS Code Stable
  - [ ] VS Code Insiders

  ## Screenshots

  N/A — no UI changes. Behavior is observable via extension output logs.

  ## Checklist

  - [x] My code follows the project's style guidelines
  - [x] I have performed a self-review of my code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings or errors
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes
  - [ ] Any dependent changes have been merged and published

  ## Documentation

  - [ ] README.md updated
  - [x] JSDoc comments added/updated
  - [ ] No documentation changes needed

  ## Additional Notes

  - The 9 pre-existing test failures (LocalAwesomeCopilotAdapter, Hub Engagement Configuration Validation) are unrelated to this change
  - ESLint is broken project-wide due to missing `jsonc-eslint-parser` dependency — also pre-existing
  - The `initializeHub()` first-run flow keeps its explicit `syncAllSources` call since `importHub()` fires `onHubImported`, not `onHubSynced`

  ## Reviewer Guidelines

  Please pay special attention to:

  - The event wiring in `registerCommands()` — the `onHubSynced` subscription replaces all ad-hoc `syncAllSources` calls after `syncHub`
  - The simplified `syncActiveHub()` — verify no source sync regression since it now relies on the event wiring

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**
