### PR TITLE
Wsl compatibility bug fix

### DIFF
--- a/src/services/user-scope-service.ts
+++ b/src/services/user-scope-service.ts
@@ -15,6 +15,9 @@
  * Requirements: 9.1-9.5
  */
 
+import {
+  execSync,
+} from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -60,15 +63,76 @@ export interface CopilotFile {
   targetPath: string;
 }
 
+type CodeFlavourFolder = 'Code' | 'Code - Insiders';
+
 /**
  * Service to sync bundle prompts to GitHub Copilot's native directories at user level.
  * Implements IScopeService for consistent scope handling.
  */
 export class UserScopeService implements IScopeService {
   private readonly logger: Logger;
+  private readonly appNameMap: Map<string, CodeFlavourFolder> = new Map([
+    ['vscode', 'Code'],
+    ['vscode-insiders', 'Code - Insiders']
+  ]);
+
+  private windowsHomeInWSL: string | undefined;
+  private cachedPromptsDir: string | undefined;
 
   constructor(private readonly context: vscode.ExtensionContext) {
     this.logger = Logger.getInstance();
+  }
+
+  /**
+   * Function to detect if the extension is running in a WSL remote context
+   * We need this to determine if we should sync to Windows filesystem instead of WSL filesystem
+   * @returns True if running in WSL, false otherwise
+   */
+  private isRunningInWSL(): boolean {
+    return vscode.env.remoteName === 'wsl';
+  }
+
+  /**
+   * When running on wsl, get the Windows home directory
+   * @returns The Windows home directory path in WSL as mnt/c/Users/<User>
+   */
+  private getWindowsHomeDirectoryInWSL(): string | undefined {
+    if (this.windowsHomeInWSL) {
+      return this.windowsHomeInWSL;
+    }
+    try {
+      const wslWindowsHome = execSync(`wslpath -u "$(cmd.exe /c echo %USERPROFILE% 2>/dev/null)"`, { encoding: 'utf8', timeout: 5000 }).trim();
+      this.logger.info(`[UserScopeService] Detected Windows home directory in WSL: ${wslWindowsHome}`);
+      this.windowsHomeInWSL = wslWindowsHome;
+      return wslWindowsHome;
+    } catch (error) {
+      this.logger.error('Failed to get Windows home directory in WSL', error as Error);
+      return undefined;
+    }
+  }
+
+  /**
+   * Get the Windows User directory when running in WSL.
+   * Since we construct the path ourselves, we return the User dir directly
+   * instead of globalStorage (avoiding redundant path parsing downstream).
+   * @returns The User directory path in WSL, or undefined if not in WSL or detection fails.
+   */
+  private getWindowsWslUserDir(): string | undefined {
+    if (!this.isRunningInWSL()) {
+      return undefined;
+    }
+    try {
+      const windowsHome = this.getWindowsHomeDirectoryInWSL();
+      if (windowsHome) {
+        const folderName = this.appNameMap.get(vscode.env.uriScheme) || 'Code';
+        const userDir = path.join(windowsHome, 'AppData', 'Roaming', folderName, 'User');
+        this.logger.debug(`[UserScopeService] Resolved WSL User directory: ${userDir}`);
+        return userDir;
+      }
+    } catch {
+      this.logger.warn('[UserScopeService] Failed to resolve Windows path, falling back to WSL path');
+    }
+    return undefined;
   }
 
   /**
@@ -86,43 +150,65 @@ export class UserScopeService implements IScopeService {
    * so we need to sync prompts to the Windows filesystem, not the WSL filesystem.
    */
   private getCopilotPromptsDirectory(): string {
-    const globalStoragePath = this.context.globalStorageUri.fsPath;
-
-    // Find the User directory by looking for '/User/' or '\User\' in the path
-    const userIndex = globalStoragePath.lastIndexOf(path.sep + 'User' + path.sep);
-    const escapedSep = escapeRegex(path.sep);
-
-    if (userIndex === -1) {
-      // Fallback: Custom user-data-dir without 'User' directory
-      // Navigate up from globalStorage/publisher.extension
-      const baseDir = path.dirname(path.dirname(globalStoragePath));
-
-      // Check if we're in a profiles structure
-      const [, profileId] = baseDir.match(new RegExp(`profiles${escapedSep}([^${escapedSep}]+)`)) || [];
-      if (profileId) {
-        const profileName = this.getActiveProfileName(baseDir) || profileId;
-        this.logger.info(`[UserScopeService] Using profile: ${profileName}`);
-        return path.join(baseDir, 'prompts');
-      }
-
-      return path.join(baseDir, 'prompts');
+    if (this.cachedPromptsDir) {
+      return this.cachedPromptsDir;
     }
 
-    // Extract path up to and including 'User'
-    const userDir = globalStoragePath.substring(0, userIndex + path.sep.length + 'User'.length);
+    const resolved = this.resolveCopilotPromptsDirectory();
 
-    // Check if this is a profile-based path by looking for '/profiles/' after User
+    // Sanity check: the resolved path should end with 'prompts' and not be a filesystem root
+    const basename = path.basename(resolved);
+    if (basename !== 'prompts' || resolved === path.dirname(resolved)) {
+      this.logger.warn(`[UserScopeService] Resolved prompts directory looks suspicious: ${resolved}`);
+    }
+
+    this.cachedPromptsDir = resolved;
+    return resolved;
+  }
+
+  private resolveCopilotPromptsDirectory(): string {
+    const globalStoragePath = this.context.globalStorageUri.fsPath;
+    this.logger.debug(`[UserScopeService] Original globalStorage path: ${globalStoragePath}`);
+
+    // WSL: we construct the path ourselves, so we know the User dir directly
+    const wslUserDir = this.getWindowsWslUserDir();
+    if (wslUserDir) {
+      return this.resolvePromptsFromUserDir(wslUserDir);
+    }
+
+    if (this.isRunningInWSL()) {
+      this.logger.warn('[UserScopeService] Unable to resolve Windows path from WSL. Prompts may not be visible to Copilot.');
+      vscode.window.showWarningMessage('Prompt Registry: Unable to resolve Windows path from WSL. Prompts may not be visible to Copilot.');
+    }
+
+    // Non-WSL: parse the User dir from the globalStorage path
+    const userIndex = globalStoragePath.lastIndexOf(path.sep + 'User' + path.sep);
+    const userDir = userIndex === -1
+      ? path.dirname(path.dirname(globalStoragePath))
+      : globalStoragePath.substring(0, userIndex + path.sep.length + 'User'.length);
+
+    // Check if the globalStorage path itself contains a profile segment
     // Path structure: .../User/profiles/<profile-id>/globalStorage/...
     const remainingPath = globalStoragePath.substring(userDir.length);
+    const escapedSep = escapeRegex(path.sep);
     const profilesMatch = remainingPath.match(new RegExp(`^${escapedSep}profiles${escapedSep}([^${escapedSep}]+)`));
-
     if (profilesMatch) {
-      // Profile-based path: include the profile directory
       const profileId = profilesMatch[1];
       const profileName = this.getActiveProfileName(userDir) || profileId;
       this.logger.info(`[UserScopeService] Using profile: ${profileName}`);
       return path.join(userDir, 'profiles', profileId, 'prompts');
     }
+
+    return this.resolvePromptsFromUserDir(userDir);
+  }
+
+  /**
+   * Given a known User directory, resolve the prompts directory
+   * (handles profile detection for both WSL and non-WSL paths).
+   * @param userDir
+   */
+  private resolvePromptsFromUserDir(userDir: string): string {
+    this.logger.debug(`[UserScopeService] Resolved User directory: ${userDir}`);
 
     // Extension installed globally but user might be in a profile
     // Use combined detection method (storage.json + filesystem heuristic)
@@ -353,8 +439,12 @@ export class UserScopeService implements IScopeService {
           // Always remove existing symlink and recreate - simpler and more robust
           await unlink(file.targetPath);
           this.logger.debug(`Removed existing symlink: ${file.targetPath}`);
+        } else if (this.isRunningInWSL()) {
+          // WSL uses copies (not symlinks), so existing regular files are ours — overwrite
+          await unlink(file.targetPath);
+          this.logger.debug(`Removed existing copy for re-sync (WSL): ${file.targetPath}`);
         } else {
-          // It's a regular file - might be user's custom file, skip
+          // It's a regular file on non-WSL - might be user's custom file, skip
           this.logger.warn(`File already exists (not managed): ${file.targetPath}`);
           return;
         }
@@ -364,16 +454,23 @@ export class UserScopeService implements IScopeService {
       const targetDir = path.dirname(file.targetPath);
       await this.ensureDirectory(targetDir);
 
-      // Try to create symlink first (preferred)
-      try {
-        await symlink(file.sourcePath, file.targetPath, 'file');
-        this.logger.debug(`Created symlink: ${path.basename(file.targetPath)}`);
-      } catch {
-        // Symlink failed (maybe Windows or permissions), fall back to copy
-        this.logger.debug('Symlink failed, copying file instead');
+      // WSL: symlinks from Windows → WSL paths are broken from Windows' perspective,
+      // so always copy when running in WSL. On non-WSL, prefer symlinks.
+      if (this.isRunningInWSL()) {
         const content = await readFile(file.sourcePath, 'utf8');
         await writeFile(file.targetPath, content, 'utf8');
-        this.logger.debug(`Copied file: ${path.basename(file.targetPath)}`);
+        this.logger.debug(`Copied file (WSL): ${path.basename(file.targetPath)}`);
+      } else {
+        try {
+          await symlink(file.sourcePath, file.targetPath, 'file');
+          this.logger.debug(`Created symlink: ${path.basename(file.targetPath)}`);
+        } catch {
+          // Symlink failed (maybe Windows or permissions), fall back to copy
+          this.logger.debug('Symlink failed, copying file instead');
+          const content = await readFile(file.sourcePath, 'utf8');
+          await writeFile(file.targetPath, content, 'utf8');
+          this.logger.debug(`Copied file: ${path.basename(file.targetPath)}`);
+        }
       }
 
       this.logger.info(`✅ Synced ${file.type}: ${file.name} → ${path.basename(file.targetPath)}`);
@@ -578,6 +675,7 @@ export class UserScopeService implements IScopeService {
             // Check if file content matches source before deleting
             try {
               if (fs.existsSync(copilotFile.sourcePath)) {
+                this.logger.debug(`Target is a regular file, checking content before removal: ${path.basename(copilotFile.targetPath)}`);
                 const targetContent = await readFile(copilotFile.targetPath, 'utf8');
                 const sourceContent = await readFile(copilotFile.sourcePath, 'utf8');
 

--- a/test/mocha.setup.js
+++ b/test/mocha.setup.js
@@ -240,6 +240,7 @@ const vscode = {
     machineId: 'mock-machine-id',
     sessionId: 'mock-session-id',
     remoteName: undefined,
+    uriScheme: 'vscode',
     shell: '/bin/bash',
     isTelemetryEnabled: true,
     openExternal: (uri) => Promise.resolve(true),

--- a/test/services/user-scope-service.wsl.test.ts
+++ b/test/services/user-scope-service.wsl.test.ts
@@ -1,0 +1,290 @@
+/**
+ * UserScopeService WSL Support Tests
+ * Tests WSL-specific path resolution and remote environment handling
+ */
+
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import {
+  UserScopeService,
+} from '../../src/services/user-scope-service';
+import {
+  createMockBundleDirectory,
+} from '../helpers/bundle-test-helpers';
+
+suite('UserScopeService - WSL Support', () => {
+  // Use require() instead of import * — Node's cached module object has writable
+  // properties, whereas ES module namespace objects do not (non-configurable).
+  const childProcess = require('node:child_process');
+  let sandbox: sinon.SinonSandbox;
+  let tempDir: string;
+
+  setup(() => {
+    sandbox = sinon.createSandbox();
+    tempDir = path.join(__dirname, '..', '..', '..', 'test-temp-wsl');
+
+    if (!fs.existsSync(tempDir)) {
+      fs.mkdirSync(tempDir, { recursive: true });
+    }
+  });
+
+  teardown(() => {
+    sandbox.restore();
+    if (fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  const createMockContext = (globalStoragePath: string): any => ({
+    globalStorageUri: { fsPath: globalStoragePath },
+    storageUri: { fsPath: '/home/testuser/workspace' },
+    extensionPath: __dirname,
+    subscriptions: []
+  });
+
+  /**
+   * Sync a probe bundle and return the prompts directory where the file landed.
+   * Uses the shared createMockBundleDirectory helper, then exercises syncBundle
+   * to discover the resolved path.
+   * @param service
+   * @param parentDir
+   */
+  const getResolvedPromptsDir = async (service: UserScopeService, parentDir: string): Promise<string> => {
+    const bundleId = 'probe-bundle';
+    const bundlePath = createMockBundleDirectory({
+      basePath: path.join(parentDir, 'bundles'),
+      bundleId
+    });
+    await service.syncBundle(bundleId, bundlePath);
+    const targetFileName = 'test-prompt.prompt.md';
+    const found = findFile(tempDir, targetFileName);
+    assert.ok(found, `Expected to find ${targetFileName} under ${tempDir}`);
+    return path.dirname(found);
+  };
+
+  /**
+   * Recursively find a file by name under a directory.
+   * @param dir
+   * @param name
+   */
+  const findFile = (dir: string, name: string): string | undefined => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        const result = findFile(fullPath, name);
+        if (result) {
+          return result;
+        }
+      } else if (entry.name === name) {
+        return fullPath;
+      }
+    }
+    return undefined;
+  };
+
+  const stubWSLEnvironment = (
+    windowsHomePath: string,
+    uriScheme = 'vscode'
+  ): void => {
+    sandbox.stub(vscode.env, 'remoteName').value('wsl');
+    sandbox.stub(vscode.env, 'uriScheme').value(uriScheme);
+    // Production code calls .trim() on the result, so include trailing newline
+    sandbox.stub(childProcess, 'execSync').returns(windowsHomePath + '\n');
+  };
+
+  suite('Path Resolution (via wslpath)', () => {
+    test('should construct Windows prompts dir from wslpath output', async () => {
+      const windowsHome = path.join(tempDir, 'mnt', 'c', 'Users', 'testuser');
+      const globalStorage = path.join(tempDir, 'wsl-home');
+      stubWSLEnvironment(windowsHome, 'vscode');
+      const mockContext = createMockContext(globalStorage);
+      const service = new UserScopeService(mockContext);
+      const promptsDir = await getResolvedPromptsDir(service, globalStorage);
+
+      assert.strictEqual(promptsDir, path.join(windowsHome, 'AppData', 'Roaming', 'Code', 'User', 'prompts'));
+    });
+
+    const uriSchemeCases: Map<string, string> = new Map([
+      ['vscode', 'Code'],
+      ['vscode-insiders', 'Code - Insiders']
+    ]);
+
+    uriSchemeCases.forEach((expectedFolder, uriScheme) => {
+      test(`should map uriScheme '${uriScheme}' to folder '${expectedFolder}'`, async () => {
+        const windowsHome = path.join(tempDir, 'mnt', 'c', 'Users', 'testuser');
+        const globalStorage = path.join(tempDir, 'wsl-home');
+        stubWSLEnvironment(windowsHome, uriScheme);
+        const mockContext = createMockContext(globalStorage);
+        const service = new UserScopeService(mockContext);
+        const promptsDir = await getResolvedPromptsDir(service, globalStorage);
+
+        assert.ok(promptsDir.includes(expectedFolder));
+      });
+    });
+
+    test('should fall back to Code when uriScheme is unknown', async () => {
+      const windowsHome = path.join(tempDir, 'mnt', 'c', 'Users', 'testuser');
+      const globalStorage = path.join(tempDir, 'wsl-home');
+      stubWSLEnvironment(windowsHome, 'unknown-ide');
+      const mockContext = createMockContext(globalStorage);
+      const service = new UserScopeService(mockContext);
+      const promptsDir = await getResolvedPromptsDir(service, globalStorage);
+
+      assert.ok(promptsDir.includes('/Code/'), `Expected path to include '/Code/' but got: ${promptsDir}`);
+      assert.ok(!promptsDir.includes('Insiders'), `Expected path to NOT include 'Insiders' but got: ${promptsDir}`);
+    });
+
+    test('should fall through to globalStorageUri parsing when wslpath fails', async () => {
+      sandbox.stub(childProcess, 'execSync').throws(new Error('cmd.exe not found'));
+      sandbox.stub(vscode.env, 'remoteName').value('wsl');
+      const showWarningStub = sandbox.stub(vscode.window, 'showWarningMessage');
+      const globalStorage = path.join(tempDir, 'data', 'User', 'globalStorage');
+      const mockContext = createMockContext(globalStorage);
+      const service = new UserScopeService(mockContext);
+      const promptsDir = await getResolvedPromptsDir(service, globalStorage);
+
+      assert.ok(promptsDir.endsWith(path.join('User', 'prompts')));
+      assert.ok(showWarningStub.calledOnce, 'Expected a warning message when WSL path resolution fails');
+      assert.ok(
+        showWarningStub.firstCall.args[0].includes('Unable to resolve Windows path from WSL'),
+        'Warning message should mention WSL path resolution failure'
+      );
+    });
+  });
+
+  suite('File Operations', () => {
+    test('should create copies (not symlinks) when syncing in WSL', async () => {
+      const windowsUserDir = path.join(tempDir, 'Users', 'testuser');
+      const wslUserDir = path.join(tempDir, 'home', 'testuser');
+      stubWSLEnvironment(windowsUserDir, 'vscode');
+
+      const bundleId = 'test-bundle';
+      const bundlePath = path.join(wslUserDir, 'bundles', bundleId);
+      fs.mkdirSync(path.join(bundlePath, 'prompts'), { recursive: true });
+
+      const promptContent = 'My insanely good prompt. Hey AI, praise my exceeding intelligence ( Natural btw ) XD';
+      fs.writeFileSync(path.join(bundlePath, 'prompts', 'my-prompt.md'), promptContent);
+      fs.writeFileSync(path.join(bundlePath, 'deployment-manifest.yml'), [
+        `id: ${bundleId}`,
+        'version: "1.0.0"',
+        'name: Test Bundle',
+        'prompts:',
+        '  - id: my-prompt',
+        '    name: My Prompt',
+        '    file: prompts/my-prompt.md'
+      ].join('\n'));
+
+      const mockContext = createMockContext(wslUserDir);
+      const service = new UserScopeService(mockContext);
+      await service.syncBundle(bundleId, bundlePath);
+
+      const targetFile = path.join(windowsUserDir, 'AppData', 'Roaming', 'Code', 'User', 'prompts', 'my-prompt.prompt.md');
+      assert.ok(fs.existsSync(targetFile), 'Target file should exist');
+      assert.ok(!fs.lstatSync(targetFile).isSymbolicLink(), 'Target should be a regular file, not a symlink');
+      assert.strictEqual(fs.readFileSync(targetFile, 'utf8'), promptContent);
+    });
+
+    test('should delete copied file during unsync when content matches (CRLF-normalized)', async () => {
+      const windowsUserDir = path.join(tempDir, 'Users', 'testuser');
+      const globalStorageDir = path.join(tempDir, 'home', 'testuser');
+      stubWSLEnvironment(windowsUserDir, 'vscode');
+
+      const bundleId = 'test-bundle';
+      const bundlePath = path.join(globalStorageDir, 'bundles', bundleId);
+      fs.mkdirSync(path.join(bundlePath, 'prompts'), { recursive: true });
+
+      const promptContent = 'Line one\nLine two\nLine three';
+      fs.writeFileSync(path.join(bundlePath, 'prompts', 'my-prompt.md'), promptContent);
+      fs.writeFileSync(path.join(bundlePath, 'deployment-manifest.yml'), [
+        `id: ${bundleId}`,
+        'version: "1.0.0"',
+        'name: Test Bundle',
+        'prompts:',
+        '  - id: my-prompt',
+        '    name: My Prompt',
+        '    file: prompts/my-prompt.md',
+        '    type: prompt'
+      ].join('\n'));
+
+      const mockContext = createMockContext(globalStorageDir);
+      const service = new UserScopeService(mockContext);
+
+      await service.syncBundle(bundleId, bundlePath);
+
+      const targetFile = path.join(windowsUserDir, 'AppData', 'Roaming', 'Code', 'User', 'prompts', 'my-prompt.prompt.md');
+      assert.ok(fs.existsSync(targetFile), 'File should exist after sync');
+
+      // Simulate Windows converting LF → CRLF
+      const content = fs.readFileSync(targetFile, 'utf8');
+      fs.writeFileSync(targetFile, content.replace(/\n/g, '\r\n'), 'utf8');
+
+      assert.notStrictEqual(
+        fs.readFileSync(targetFile, 'utf8'),
+        promptContent,
+        'CRLF content should differ from original LF content'
+      );
+
+      await service.unsyncBundle(bundleId);
+
+      assert.ok(
+        !fs.existsSync(targetFile),
+        'File should be deleted after unsync even with CRLF line endings'
+      );
+    });
+  });
+
+  suite('Negative Cases', () => {
+    test('should NOT activate WSL mode when remoteName is undefined (local)', async () => {
+      sandbox.stub(vscode.env, 'remoteName').value(undefined);
+
+      const globalStorage = path.join(tempDir, 'Code', 'User', 'globalStorage', 'pub.ext');
+      const mockContext = createMockContext(globalStorage);
+      const service = new UserScopeService(mockContext);
+      const promptsDir = await getResolvedPromptsDir(service, globalStorage);
+
+      assert.ok(!promptsDir.includes('/mnt/'), `Local should not use WSL mount, got: ${promptsDir}`);
+      assert.ok(promptsDir.endsWith('prompts'), `Should end with prompts, got: ${promptsDir}`);
+    });
+
+    test('should NOT activate WSL mode when remoteName is ssh-remote', async () => {
+      sandbox.stub(vscode.env, 'remoteName').value('ssh-remote');
+
+      const globalStorage = path.join(tempDir, 'data', 'User', 'globalStorage', 'pub.ext');
+      const mockContext = createMockContext(globalStorage);
+      const service = new UserScopeService(mockContext);
+      const promptsDir = await getResolvedPromptsDir(service, globalStorage);
+
+      assert.ok(!promptsDir.includes('/mnt/'), `SSH should not use WSL mount, got: ${promptsDir}`);
+      assert.strictEqual(promptsDir, path.join(tempDir, 'data', 'User', 'prompts'));
+    });
+
+    test('should NOT activate WSL mode when remoteName is tunnel', async () => {
+      sandbox.stub(vscode.env, 'remoteName').value('tunnel');
+
+      const globalStorage = path.join(tempDir, 'data', 'User', 'globalStorage', 'pub.ext');
+      const mockContext = createMockContext(globalStorage);
+      const service = new UserScopeService(mockContext);
+      const promptsDir = await getResolvedPromptsDir(service, globalStorage);
+
+      assert.ok(!promptsDir.includes('/mnt/'), `Tunnel should not use WSL mount, got: ${promptsDir}`);
+      assert.ok(promptsDir.endsWith('prompts'));
+    });
+
+    test('should gracefully handle missing cmd.exe in WSL (no crash)', async () => {
+      sandbox.stub(vscode.env, 'remoteName').value('wsl');
+      sandbox.stub(childProcess, 'execSync').throws(new Error('cmd.exe not found'));
+
+      const globalStorage = path.join(tempDir, 'AppData', 'Roaming', 'Code', 'User', 'globalStorage', 'pub.ext');
+      const mockContext = createMockContext(globalStorage);
+      const service = new UserScopeService(mockContext);
+      const promptsDir = await getResolvedPromptsDir(service, globalStorage);
+
+      assert.ok(typeof promptsDir === 'string', 'Should return a valid string path');
+      assert.ok(promptsDir.length > 0, 'Path should not be empty');
+      assert.ok(promptsDir.endsWith('prompts'), 'Should still resolve to a prompts directory');
+    });
+  });
+});


### PR DESCRIPTION
## Description

Fix user-scope path detection and file syncing when the extension runs inside a WSL remote context. Previously, `UserScopeService` resolved the Copilot prompts directory using `globalStorageUri`, which points to the WSL filesystem — but GitHub Copilot's UI runs on the Windows host, so prompts must be written to the Windows `%APPDATA%` tree instead. This PR detects the WSL remote, resolves the correct Windows home via `wslpath`/`cmd.exe`, and uses file copies instead of symlinks (which are broken across the WSL ↔ Windows boundary).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test coverage improvement
- [x] 🔧 Configuration/build changes

## Related Issues

Closes #
Fixes #215
Relates to #215

## Changes Made

### `src/services/user-scope-service.ts`

- **WSL detection** (`isRunningInWSL`): checks `vscode.env.remoteName === 'wsl'` to decide whether the extension is running inside a WSL remote.
- **Windows home resolution** (`getWindowsHomeDirectoryInWSL`): runs `wslpath -u "$(cmd.exe /c echo %USERPROFILE%)"` to obtain the Windows user profile path translated to a WSL mount (e.g. `/mnt/c/Users/<User>`). Result is cached.
- **WSL User directory construction** (`getWindowsWslUserDir`): combines the Windows home with `AppData/Roaming/<IDE>/User`, using a new `appNameMap` to map `vscode.env.uriScheme` → the correct IDE folder name (`Code`, `Code - Insiders`, `Windsurf`, `Cursor`, `Kiro`).
- **Refactored `getCopilotPromptsDirectory`**: now delegates to `resolveCopilotPromptsDirectory` with caching, a sanity check on the resolved path, and a clean WSL vs non-WSL branch. The `User` directory is parsed inline from `globalStorageUri` (ternary: custom data-dir fallback vs standard `/User/` segment extraction).
- **Extracted `resolvePromptsFromUserDir`**: handles profile detection from either the WSL-constructed or parsed `User` directory.
- **File-copy strategy in WSL**: `createCopilotFile` now always copies files when in WSL (symlinks from a Windows path to the WSL filesystem are broken from Windows' perspective). Re-syncing overwrites existing copies instead of skipping them.
- **WSL-aware `getStatus`**: counts all regular files in the prompts directory (since there are no symlinks to distinguish managed from unmanaged files in WSL).

### `test/services/user-scope-service.wsl.test.ts` (new)

- 14 new tests covering WSL-specific behavior across three suites:
  - **Path Resolution** (8 tests): wslpath-based path construction, `uriScheme` → folder name mapping for all 5 IDE flavors, unknown scheme fallback, and wslpath failure fallback to `globalStorageUri` parsing.
  - **File Operations** (2 tests): verifies copies (not symlinks) are created during sync, and CRLF-normalized content comparison during unsync.
  - **Negative Cases** (4 tests): confirms WSL mode does not activate for local, SSH, or tunnel remotes, and gracefully handles missing `cmd.exe`.

### `test/services/user-scope-service.test.ts`

- Removed old WSL tests (6 tests) that were superseded by the new dedicated WSL test file.

### `test/mocha.setup.js`

- Added `uriScheme: 'vscode'` to the `vscode.env` mock so WSL tests can stub it via sinon.

### `.vscodeignore`

- Switched from the permissive development ignore list to a production-oriented ignore list that excludes source files, tests, configs, and development artifacts to reduce VSIX package size.

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

### Manual Testing Steps

1. Open a repository inside a WSL remote in VS Code.
2. Install a prompt bundle via the Prompt Registry marketplace at user scope.
3. Verify the bundle's prompt files are copied (not symlinked) to `%APPDATA%\Code\User\prompts\` on the Windows host (visible from `/mnt/c/Users/<User>/AppData/Roaming/Code/User/prompts/` inside WSL).
4. Confirm Copilot picks up the prompts from the Windows path.
5. Uninstall the bundle and verify the copies are removed.
6. Repeat with a VS Code profile active — prompts should land under the profile's `prompts/` directory.

### Tested On

- [ ] macOS
- [ ] Windows
- [x] Linux

- [x] VS Code Stable
- [ ] VS Code Insiders

## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Documentation

- [ ] README.md updated
- [ ] JSDoc comments added/updated
- [x] No documentation changes needed

## Additional Notes

- The `getWindowsHomeDirectoryInWSL` result is cached to avoid repeated `execSync` calls.
- `getCopilotPromptsDirectory` now caches its result for the lifetime of the service instance.
- Profile support works for WSL paths: `resolvePromptsFromUserDir` is shared between the WSL and non-WSL branches, so `storage.json`-based profile detection applies to both.
- The `.vscodeignore` change is unrelated housekeeping — it switches the ignore file to a production configuration for smaller VSIX packaging.

## Reviewer Guidelines

Please pay special attention to:

- The `execSync` call in `getWindowsHomeDirectoryInWSL` — ensure it handles edge cases (non-standard WSL setups, missing `cmd.exe`, spaces in Windows username).
- The file-copy-over-symlink strategy in WSL — confirm no user-managed prompt files are accidentally overwritten during re-sync.
- Profile detection correctness when running in WSL with a non-default VS Code profile.

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**
