### PR TITLE
feat: add periodic hub sync and auto source sync after hub sync

### DIFF
--- a/docs/contributor-guide/architecture/update-system.md
+++ b/docs/contributor-guide/architecture/update-system.md
@@ -68,7 +68,19 @@ class AutoUpdateService {
 }
 ```
 
+## Hub Sync Scheduler
+
+Separate from bundle update checks, `HubSyncScheduler` keeps the active hub configuration fresh:
+
+| Component | Responsibility |
+|-----------|---------------|
+| **HubSyncScheduler** | 24h periodic timer calling `HubManager.syncActiveHub()` |
+| **HubManager.onHubSynced** | Event fired after every hub sync (startup, manual, periodic) |
+
+Source sync is event-driven: a single `onHubSynced` listener in `extension.ts` triggers `syncAllSources({ silent: true })` after any hub sync, ensuring sources stay in sync regardless of how the hub sync was initiated.
+
 ## See Also
 
 - [Installation Flow](./installation-flow.md) — How updates are installed
 - [User Guide: Marketplace](../../user-guide/marketplace.md) — User-facing updates
+- [User Guide: Profiles and Hubs](../../user-guide/profiles-and-hubs.md) — Hub sync behavior

--- a/docs/user-guide/profiles-and-hubs.md
+++ b/docs/user-guide/profiles-and-hubs.md
@@ -39,12 +39,14 @@ When you select a hub:
 
 On first run, the extension automatically adds the **Awesome Copilot** source (`github/awesome-copilot`) as a default source. This ensures you have immediate access to community collections.
 
-### Auto-Sync on Startup
+### Automatic Hub Sync
 
-Each time VS Code starts, the active hub is automatically synchronized:
-- Hub configuration is refreshed from its source
-- All sources are synced for latest bundles
-- Tree view updates with current state
+The active hub is automatically synchronized to keep it up-to-date:
+- **On startup**: Hub configuration is refreshed each time VS Code starts
+- **Periodic**: Hub re-syncs every 24 hours while VS Code is open
+- **Manual**: Right-click hub → Sync Hub
+
+After every hub sync (startup, periodic, or manual), all sources are automatically re-synced and the tree view refreshes with the latest bundles.
 
 ### Commands
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -66,6 +66,9 @@ import {
   HubManager,
 } from './services/hub-manager';
 import {
+  HubSyncScheduler,
+} from './services/hub-sync-scheduler';
+import {
   LockfileManager,
 } from './services/lockfile-manager';
 import {
@@ -149,6 +152,9 @@ export class PromptRegistryExtension {
   private validateApmCommand: ValidateApmCommand | undefined;
   private createCollectionCommand: CreateCollectionCommand | undefined;
   private copilotIntegration: CopilotIntegration | undefined;
+
+  // Hub sync scheduler
+  private hubSyncScheduler: HubSyncScheduler | undefined;
 
   // Update notification services
   private updateScheduler: UpdateScheduler | undefined;
@@ -246,6 +252,23 @@ export class PromptRegistryExtension {
     this.hubCommands = new HubCommands(this.hubManager, this.registryManager, this.context);
     this.hubIntegrationCommands = new HubIntegrationCommands(this.hubManager, this.context);
     this.hubProfileCommands = new HubProfileCommands(this.context);
+
+    // Wire event-driven source sync after every hub sync (activation, manual, periodic).
+    // This replaces the ad-hoc syncAllSources call that was previously in syncActiveHub().
+    this.hubManager.onHubSynced(async (hubId) => {
+      this.logger.info(`Hub synced (${hubId}), syncing all sources...`);
+      try {
+        await this.sourceCommands!.syncAllSources({ silent: true });
+        vscode.commands.executeCommand('promptRegistry.refresh');
+      } catch (error) {
+        this.logger.warn('Source sync after hub sync failed', error as Error);
+      }
+    });
+
+    // Initialize periodic hub sync scheduler (24h interval)
+    this.hubSyncScheduler = new HubSyncScheduler(this.context, this.hubManager);
+    this.hubSyncScheduler.initialize(); // Synchronous — only starts timers
+
     // Note: scaffoldCommand is registered inline in command handler
     const addResourceCommand = new AddResourceCommand(this.context.extensionPath);
     const githubAuthCommand = new GitHubAuthCommand(this.registryManager);
@@ -1274,49 +1297,16 @@ export class PromptRegistryExtension {
   }
 
   /**
-   * Sync active hub configuration on every activation
-   * Ensures users always have the latest hub configuration
+   * Sync active hub configuration on every activation.
+   * Source sync and UI refresh are handled by the onHubSynced event listener.
    */
   private async syncActiveHub(): Promise<void> {
     try {
-      const hubManager = this.hubManager;
-      const sourceCommands = this.sourceCommands;
-
-      if (!hubManager || !sourceCommands) {
-        this.logger.warn('HubManager or SourceCommands not initialized, skipping hub sync');
+      if (!this.hubManager) {
+        this.logger.warn('HubManager not initialized, skipping hub sync');
         return;
       }
-
-      // Check if there's an active hub
-      const activeHub = await hubManager.getActiveHub();
-      if (!activeHub) {
-        this.logger.info('No active hub configured, skipping auto-sync');
-        return;
-      }
-
-      // Get active hub ID
-      const activeProfiles = await hubManager.listActiveHubProfiles();
-      if (activeProfiles.length === 0 || !activeProfiles[0].hubId) {
-        this.logger.warn('Active hub has no profiles or hub ID, skipping auto-sync');
-        return;
-      }
-
-      const activeHubId = activeProfiles[0].hubId;
-      this.logger.info(`Auto-syncing active hub: ${activeHubId}`);
-
-      // Sync hub configuration
-      await hubManager.syncHub(activeHubId);
-
-      // Sync all sources from the active hub in the background (non-blocking)
-      // This allows the extension to finish activation quickly so the webview can resolve
-      // and show cached bundles while sync happens progressively
-      sourceCommands.syncAllSources({ silent: true }).then(() => {
-        this.logger.info('Active hub synchronized successfully on activation');
-        // Refresh tree view after sync completes
-        vscode.commands.executeCommand('promptRegistry.refresh');
-      }).catch((error) => {
-        this.logger.warn('Background sync failed', error as Error);
-      });
+      await this.hubManager.syncActiveHub();
     } catch (error) {
       this.logger.warn('Failed to auto-sync active hub on activation', error as Error);
       // Don't fail extension activation if sync fails
@@ -1608,6 +1598,9 @@ export class PromptRegistryExtension {
 
       // Dispose telemetry event subscriptions
       this.telemetryService?.dispose();
+
+      // Dispose hub sync scheduler
+      this.hubSyncScheduler?.dispose();
 
       // Dispose update scheduler
       this.updateScheduler?.dispose();

--- a/src/services/hub-manager.ts
+++ b/src/services/hub-manager.ts
@@ -646,6 +646,20 @@ export class HubManager {
   }
 
   /**
+   * Sync the currently active hub from remote source.
+   * Resolves the active hub ID from storage and delegates to syncHub().
+   * No-ops silently if no hub is active.
+   */
+  public async syncActiveHub(): Promise<void> {
+    const activeHubId = await this.storage.getActiveHubId();
+    if (!activeHubId) {
+      this.logger.info('No active hub configured, skipping sync');
+      return;
+    }
+    await this.syncHub(activeHubId);
+  }
+
+  /**
    * Sync hub from remote source
    * @param hubId Hub identifier to sync
    */

--- a/src/services/hub-sync-scheduler.ts
+++ b/src/services/hub-sync-scheduler.ts
@@ -1,0 +1,124 @@
+/**
+ * Hub Sync Scheduler Service
+ * Periodically syncs the active hub configuration to keep it up-to-date
+ */
+
+import * as vscode from 'vscode';
+import {
+  Logger,
+} from '../utils/logger';
+import {
+  HubManager,
+} from './hub-manager';
+
+const SCHEDULER_CONSTANTS = {
+  SYNC_INTERVAL_MS: 24 * 60 * 60 * 1000 // 24 hours
+} as const;
+
+/**
+ * Schedules periodic hub sync to keep hub configuration fresh.
+ * Follows the UpdateScheduler pattern: setTimeout re-scheduling with overlap guard.
+ */
+export class HubSyncScheduler {
+  private readonly logger: Logger;
+  private scheduledSyncTimer?: NodeJS.Timeout;
+  private isSyncInProgress = false;
+  private isInitialized = false;
+  private readonly isTestEnvironment: boolean;
+
+  constructor(
+    context: vscode.ExtensionContext,
+    private readonly hubManager: HubManager
+  ) {
+    this.logger = Logger.getInstance();
+
+    // Test environment detection — same pattern as UpdateScheduler.
+    // Node.js timers keep the process alive, causing test runners to hang.
+    const isNodeTestEnvironment =
+      process.env.NODE_ENV === 'test'
+      || process.argv.some((arg) => arg.includes('mocha'))
+      || process.argv.some((arg) => arg.includes('test'));
+    const allowTimersOverride = process.env.HUB_SYNC_SCHEDULER_ALLOW_TIMERS_IN_TESTS === 'true';
+    this.isTestEnvironment = isNodeTestEnvironment && !allowTimersOverride;
+
+    // Register for automatic disposal when extension deactivates
+    if (context?.subscriptions) {
+      context.subscriptions.push({
+        dispose: () => this.dispose()
+      });
+    }
+  }
+
+  /**
+   * Schedule the next periodic hub sync using setTimeout with re-scheduling.
+   */
+  private schedulePeriodicSync(): void {
+    if (this.isTestEnvironment) {
+      this.logger.debug('Test environment detected, skipping periodic sync timers');
+      return;
+    }
+
+    // Clear existing timer
+    if (this.scheduledSyncTimer) {
+      clearTimeout(this.scheduledSyncTimer);
+      this.scheduledSyncTimer = undefined;
+    }
+
+    const intervalMs = SCHEDULER_CONSTANTS.SYNC_INTERVAL_MS;
+    this.logger.debug(`Scheduling periodic hub sync in ${intervalMs}ms`);
+
+    this.scheduledSyncTimer = setTimeout(async () => {
+      if (this.isSyncInProgress) {
+        this.logger.warn('Previous hub sync still in progress, skipping this cycle');
+        this.schedulePeriodicSync();
+        return;
+      }
+
+      this.isSyncInProgress = true;
+      try {
+        this.logger.info('Performing scheduled hub sync');
+        await this.hubManager.syncActiveHub();
+      } catch (error) {
+        this.logger.error('Scheduled hub sync failed', error as Error);
+      } finally {
+        this.isSyncInProgress = false;
+        this.schedulePeriodicSync();
+      }
+    }, intervalMs);
+  }
+
+  /**
+   * Start the periodic hub sync timer.
+   */
+  public initialize(): void {
+    if (this.isInitialized) {
+      this.logger.debug('HubSyncScheduler already initialized');
+      return;
+    }
+
+    this.logger.info('Initializing HubSyncScheduler');
+
+    if (this.isTestEnvironment) {
+      this.logger.debug('Test environment detected, skipping hub sync timers');
+    } else {
+      this.schedulePeriodicSync();
+    }
+
+    this.isInitialized = true;
+    this.logger.info('HubSyncScheduler initialized successfully');
+  }
+
+  /**
+   * Cleanup timers.
+   */
+  public dispose(): void {
+    this.logger.debug('Disposing HubSyncScheduler');
+
+    if (this.scheduledSyncTimer) {
+      clearTimeout(this.scheduledSyncTimer);
+      this.scheduledSyncTimer = undefined;
+    }
+
+    this.isInitialized = false;
+  }
+}

--- a/test/services/hub-manager.test.ts
+++ b/test/services/hub-manager.test.ts
@@ -294,6 +294,42 @@ suite('HubManager', () => {
     });
   });
 
+  suite('syncActiveHub()', () => {
+    test('should sync the active hub when one is set', async () => {
+      // Import and set as active
+      await hubManager.importHub(localRef, 'test-active');
+      await storage.setActiveHubId('test-active');
+
+      // Modify the source file to verify sync happened
+      const tempFixture = path.join(tempDir, 'sync-active-hub.yml');
+      const fixturePath = path.join(__dirname, '..', 'fixtures', 'hubs', 'valid-hub-config.yml');
+      fs.copyFileSync(fixturePath, tempFixture);
+
+      const config = yaml.load(fs.readFileSync(tempFixture, 'utf8')) as any;
+      config.metadata.maintainer = 'Active Sync Team';
+      fs.writeFileSync(tempFixture, yaml.dump(config));
+
+      // Re-import with the modified fixture so syncHub re-fetches it
+      const syncRef: HubReference = { type: 'local', location: tempFixture };
+      await hubManager.importHub(syncRef, 'test-active');
+      await storage.setActiveHubId('test-active');
+
+      // Now modify again to verify syncActiveHub picks it up
+      config.metadata.maintainer = 'Updated Active Sync Team';
+      fs.writeFileSync(tempFixture, yaml.dump(config));
+
+      await hubManager.syncActiveHub();
+
+      const loaded = await storage.loadHub('test-active');
+      assert.strictEqual(loaded.config.metadata.maintainer, 'Updated Active Sync Team');
+    });
+
+    test('should no-op silently when no active hub is set', async () => {
+      // No active hub set — should not throw
+      await hubManager.syncActiveHub();
+    });
+  });
+
   suite('Get Hub Info', () => {
     test('should get detailed hub information', async () => {
       await hubManager.importHub(localRef, 'test-info');

--- a/test/services/hub-sync-scheduler.test.ts
+++ b/test/services/hub-sync-scheduler.test.ts
@@ -1,0 +1,164 @@
+/**
+ * HubSyncScheduler Unit Tests
+ * Tests for periodic hub sync scheduling
+ */
+
+import * as assert from 'node:assert';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import {
+  HubManager,
+} from '../../src/services/hub-manager';
+import {
+  HubSyncScheduler,
+} from '../../src/services/hub-sync-scheduler';
+
+suite('HubSyncScheduler', () => {
+  let sandbox: sinon.SinonSandbox;
+  let clock: sinon.SinonFakeTimers;
+  let mockContext: vscode.ExtensionContext;
+  let mockHubManager: sinon.SinonStubbedInstance<HubManager>;
+  let scheduler: HubSyncScheduler;
+  let disposables: vscode.Disposable[];
+
+  const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
+
+  const originalEnv = process.env.HUB_SYNC_SCHEDULER_ALLOW_TIMERS_IN_TESTS;
+
+  setup(() => {
+    sandbox = sinon.createSandbox();
+    clock = sinon.useFakeTimers();
+
+    // Allow timers in tests so we can exercise the scheduling logic
+    process.env.HUB_SYNC_SCHEDULER_ALLOW_TIMERS_IN_TESTS = 'true';
+
+    disposables = [];
+    mockContext = {
+      subscriptions: disposables,
+      globalState: {} as any,
+      extensionPath: '/mock/path'
+    } as any;
+
+    mockHubManager = sandbox.createStubInstance(HubManager);
+    mockHubManager.syncActiveHub.resolves();
+  });
+
+  teardown(() => {
+    scheduler?.dispose();
+    clock.restore();
+    sandbox.restore();
+
+    if (originalEnv === undefined) {
+      delete process.env.HUB_SYNC_SCHEDULER_ALLOW_TIMERS_IN_TESTS;
+    } else {
+      process.env.HUB_SYNC_SCHEDULER_ALLOW_TIMERS_IN_TESTS = originalEnv;
+    }
+  });
+
+  suite('initialize()', () => {
+    test('should schedule periodic sync', async () => {
+      scheduler = new HubSyncScheduler(mockContext, mockHubManager as any);
+      scheduler.initialize();
+
+      // Advance 24h — should trigger sync
+      await clock.tickAsync(TWENTY_FOUR_HOURS_MS);
+      assert.strictEqual(mockHubManager.syncActiveHub.callCount, 1);
+    });
+
+    test('should not schedule if already initialized', async () => {
+      scheduler = new HubSyncScheduler(mockContext, mockHubManager as any);
+      scheduler.initialize();
+      scheduler.initialize(); // second call is a no-op
+
+      await clock.tickAsync(TWENTY_FOUR_HOURS_MS);
+      assert.strictEqual(mockHubManager.syncActiveHub.callCount, 1);
+    });
+  });
+
+  suite('periodic sync', () => {
+    test('should call hubManager.syncActiveHub() on each tick', async () => {
+      scheduler = new HubSyncScheduler(mockContext, mockHubManager as any);
+      scheduler.initialize();
+
+      await clock.tickAsync(TWENTY_FOUR_HOURS_MS);
+      assert.strictEqual(mockHubManager.syncActiveHub.callCount, 1);
+
+      await clock.tickAsync(TWENTY_FOUR_HOURS_MS);
+      assert.strictEqual(mockHubManager.syncActiveHub.callCount, 2);
+    });
+
+    test('should skip cycle if previous sync is still in progress', async () => {
+      // Make syncActiveHub hang until we resolve it
+      let resolveSync: () => void;
+      mockHubManager.syncActiveHub.callsFake(() => new Promise<void>((resolve) => {
+        resolveSync = resolve;
+      }));
+
+      scheduler = new HubSyncScheduler(mockContext, mockHubManager as any);
+      scheduler.initialize();
+
+      // Trigger first sync (will hang)
+      clock.tick(TWENTY_FOUR_HOURS_MS);
+      assert.strictEqual(mockHubManager.syncActiveHub.callCount, 1);
+
+      // Trigger second cycle while first is in progress — should be skipped
+      clock.tick(TWENTY_FOUR_HOURS_MS);
+      assert.strictEqual(mockHubManager.syncActiveHub.callCount, 1);
+
+      // Resolve the first sync
+      resolveSync!();
+      await clock.tickAsync(0);
+
+      // Now the next cycle should work
+      await clock.tickAsync(TWENTY_FOUR_HOURS_MS);
+      assert.strictEqual(mockHubManager.syncActiveHub.callCount, 2);
+    });
+
+    test('should continue scheduling after sync error', async () => {
+      mockHubManager.syncActiveHub
+        .onFirstCall().rejects(new Error('Network error'))
+        .onSecondCall().resolves();
+
+      scheduler = new HubSyncScheduler(mockContext, mockHubManager as any);
+      scheduler.initialize();
+
+      // First tick — fails
+      await clock.tickAsync(TWENTY_FOUR_HOURS_MS);
+      assert.strictEqual(mockHubManager.syncActiveHub.callCount, 1);
+
+      // Second tick — should still fire despite previous error
+      await clock.tickAsync(TWENTY_FOUR_HOURS_MS);
+      assert.strictEqual(mockHubManager.syncActiveHub.callCount, 2);
+    });
+  });
+
+  suite('dispose()', () => {
+    test('should clear scheduled timer', async () => {
+      scheduler = new HubSyncScheduler(mockContext, mockHubManager as any);
+      scheduler.initialize();
+
+      scheduler.dispose();
+
+      // Advance time — no sync should fire
+      await clock.tickAsync(TWENTY_FOUR_HOURS_MS);
+      assert.strictEqual(mockHubManager.syncActiveHub.callCount, 0);
+    });
+
+    test('should register on context.subscriptions for auto-disposal', () => {
+      scheduler = new HubSyncScheduler(mockContext, mockHubManager as any);
+      assert.strictEqual(disposables.length, 1);
+    });
+  });
+
+  suite('test environment', () => {
+    test('should skip timers in test environment', async () => {
+      delete process.env.HUB_SYNC_SCHEDULER_ALLOW_TIMERS_IN_TESTS;
+
+      scheduler = new HubSyncScheduler(mockContext, mockHubManager as any);
+      scheduler.initialize();
+
+      await clock.tickAsync(TWENTY_FOUR_HOURS_MS);
+      assert.strictEqual(mockHubManager.syncActiveHub.callCount, 0);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Hub is only synced on extension activation and via manual command. If VS Code stays open for days, users won't see new sources/profiles published to the hub. This adds periodic hub sync every 24h and event-driven source sync after every hub sync.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [x] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔧 Configuration/build changes

## Related Issues

N/A

## Changes Made

- **New `HubSyncScheduler` service** (`src/services/hub-sync-scheduler.ts`): Periodic 24h timer that calls `hubManager.syncActiveHub()`. Follows the `UpdateScheduler` pattern (setTimeout re-scheduling, overlap guard, test env detection, auto-disposal).
- **New `HubManager.syncActiveHub()` method** (`src/services/hub-manager.ts`): Convenience method that resolves the active hub ID from storage and delegates to `syncHub()`.
- **Event-driven source sync** (`src/extension.ts`): Single `onHubSynced` event subscription triggers `syncAllSources({ silent: true })` + tree refresh after any hub sync (activation, manual, or periodic).
- **Simplified `syncActiveHub()` in extension.ts**: Reduced from 45 lines to 10 by delegating to `hubManager.syncActiveHub()` and relying on event-driven source sync.
- **Documentation updates**: Updated user guide (profiles-and-hubs.md) and contributor architecture docs (update-system.md).

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing completed
- [x] All existing tests pass

### Manual Testing Steps

1. Start VS Code with the extension — verify hub syncs on activation (check output logs for "Hub synced" and "syncing all sources")
2. Manually sync hub via right-click → Sync Hub — verify sources are re-synced and tree view refreshes
3. Leave VS Code open for 24h (or modify `SYNC_INTERVAL_MS` temporarily) — verify periodic sync fires

### Tested On

- [x] macOS
- [ ] Windows
- [ ] Linux

- [ ] VS Code Stable
- [ ] VS Code Insiders

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Documentation

- [ ] README.md updated
- [x] JSDoc comments added/updated
- [ ] No documentation changes needed

Updated:
- `docs/user-guide/profiles-and-hubs.md` — Renamed "Auto-Sync on Startup" to "Automatic Hub Sync", documented all three sync triggers
- `docs/contributor-guide/architecture/update-system.md` — Added "Hub Sync Scheduler" section

## Additional Notes

The 6 pre-existing test failures in `bundle-scope-commands.property.test.ts` (`getContextMenuActions is not a function`) are unrelated to this PR.

## Reviewer Guidelines

Please pay special attention to:

- The event wiring in `extension.ts` — single `onHubSynced` listener replaces ad-hoc `syncAllSources` call
- The `HubSyncScheduler` pattern consistency with `UpdateScheduler`

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**