### PR TITLE
docs: realign AGENTS.md and add CLAUDE.md pointers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,32 +8,18 @@ Before working in any folder, **MUST READ** the corresponding AGENTS.md file:
 
 | Working in... | Read first |
 |---------------|------------|
-| `.kiro/specs/` | `.kiro/specs/AGENTS.md` — Guidance for specifications, design, and tasks |
-| `docs/` | `docs/AGENTS.md` — Documentation structure and update guidelines |
+| `docs/` | `docs/AGENTS.md` — Documentation structure, placement, and discovery |
 | `test/` | `test/AGENTS.md` — Test writing patterns and helpers |
-| `test/e2e/` | `test/e2e/AGENTS.md` — E2E test guidance |
-| `src/adapters/` | `src/adapters/AGENTS.md` — Adapter implementation guide |
+| `test/e2e/` | `test/e2e/AGENTS.md` — E2E test patterns |
+| `src/adapters/` | `src/adapters/AGENTS.md` — Adapter interface and implementation |
 | `src/services/` | `src/services/AGENTS.md` — Service layer patterns |
 
-**Before writing or modifying ANY file, you MUST:**
-1. **Identify which folder** the file is in (e.g., `test/services/NewService.test.ts` → folder is `test/`)
-2. **Read the corresponding AGENTS.md file FIRST** (e.g., `test/AGENTS.md`)
-3. **Apply the guidance** from that file to your changes
+**Before writing or modifying ANY file:**
+1. Identify which folder the file is in (e.g., `test/services/foo.test.ts` → `test/`)
+2. Read that folder's `AGENTS.md` first
+3. Apply its guidance
 
-**Concrete Examples:**
-- Creating `test/services/NewService.test.ts` → **MUST read `test/AGENTS.md` BEFORE writing any test code**
-- Modifying `src/adapters/GitHubAdapter.ts` → **MUST read `src/adapters/AGENTS.md` BEFORE making changes**
-- Writing `.kiro/specs/new-feature/design.md` → **MUST read `.kiro/specs/AGENTS.md` BEFORE creating the spec**
-- Updating `docs/user-guide/getting-started.md` → **MUST read `docs/AGENTS.md` BEFORE editing documentation**
-- Creating `src/services/NewManager.ts` → **MUST read `src/services/AGENTS.md` BEFORE implementing the service**
-- Adding `test/e2e/new-workflow.test.ts` → **MUST read `test/e2e/AGENTS.md` BEFORE writing E2E tests**
-
-**Failure to read these guides will result in:**
-- Broken tests due to incorrect VS Code mocking
-- Duplicated utilities that already exist
-- Missing critical debugging strategies
-- Wasted time on solved problems
-- Code that doesn't follow established patterns
+Skipping these guides leads to broken VS Code mocks, duplicated utilities, and deviation from established patterns.
 
 ---
 
@@ -71,62 +57,13 @@ Use TDD when it makes sense (most new functionality):
 2. Write the minimum code to make it pass
 3. Refactor if needed, keeping tests green
 
-### 🚨 E2E Testing: NEVER Reimplement Production Code 🚨
+### E2E Testing
 
-**E2E tests must invoke the actual code path, NOT duplicate it.**
-
-This is a critical mistake that defeats the purpose of E2E testing:
-
-❌ **WRONG**: Manually calling internal methods with the same logic as production code
-```typescript
-// This is NOT an E2E test - it duplicates production code!
-const result = await scopeConflictResolver.migrateBundle(
-    bundleId, 'repository', 'user',
-    async () => { await registryManager.uninstallBundle(bundleId, 'repository'); },
-    async (bundle, scope) => { await registryManager.installBundle(bundleId, { scope }); }
-);
-```
-
-✅ **CORRECT**: Test through the actual entry point
-```typescript
-// Option 1: VS Code Extension Tests (test/suite/*.test.ts) - runs in real VS Code
-await vscode.commands.executeCommand('promptRegistry.moveToUser', bundleId);
-
-// Option 2: Test through the command handler class
-const bundleScopeCommands = new BundleScopeCommands(registryManager, resolver, service);
-await bundleScopeCommands.moveToUser(bundleId);
-```
-
-**Why this matters:**
-- If production code has a bug, duplicated test code has the same bug
-- Tests don't catch regressions when production code changes
-- Tests don't verify command registration wiring in `extension.ts`
-
-**See `test/AGENTS.md` for detailed E2E testing guidance.**
+E2E tests must invoke actual code paths, never reimplement production code. See `test/e2e/AGENTS.md` for detailed patterns and examples.
 
 ### Test Completion Criteria
 
-**CRITICAL**: Before marking any test-related task as complete, verify ALL of the following:
-
-1. **Compilation**: All test files must compile without TypeScript errors
-2. **Mock Setup**: All mocks must be properly configured (no "Property 'X' is private" errors, no type mismatches)
-3. **Execution**: Tests must be runnable (even if they fail assertions - that's expected in RED phase)
-4. **RED Phase**: For TDD tasks, tests should fail for the RIGHT reason (missing implementation), not wrong reasons (broken mocks, syntax errors, import errors)
-
-**If tests won't run due to setup issues YOU introduced, the task is incomplete.**
-
-**What counts as YOUR responsibility:**
-- Mock setup issues caused by your code changes
-- Type errors introduced by your implementation
-- Compilation failures from your new code
-- Import errors from files you created
-
-**What does NOT count:**
-- Pre-existing test failures
-- Flaky tests that were already flaky
-- Infrastructure issues (network, file system)
-
-**Before stopping work on a task**: Run the tests to verify they compile and mocks are properly set up. If you introduced compilation errors or mock issues, fix them first.
+See `test/AGENTS.md` for the full test completion checklist. Key rule: if tests won't run due to setup issues **you** introduced, the task is incomplete.
 
 ### Minimal Code Principle
 
@@ -181,14 +118,14 @@ src/
 
 | File | Purpose |
 |------|---------|
-| `src/services/RegistryManager.ts` | Main entrypoint, event emitters |
-| `src/services/BundleInstaller.ts` | Download/extract/validate/install logic |
-| `src/services/LockfileManager.ts` | Lockfile CRUD for repository-scoped bundles |
-| `src/services/UserScopeService.ts` | User/workspace scope file placement |
-| `src/services/RepositoryScopeService.ts` | Repository scope file placement |
-| `src/adapters/*` | Source implementations (github, local, awesome-copilot, apm) |
-| `src/storage/RegistryStorage.ts` | Persistent paths and JSON layout |
-| `src/services/MigrationRegistry.ts` | globalState-based migration tracker |
+| `src/services/registry-manager.ts` | Main entrypoint, event emitters |
+| `src/services/bundle-installer.ts` | Download/extract/validate/install logic |
+| `src/services/lockfile-manager.ts` | Lockfile CRUD for repository-scoped bundles |
+| `src/services/user-scope-service.ts` | User/workspace scope file placement |
+| `src/services/repository-scope-service.ts` | Repository scope file placement |
+| `src/adapters/*` | Source implementations (github, awesome-copilot, apm, skills, and local variants) |
+| `src/storage/registry-storage.ts` | Persistent paths and JSON layout |
+| `src/services/migration-registry.ts` | globalState-based migration tracker |
 | `src/migrations/` | Migration scripts (one file per migration) |
 | `src/commands/*` | Command handlers wiring UI to services |
 
@@ -202,18 +139,11 @@ src/
 npm install                    # Install dependencies
 npm run compile                # Production webpack bundle
 npm run watch                  # Dev watch mode
-
-# Testing (always prefix with LOG_LEVEL=ERROR unless debugging)
-npm run test:one -- test/services/MyService.test.ts
-LOG_LEVEL=ERROR npm run test:unit
-LOG_LEVEL=ERROR npm test
-
-# Capture test output for analysis
-LOG_LEVEL=ERROR npm test 2>&1 | tee test.log | tail -20
-
 npm run lint                   # ESLint (v9 flat config: eslint.config.mjs)
 npm run package:vsix           # Create .vsix package
 ```
+
+For test commands and debugging strategies, see `test/AGENTS.md`.
 
 ### Log Management
 
@@ -273,7 +203,7 @@ This finds every file with dual-read fallback, legacy functions, and migration l
 ## Quick Examples
 
 ### Add a new adapter
-Copy `src/adapters/HttpAdapter.ts`, implement `fetchBundles()`/`getDownloadUrl()`/`validate()`, register in `RegistryManager`.
+Copy `src/adapters/github-adapter.ts` (or the closest existing adapter), implement `IRepositoryAdapter` (see `src/adapters/AGENTS.md`), and register via `RepositoryAdapterFactory.register('type', AdapterClass)` in `RegistryManager`.
 
 ### Fix bundle validation
 Update `BundleInstaller.validateBundle()` — manifest version must match bundle.version unless `'latest'`.
@@ -294,45 +224,7 @@ Open extension global storage path (see `RegistryStorage.getPaths().installed`) 
 
 ## **MANDATORY** Documentation Updates
 
-**After implementing features or fixing bugs, you MUST update documentation.** Consult [`docs/README.md`](docs/README.md) to identify which files need updates.
-
-| Change type | Update these docs |
-|-------------|-------------------|
-| New command | `docs/reference/commands.md` |
-| New setting | `docs/reference/settings.md` |
-| New adapter | `docs/contributor-guide/architecture/adapters.md`, `docs/reference/adapter-api.md` |
-| Installation/update flow changes | `docs/contributor-guide/architecture/installation-flow.md`, `docs/contributor-guide/architecture/update-system.md` |
-| UI changes | `docs/contributor-guide/architecture/ui-components.md` |
-| User-facing behavior | Relevant file in `docs/user-guide/` |
-| Schema changes | `docs/author-guide/collection-schema.md` or `docs/reference/hub-schema.md` |
-
-**Documentation standards:**
-1. **Keep it concise** — One clear sentence beats three vague ones
-2. **Update the right file** — See [docs/AGENTS.md](docs/AGENTS.md) for file placement guidance
-3. **Verify accuracy** — Ensure docs match the implemented behavior
-
----
-
-## **MANDATORY** Documentation Discovery
-
-**Before planning or implementing features**, consult the documentation index at [`docs/README.md`](docs/README.md) to understand existing designs and user-facing behavior.
-
-| Working on... | Read first |
-|---------------|------------|
-| Installation/update flows | `docs/contributor-guide/architecture/installation-flow.md`, `docs/contributor-guide/architecture/update-system.md` |
-| Adapters (GitHub, Local, etc.) | `docs/contributor-guide/architecture/adapters.md`, `docs/reference/adapter-api.md` |
-| Authentication | `docs/contributor-guide/architecture/authentication.md` |
-| UI (Marketplace, TreeView) | `docs/contributor-guide/architecture/ui-components.md` |
-| Validation logic | `docs/contributor-guide/architecture/validation.md` |
-| MCP integration | `docs/contributor-guide/architecture/mcp-integration.md` |
-| Commands or settings | `docs/reference/commands.md`, `docs/reference/settings.md` |
-| Bundle/collection schemas | `docs/author-guide/collection-schema.md`, `docs/reference/hub-schema.md` |
-| Testing strategy | `docs/contributor-guide/testing.md` |
-
-**Why this matters:**
-- Prevents reimplementing existing documented behavior
-- Ensures new code aligns with documented architecture
-- Avoids breaking user-facing contracts described in user guides
+**After implementing features or fixing bugs, you MUST update documentation.** See [docs/AGENTS.md](docs/AGENTS.md) for file placement guidance, documentation discovery, and standards.
 
 ---
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -26,6 +26,22 @@ docs/
 | Contributors | `contributor-guide/` | Dev setup, architecture, testing, coding standards |
 | Developers | `reference/` | Commands, settings, APIs, schemas |
 
+## Documentation Discovery
+
+**Before planning or implementing features**, consult the documentation index at [`README.md`](README.md) to understand existing designs and user-facing behavior.
+
+| Working on... | Read first |
+|---------------|------------|
+| Installation/update flows | `contributor-guide/architecture/installation-flow.md`, `contributor-guide/architecture/update-system.md` |
+| Adapters (GitHub, Local, etc.) | `contributor-guide/architecture/adapters.md`, `reference/adapter-api.md` |
+| Authentication | `contributor-guide/architecture/authentication.md` |
+| UI (Marketplace, TreeView) | `contributor-guide/architecture/ui-components.md` |
+| Validation logic | `contributor-guide/architecture/validation.md` |
+| MCP integration | `contributor-guide/architecture/mcp-integration.md` |
+| Commands or settings | `reference/commands.md`, `reference/settings.md` |
+| Bundle/collection schemas | `author-guide/collection-schema.md`, `reference/hub-schema.md` |
+| Testing strategy | `contributor-guide/testing.md` |
+
 ## Updating Documentation
 
 ### When to Update
@@ -38,19 +54,24 @@ Update documentation when:
 
 ### Guidelines
 
-1. **Keep it concise** — Avoid verbose explanations. One clear sentence beats three vague ones.
+1. **Keep it concise** — One clear sentence beats three vague ones.
 2. **Match the audience** — User docs should avoid implementation details. Contributor docs can be technical.
 3. **Update the right file** — Place content where users expect to find it based on their role.
 4. **Maintain links** — When moving or renaming files, update all references.
 5. **Use Mermaid diagrams** — Prefer Mermaid diagrams over ASCII diagrams for visual representations, except for file structure/tree displays where ASCII is more appropriate.
+6. **Verify accuracy** — Ensure docs match the implemented behavior.
 
-### File Placement
+### File Placement by Change Type
 
-| Content Type | Location |
-|--------------|----------|
-| New VS Code command | `reference/commands.md` |
-| New extension setting | `reference/settings.md` |
-| User-facing feature | `user-guide/` (appropriate file) |
+| Change Type | Update These Docs |
+|-------------|-------------------|
+| New command | `reference/commands.md` |
+| New setting | `reference/settings.md` |
+| New adapter | `contributor-guide/architecture/adapters.md`, `reference/adapter-api.md` |
+| Installation/update flow changes | `contributor-guide/architecture/installation-flow.md`, `contributor-guide/architecture/update-system.md` |
+| UI changes | `contributor-guide/architecture/ui-components.md` |
+| User-facing behavior | Relevant file in `user-guide/` |
+| Schema changes | `author-guide/collection-schema.md` or `reference/hub-schema.md` |
 | Repository-level installation | `user-guide/repository-installation.md` |
 | Collection authoring | `author-guide/` (appropriate file) |
 | Development process | `contributor-guide/` (appropriate file) |

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/docs/contributor-guide/testing.md
+++ b/docs/contributor-guide/testing.md
@@ -1,26 +1,44 @@
 # Testing Guide
 
-This guide covers testing practices for the Prompt Registry extension.
+How to run tests in the Prompt Registry extension.
+
+> **For test writing patterns** (style, helpers, anti-patterns, deduplication rules), see [`test/AGENTS.md`](../../test/AGENTS.md). This file covers commands and tooling only.
+
+## Testing Architecture
+
+The project uses a **two-tier** test layout, both running under **Mocha TDD style** (`suite` / `test` / `assert`):
+
+| Tier | Location | Runs In | Purpose |
+|------|----------|---------|---------|
+| Unit / Property / E2E (mocked) | `test/{services,adapters,commands,ui,utils,storage,e2e}/**/*.test.ts` | Node.js with `vscode` mocked via `test/mocha.setup.js` | Pure logic, data flow, multi-component workflows |
+| Integration (real VS Code) | `test/suite/**/*.test.ts` | Electron via `test/runExtensionTests.js` | Extension activation, command registration, UI wiring |
+
+Tests compile to `test-dist/` first (`npm run compile-tests`) — Mocha runs the compiled JS.
 
 ## Quick Start
 
 ```bash
-# Run all tests
+# All tests (unit + integration)
 LOG_LEVEL=ERROR npm test
 
-# Run specific test file
-npm run test:one -- test/services/MyService.test.ts
-
-# Run unit tests only
+# Unit / property / e2e only (no VS Code host)
 LOG_LEVEL=ERROR npm run test:unit
 
-# Run with coverage
-LOG_LEVEL=ERROR npm run test:coverage
+# Integration tests (real VS Code)
+npm run test:integration
+
+# Single file (auto-compiles)
+npm run test:one -- test/services/bundle-installer.test.ts
+
+# Coverage
+npm run test:coverage            # all tests
+npm run test:coverage:unit       # unit only, c8 html report
+npm run test:coverage:integration # integration only
 ```
 
-Use `LOG_LEVEL=ERROR` to suppress debug output and keep test results readable.
+Use `LOG_LEVEL=ERROR` to suppress debug output.
 
-## Test Structure
+## Test Directory Layout
 
 ```
 test/
@@ -30,183 +48,43 @@ test/
 ├── storage/            # Storage tests
 ├── ui/                 # UI component tests
 ├── utils/              # Utility tests
-├── e2e/                # End-to-end workflow tests
+├── e2e/                # Multi-component workflow tests (mocked VS Code)
+├── suite/              # Real VS Code integration tests
 ├── fixtures/           # Test data and mock responses
 ├── helpers/            # Shared test utilities
-└── mocks/              # Mock implementations
+├── mocks/              # Mock implementations
+├── mocha.setup.js      # Mocks `require('vscode')` before tests load
+└── vscode-mock.js      # VS Code API mock implementation
 ```
 
 ## Test Types
 
 | Type | Suffix | Purpose |
 |------|--------|---------|
-| Unit | `.test.ts` | Single component isolation |
-| Property | `.property.test.ts` | Invariant testing with fast-check |
-| Integration | `.integration.test.ts` | Multi-component interaction |
-| E2E | `test/e2e/*.test.ts` | Full workflow validation |
+| Unit | `.test.ts` | Single component |
+| Property | `.property.test.ts` | Invariant testing with `fast-check` |
+| E2E | `test/e2e/*.test.ts` | Multi-component workflows (mocked VS Code) |
+| Integration | `test/suite/*.test.ts` | Real VS Code extension host |
 
-## Writing Tests
-
-### Basic Pattern
-
-```typescript
-import * as assert from 'assert';
-import * as sinon from 'sinon';
-
-suite('ComponentName', () => {
-    let sandbox: sinon.SinonSandbox;
-
-    setup(() => { sandbox = sinon.createSandbox(); });
-    teardown(() => { sandbox.restore(); });
-
-    suite('methodName()', () => {
-        test('should handle expected case', async () => {
-            // Arrange
-            const input = createTestInput();
-            
-            // Act
-            const result = await component.method(input);
-            
-            // Assert
-            assert.strictEqual(result.status, 'success');
-        });
-    });
-});
-```
-
-### Using Test Helpers
-
-The project provides shared utilities in `test/helpers/`:
-
-```typescript
-import {
-    BundleBuilder,
-    createMockInstalledBundle,
-    createMockUpdateCheckResult
-} from '../helpers/bundleTestHelpers';
-
-import {
-    BundleGenerators,
-    PropertyTestConfig,
-    ErrorCheckers
-} from '../helpers/propertyTestHelpers';
-
-import {
-    LockfileBuilder,
-    createMockLockfile,
-    LockfileGenerators
-} from '../helpers/lockfileTestHelpers';
-
-import {
-    setupReleaseMocks,
-    createBundleZip,
-    createMockGitHubSource
-} from '../helpers/repositoryFixtureHelpers';
-
-// Create test bundles
-const bundle = BundleBuilder.github('owner', 'repo').withVersion('1.0.0').build();
-const installed = createMockInstalledBundle('bundle-id', '1.0.0');
-
-// Create test lockfiles
-const lockfile = new LockfileBuilder()
-    .withBundle('bundle-id', { version: '1.0.0', sourceId: 'source-1' })
-    .build();
-```
-
-### Property-Based Tests
-
-Use fast-check for property-based testing:
-
-```typescript
-import * as fc from 'fast-check';
-import { PropertyTestConfig, BundleGenerators } from '../helpers/propertyTestHelpers';
-
-test('property: version parsing is consistent', async function() {
-    this.timeout(PropertyTestConfig.TIMEOUT);
-    
-    await fc.assert(
-        fc.asyncProperty(BundleGenerators.version(), async (version) => {
-            const parsed = parseVersion(version);
-            return parsed !== null;
-        }),
-        { numRuns: PropertyTestConfig.RUNS.STANDARD, ...PropertyTestConfig.FAST_CHECK_OPTIONS }
-    );
-});
-```
-
-### HTTP Mocking
-
-Use nock for HTTP request mocking:
-
-```typescript
-import nock from 'nock';
-
-setup(() => {
-    nock('https://api.github.com')
-        .get('/repos/owner/repo/releases')
-        .reply(200, mockReleases);
-});
-
-teardown(() => {
-    nock.cleanAll();
-});
-```
-
-## Test Fixtures
-
-Test fixtures are in `test/fixtures/`:
-
-| Directory | Contents |
-|-----------|----------|
-| `github/` | GitHub API mock responses |
-| `hubs/` | Hub configuration files |
-| `local-library/` | Local bundle fixtures |
-| `collections-validator/` | Collection validation test cases |
-| `apm/` | APM package fixtures |
-
-## Running Tests
-
-### Available Scripts
+## Debugging
 
 ```bash
-npm test                    # Run all tests
-npm run test:unit           # Unit tests only
-npm run test:integration    # Integration tests (requires VS Code)
-npm run test:coverage       # Generate coverage report
-npm run test:one -- <path>  # Run single test file
-```
-
-### Debugging Tests
-
-```bash
-# Run with debug output
 LOG_LEVEL=DEBUG npm run test:one -- test/path/to/test.ts
 
-# Capture output for analysis
+# Capture for analysis
 LOG_LEVEL=ERROR npm test 2>&1 | tee test.log | tail -20
 ```
 
-## Best Practices
-
-1. **Check helpers first** — Use existing utilities from `test/helpers/` before creating new ones
-2. **Mock external boundaries** — Mock HTTP, file system, and VS Code APIs, not internal services
-3. **Test behavior, not implementation** — Assert on outcomes, not internal state
-4. **Use descriptive names** — Test names should explain what behavior is being verified
-5. **Clean up resources** — Always restore stubs and clean mocks in teardown
-
 ## Coverage
 
-Run coverage reports:
-
 ```bash
-npm run test:coverage           # Full coverage
-npm run test:coverage:unit      # Unit test coverage only
+npm run test:coverage:unit    # c8 html output in coverage/
 ```
 
-Coverage reports are generated in the `coverage/` directory.
+Coverage reports are written to the `coverage/` directory.
 
 ## See Also
 
-- [test/AGENTS.md](../../test/AGENTS.md) — Detailed test writing patterns
-- [test/fixtures/README.md](../../test/fixtures/README.md) — Fixture documentation
+- [`test/AGENTS.md`](../../test/AGENTS.md) — Test writing patterns, helpers, anti-patterns
+- [`test/e2e/AGENTS.md`](../../test/e2e/AGENTS.md) — E2E-specific guidance
 - [Development Setup](./development-setup.md) — Environment setup

--- a/src/adapters/AGENTS.md
+++ b/src/adapters/AGENTS.md
@@ -2,42 +2,65 @@
 
 ## Purpose
 
-Adapters provide a unified interface for different prompt bundle sources (GitHub, Local, Awesome Copilot).
+Adapters provide a unified interface for prompt bundle sources (GitHub, Local, Awesome Copilot, APM, Skills, and their local variants).
 
 ## Adding a New Adapter
 
-1. Copy an existing adapter (e.g., `GitHubAdapter.ts`)
-2. Implement `IRepositoryAdapter` interface
-3. Register in `RepositoryAdapterFactory`
+1. Copy an existing adapter (e.g., `github-adapter.ts`)
+2. Extend `RepositoryAdapter` (see `repository-adapter.ts`) — it implements shared auth/header logic
+3. Register in `RegistryManager` via `RepositoryAdapterFactory.register('type', AdapterClass)`
 
-### Required Methods
+## Interface
+
+`IRepositoryAdapter` (defined in `src/adapters/repository-adapter.ts`):
 
 ```typescript
 interface IRepositoryAdapter {
-    fetchBundles(source: RegistrySource): Promise<Bundle[]>;
-    getDownloadUrl(bundle: Bundle): Promise<string | Buffer>;
-    validate(source: RegistrySource): Promise<boolean>;
+  readonly type: string;
+  readonly source: RegistrySource;
+
+  fetchBundles(): Promise<Bundle[]>;
+  downloadBundle(bundle: Bundle): Promise<Buffer>;
+  fetchMetadata(): Promise<SourceMetadata>;
+  validate(): Promise<ValidationResult>;
+  requiresAuthentication(): boolean;
+  getManifestUrl(bundleId: string, version?: string): string;
+  getDownloadUrl(bundleId: string, version?: string): string;
+  forceAuthentication?(): Promise<void>;   // optional
 }
 ```
 
-### Two Download Patterns
-
-| Pattern | Return Type | Used By | When |
-|---------|-------------|---------|------|
-| URL-based | `string` | GitHub | Pre-packaged bundles |
-| Buffer-based | `Buffer` | Awesome Copilot, Local | Dynamically created bundles |
+- `downloadBundle` always returns a `Buffer` — whether the source provides pre-packaged ZIPs (GitHub) or builds them dynamically (Awesome Copilot, Local).
+- `getDownloadUrl` / `getManifestUrl` return `string` URLs — used for UI display and debug links, not for the actual download (which goes through `downloadBundle`).
+- `validate` returns a `ValidationResult` (not a boolean) — contains error details for user-facing diagnostics.
 
 ## Authentication Chain (GitHub)
 
-1. Explicit token from source configuration
-2. VS Code GitHub authentication session
+Resolved in order:
+1. Explicit `token` on `RegistrySource`
+2. VS Code GitHub authentication session (`vscode.authentication.getSession('github', ...)`)
 3. GitHub CLI (`gh auth token`)
 4. No auth (public repos only)
 
+## Existing Adapters
+
+| File | Type |
+|------|------|
+| `github-adapter.ts` | Remote GitHub repo releases |
+| `awesome-copilot-adapter.ts` | Awesome Copilot repo (dynamic bundle assembly) |
+| `apm-adapter.ts` | Remote APM registry |
+| `skills-adapter.ts` | Remote Skills source |
+| `local-adapter.ts` | Local filesystem bundles |
+| `local-apm-adapter.ts` | Local APM registry |
+| `local-awesome-copilot-adapter.ts` | Local Awesome Copilot clone |
+| `local-skills-adapter.ts` | Local Skills source |
+
 ## Checklist
 
-- [ ] Extends `RepositoryAdapter` base class
-- [ ] Implements all three methods
-- [ ] Handles authentication appropriately
-- [ ] Returns proper error messages
+- [ ] Extends `RepositoryAdapter`
+- [ ] Implements all required `IRepositoryAdapter` methods
+- [ ] Returns `Buffer` from `downloadBundle`
+- [ ] Returns `ValidationResult` from `validate` with actionable error messages
+- [ ] Handles authentication via inherited helpers where possible
+- [ ] Registered in `RepositoryAdapterFactory`
 - [ ] Has corresponding test file in `test/adapters/`

--- a/src/adapters/CLAUDE.md
+++ b/src/adapters/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/src/services/CLAUDE.md
+++ b/src/services/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -8,8 +8,6 @@ Efficient test writing patterns for this repository.
 
 **Tests MUST verify expected behavior through public entry points, NEVER implementation details.**
 
-### The Rule
-
 | ✅ DO | ❌ DON'T |
 |-------|----------|
 | Test public methods and their observable outcomes | Test private methods or internal state |
@@ -17,52 +15,7 @@ Efficient test writing patterns for this repository.
 | Mock external boundaries (HTTP, file system, VS Code API) | Mock internal collaborators within the same module |
 | Write tests that survive refactoring | Write tests that break when internals change |
 
-### What This Means in Practice
-
-**Unit Tests**: Test the public API of a class/module
-```typescript
-// ✅ CORRECT: Testing public behavior
-test('should return installed bundles sorted by name', async () => {
-    const result = await registryManager.getInstalledBundles();
-    assert.strictEqual(result[0].name, 'alpha-bundle');
-});
-
-// ❌ WRONG: Testing implementation details
-test('should call _sortBundles internally', async () => {
-    const spy = sandbox.spy(registryManager, '_sortBundles');
-    await registryManager.getInstalledBundles();
-    assert.ok(spy.called); // This tests HOW, not WHAT
-});
-```
-
-**Integration Tests**: Test real scenarios end-to-end
-```typescript
-// ✅ CORRECT: Testing a real user scenario
-test('should install bundle from GitHub and make it available', async () => {
-    await registryManager.installBundle('owner/repo');
-    const installed = await registryManager.getInstalledBundles();
-    assert.ok(installed.some(b => b.id === 'owner/repo'));
-});
-
-// ❌ WRONG: Testing internal coordination
-test('should call adapter then installer then storage', async () => {
-    const adapterSpy = sandbox.spy(adapter, 'fetchBundle');
-    const installerSpy = sandbox.spy(installer, 'install');
-    const storageSpy = sandbox.spy(storage, 'save');
-    await registryManager.installBundle('owner/repo');
-    assert.ok(adapterSpy.calledBefore(installerSpy)); // Fragile!
-    assert.ok(installerSpy.calledBefore(storageSpy)); // Fragile!
-});
-```
-
-### Why This Matters
-
-1. **Refactoring freedom**: Tests that focus on behavior allow you to change implementation without breaking tests
-2. **Meaningful failures**: When a behavior test fails, it means actual functionality is broken
-3. **Documentation value**: Behavior tests document what the code does, not how it does it
-4. **Reduced maintenance**: Implementation-focused tests require constant updates as code evolves
-
-### Red Flags Your Test Is Testing Implementation
+### Red Flags (test is coupled to implementation)
 
 - Spying on private methods (`_methodName`)
 - Asserting on call counts of internal methods
@@ -72,19 +25,41 @@ test('should call adapter then installer then storage', async () => {
 
 ---
 
+## Test Stack
+
+This repo uses **Mocha TDD style** (`suite` / `test` / `assert`) for **all** tests — unit, property, e2e, and suite. There is no Vitest, no Playwright suite.
+
+| Test Type | Location | Runs In | Purpose |
+|-----------|----------|---------|---------|
+| Unit | `test/{services,adapters,commands,ui,utils,storage}/*.test.ts` | Node with `test/mocha.setup.js` mocking `vscode` | Individual classes/methods |
+| Property | `test/**/*.property.test.ts` | Same as unit | Invariants via `fast-check` |
+| E2E (mocked VS Code) | `test/e2e/*.test.ts` | Same as unit | Multi-component workflows |
+| Integration (real VS Code) | `test/suite/*.test.ts` | Electron via `test/runExtensionTests.js` | Commands, activation, UI wiring |
+
+Tests compile to `test-dist/` first (`npm run compile-tests`), then Mocha runs the compiled JS.
+
 ## Commands
 
 ```bash
-# Run specific test (no LOG_LEVEL needed for debugging)
-npm run test:one -- test/services/MyService.test.ts
-
-# Run unit/all tests (use LOG_LEVEL to reduce noise)
+# Compile + run all unit/property/e2e (excludes test/suite/)
 LOG_LEVEL=ERROR npm run test:unit
+
+# Compile + run everything (unit + integration in real VS Code)
 LOG_LEVEL=ERROR npm test
 
-# Capture output once, analyze multiple times
-LOG_LEVEL=ERROR npm run test:unit 2>&1 | tee test-output.log
-grep "passing\|failing" test-output.log
+# Integration tests only (real VS Code instance)
+npm run test:integration
+
+# Single file by path (auto-compiles)
+npm run test:one -- test/services/bundle-installer.test.ts
+
+# Coverage
+npm run test:coverage          # all tests with c8
+npm run test:coverage:unit     # unit only, c8 + html report
+
+# Capture output once, analyze many times
+LOG_LEVEL=ERROR npm run test:unit 2>&1 | tee test.log | tail -20
+grep -E "passing|failing" test.log
 ```
 
 ---
@@ -94,26 +69,12 @@ grep "passing\|failing" test-output.log
 **Check existing patterns BEFORE writing tests.**
 
 ```bash
-# Find similar tests
 ls test/services/   # or adapters/, commands/, ui/
-
-# Check helpers
 cat test/helpers/bundle-test-helpers.ts
 cat test/helpers/property-test-helpers.ts
 ```
 
-If utilities exist, **USE THEM**. Don't recreate.
-
----
-
-## Test Types
-
-| Type | Suffix | Purpose |
-|------|--------|---------|
-| Unit | `.test.ts` | Single component |
-| Property | `.property.test.ts` | Invariant testing |
-| Integration | `.integration.test.ts` | Multi-component |
-| E2E | `test/e2e/` | Full workflows |
+If a helper exists, **USE IT**. Don't recreate.
 
 ---
 
@@ -122,16 +83,12 @@ If utilities exist, **USE THEM**. Don't recreate.
 ### One Class = Maximum Two Test Files
 
 For any class `MyService`:
-- `MyService.test.ts` - Unit tests (specific examples, edge cases)
-- `MyService.property.test.ts` - Property tests (invariants across inputs)
+- `my-service.test.ts` — Unit tests (specific examples, edge cases)
+- `my-service.property.test.ts` — Property tests (invariants across inputs)
 
 **That's it. No more files.**
 
-❌ **NEVER create:**
-- `MyServiceBehaviorA.test.ts`
-- `MyServiceBehaviorB.test.ts`  
-- `MyServiceIntegration.test.ts`
-- `ExtensionMyServiceUsage.test.ts`
+❌ **NEVER create:** `MyServiceBehaviorA.test.ts`, `MyServiceIntegration.test.ts`, `ExtensionMyServiceUsage.test.ts`
 
 ### Unit vs Property: No Overlap
 
@@ -144,191 +101,142 @@ For any class `MyService`:
 
 **If you wrote a unit test for it, DON'T write a property test for the same thing.**
 
-```typescript
-// ✅ Unit test: specific example
-test('should return expected state after operation', async () => {
-    await service.doOperation();
-    assert.strictEqual(await service.getState(), ExpectedState.DONE);
-});
+### E2E: Commands Only, Not Methods
 
-// ✅ Property test: invariant across ALL inputs (different concern)
-test('state is always valid after any operation sequence', async () => {
-    await fc.assert(fc.asyncProperty(
-        fc.array(fc.constantFrom('op1', 'op2', 'op3')),
-        async (ops) => {
-            // ... apply ops
-            return isValidState(await service.getState());
-        }
-    ));
-});
-
-// ❌ WRONG: Property test that duplicates unit test
-test('doOperation sets state to DONE', async () => {
-    await fc.assert(fc.asyncProperty(
-        fc.integer({ min: 1, max: 10 }), // Pointless variation
-        async (count) => {
-            await service.doOperation();
-            return await service.getState() === ExpectedState.DONE; // Same as unit test!
-        }
-    ));
-});
-```
-
-### E2E Tests: Commands Only, Not Methods
-
-E2E tests verify **user-facing commands**, not internal methods.
-
-```typescript
-// ✅ CORRECT E2E: Tests actual VS Code command
-test('command resets application state', async () => {
-    await vscode.commands.executeCommand('myExtension.resetState');
-    // Assert on observable outcome
-});
-
-// ❌ WRONG E2E: Just calls the same method as unit tests
-test('should reset state', async () => {
-    await stateManager.reset(); // This is a UNIT test, not E2E!
-    assert.strictEqual(await stateManager.getState(), State.INITIAL);
-});
-```
+E2E tests verify **user-facing commands**, not internal methods. See `test/e2e/AGENTS.md`.
 
 ### Before Writing Tests: Search First
 
 ```bash
-# Check if behavior is already tested
-grep -r "the behavior you want to test" test/ --include="*.test.ts" | head -10
-
-# If you find existing tests, ADD to that file, don't create new file
+grep -r "behavior you want to test" test/ --include="*.test.ts" | head -10
 ```
 
-### Consolidation Checklist
-
-Before creating a new test file, verify:
-- [ ] No existing test file for this class
-- [ ] Behavior isn't already covered in property tests
-- [ ] E2E test actually uses VS Code commands, not direct method calls
-- [ ] Test file count for this feature ≤ 3
+If tests exist, **add to that file** — don't create new files.
 
 ---
 
-## Template
+## Template (Mocha TDD — used for all tests)
 
 ```typescript
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 import * as sinon from 'sinon';
-import { BundleBuilder, createMockInstalledBundle } from '../helpers/bundle-test-helpers';
+import {
+  BundleBuilder,
+  createMockInstalledBundle,
+} from '../helpers/bundle-test-helpers';
 
 suite('ComponentName', () => {
-    let sandbox: sinon.SinonSandbox;
+  let sandbox: sinon.SinonSandbox;
 
-    // ===== Utilities FIRST =====
-    const resetAllMocks = (): void => { /* reset stubs */ };
+  setup(() => {
+    sandbox = sinon.createSandbox();
+  });
 
-    setup(() => { sandbox = sinon.createSandbox(); });
-    teardown(() => { sandbox.restore(); });
+  teardown(() => {
+    sandbox.restore();
+  });
 
-    suite('methodName()', () => {
-        test('should handle success case', async () => {
-            // Arrange → Act → Assert
-        });
+  suite('methodName()', () => {
+    test('handles success case', async () => {
+      // Arrange → Act → Assert
+      assert.strictEqual(actual, expected);
     });
+  });
 });
 ```
 
+> Integration tests in `test/suite/` use the **same** Mocha TDD style but run in a real VS Code extension host — inside them you can call `vscode.commands.executeCommand(...)` and activate the extension.
+
 ---
 
-## Key Helpers
+## Key Helpers (real exports, see each file for full API)
 
-### bundleTestHelpers.ts
+### `test/helpers/bundle-test-helpers.ts`
 ```typescript
 import {
-    BundleBuilder,                // Fluent builder for Bundle
-    createMockInstalledBundle,    // Factory for InstalledBundle
-    createMockUpdateCheckResult,  // Factory for UpdateCheckResult
-    setupUpdateAvailable,         // Mock setup for updates
-    resetBundleCommandsMocks      // Reset all mocks
+  BundleBuilder,                // Fluent builder for Bundle
+  createMockInstalledBundle,    // Factory for InstalledBundle
+  createMockUpdateCheckResult,
 } from '../helpers/bundle-test-helpers';
 
 const bundle = BundleBuilder.github('owner', 'repo').withVersion('1.0.0').build();
 const installed = createMockInstalledBundle('bundle-id', '1.0.0');
 ```
 
-### lockfileTestHelpers.ts
+### `test/helpers/lockfile-test-helpers.ts`
 ```typescript
 import {
-    LockfileBuilder,              // Fluent builder for Lockfile
-    createMockLockfile,           // Factory for quick mock generation
-    LockfileGenerators            // fast-check generators for property tests
+  LockfileBuilder,
+  createMockLockfile,
+  LockfileGenerators,
 } from '../helpers/lockfile-test-helpers';
-
-const lockfile = new LockfileBuilder()
-    .withBundle('bundle-id', { version: '1.0.0', sourceId: 'source-1' })
-    .withSource('source-1', { type: 'github', url: 'https://github.com/org/repo' })
-    .build();
 ```
 
-### repositoryFixtureHelpers.ts
+### `test/helpers/repository-fixture-helpers.ts`
 ```typescript
 import {
-    setupReleaseMocks,            // Configure nock for GitHub releases
-    createBundleZip,              // Generate valid bundle ZIP
-    createDeploymentManifest,     // Generate deployment manifest
-    createMockGitHubSource,       // Create mock GitHub source
-    cleanupReleaseMocks           // Clear nock mocks
+  setupReleaseMocks,
+  createBundleZip,
+  createDeploymentManifest,
+  createMockGitHubSource,
+  cleanupReleaseMocks,
 } from '../helpers/repository-fixture-helpers';
 
-// Set up GitHub release mocks for E2E tests
 setupReleaseMocks(
-    { owner: 'test-owner', repo: 'test-repo', manifestId: 'test-bundle' },
-    [{ tag: 'v1.0.0', version: '1.0.0', content: 'initial' }]
+  { owner: 'test-owner', repo: 'test-repo', manifestId: 'test-bundle' },
+  [{ tag: 'v1.0.0', version: '1.0.0', content: 'initial' }]
 );
 ```
 
-### propertyTestHelpers.ts
+### `test/helpers/property-test-helpers.ts`
 ```typescript
 import {
-    BundleGenerators,     // version(), bundleId()
-    PropertyTestConfig,   // RUNS.QUICK, FAST_CHECK_OPTIONS
-    ErrorCheckers         // indicatesAuthIssue(), indicatesNetworkIssue()
+  BundleGenerators,
+  PropertyTestConfig,
+  ErrorCheckers,
 } from '../helpers/property-test-helpers';
 
+import * as fc from 'fast-check';
+
 await fc.assert(
-    fc.asyncProperty(BundleGenerators.bundleId(), async (id) => { return true; }),
-    { ...PropertyTestConfig.FAST_CHECK_OPTIONS, numRuns: PropertyTestConfig.RUNS.QUICK }
+  fc.asyncProperty(BundleGenerators.bundleId(), async (id) => true),
+  { ...PropertyTestConfig.FAST_CHECK_OPTIONS, numRuns: PropertyTestConfig.RUNS.QUICK }
 );
 ```
+
+See also: `e2e-test-helpers.ts`, `auto-update-test-helpers.ts`, `marketplace-test-helpers.ts`, `ui-test-helpers.ts`, `process-test-helpers.ts`, `setup-state-test-helpers.ts`.
 
 ---
 
 ## VS Code Mocking
 
-Project uses `test/mocha.setup.js` for VS Code API mocks. If you get "Cannot read properties of undefined":
-1. Check if API is in `test/mocha.setup.js`
-2. Add missing APIs there first
+`test/mocha.setup.js` intercepts `require('vscode')` and loads `test/vscode-mock.js`. If you see `Cannot read properties of undefined` for a `vscode.*` API:
+
+1. Check `test/vscode-mock.js` — add missing APIs there first
+2. For per-test stubs, use sinon against the already-loaded mock
 
 ```typescript
-const mockContext: vscode.ExtensionContext = {
-    globalState: {
-        get: (key, def) => globalStateData.get(key) ?? def,
-        update: async (key, val) => { globalStateData.set(key, val); },
-        keys: () => Array.from(globalStateData.keys()),
-        setKeysForSync: sandbox.stub()
-    } as any,
-    globalStorageUri: vscode.Uri.file('/mock/storage'),
-    // ... see existing tests for full pattern
-} as vscode.ExtensionContext;
+const mockContext: any = {
+  globalState: {
+    get: (key: string, def: any) => globalStateData.get(key) ?? def,
+    update: async (key: string, val: any) => { globalStateData.set(key, val); },
+    keys: () => Array.from(globalStateData.keys()),
+    setKeysForSync: sandbox.stub(),
+  },
+  globalStorageUri: { fsPath: '/mock/storage' },
+};
 ```
 
 ---
 
-## HTTP Mocking
+## HTTP Mocking (nock)
 
 ```typescript
 import nock from 'nock';
 
 nock('https://api.github.com')
-    .get('/repos/owner/repo/releases')
-    .reply(200, mockData);
+  .get('/repos/owner/repo/releases')
+  .reply(200, mockData);
 
 teardown(() => { nock.cleanAll(); });
 ```
@@ -337,159 +245,33 @@ teardown(() => { nock.cleanAll(); });
 
 ## Anti-Patterns
 
-### 🚨 Implementation Testing (FORBIDDEN)
+### E2E: Never Reimplement Production Code
+See `test/e2e/AGENTS.md` for details. E2E tests must invoke actual code paths through VS Code commands or command handler classes, never duplicate production logic.
 
-❌ **NEVER** spy on private methods: `sandbox.spy(service, '_internalMethod')`
-❌ **NEVER** assert on internal call counts: `assert.ok(internalSpy.calledOnce)`
-❌ **NEVER** test internal state: `assert.strictEqual(service._cache.size, 3)`
-❌ **NEVER** mock internal collaborators: `sandbox.stub(service, '_helper')`
+### When to Prefer `test/suite/` (Real VS Code)
 
-✅ **ALWAYS** test through public entry points
-✅ **ALWAYS** assert on observable outcomes (return values, side effects, errors)
-✅ **ALWAYS** mock only external boundaries (HTTP, file system, VS Code API)
-
-### 🚨 E2E Tests: NEVER Reimplement Production Code (CRITICAL)
-
-**E2E tests must invoke the actual code path, NOT duplicate it.**
-
-❌ **WRONG**: Manually calling internal methods with the same logic as production code:
-```typescript
-// This is NOT an E2E test - it's reimplementing production code!
-test('should migrate bundle from repository to user scope', async () => {
-    const scopeConflictResolver = new ScopeConflictResolver(storage);
-    
-    // ❌ WRONG: This duplicates BundleScopeCommands.moveToUser() logic
-    const result = await scopeConflictResolver.migrateBundle(
-        bundleId,
-        'repository',
-        'user',
-        async () => {
-            await registryManager.uninstallBundle(bundleId, 'repository');
-        },
-        async (bundle, scope) => {
-            await registryManager.installBundle(bundleId, { scope, version: bundle.version });
-        }
-    );
-    
-    assert.ok(result.success);
-});
-```
-
-**Why this is wrong:**
-1. If production code has a bug (e.g., wrong scope parameter), the test has the same bug
-2. If production code changes, the test doesn't catch regressions
-3. The test doesn't verify the actual command wiring in `extension.ts`
-
-✅ **CORRECT**: Test through the actual entry point:
-
-**Option 1: VS Code Extension Tests** (runs in real VS Code via `@vscode/test-electron`)
-```typescript
-// In test/suite/integration-scenarios.test.ts
-test('should migrate bundle via moveToUser command', async () => {
-    // Setup: Install bundle at repository scope
-    await vscode.commands.executeCommand('promptRegistry.installBundle', bundleId, {
-        scope: 'repository', version: '1.0.0'
-    });
-    
-    // Act: Execute the actual VS Code command
-    await vscode.commands.executeCommand('promptRegistry.moveToUser', bundleId);
-    
-    // Assert: Verify end state (files moved, lockfile updated)
-    const userBundles = await storage.getInstalledBundles('user');
-    assert.ok(userBundles.some(b => b.bundleId === bundleId));
-});
-```
-
-**Option 2: Test through the Command Handler Class**
-```typescript
-// If you can't run in VS Code, at least test through the actual class
-test('should migrate bundle via BundleScopeCommands.moveToUser', async () => {
-    // Create the actual command handler (like extension.ts does)
-    const bundleScopeCommands = new BundleScopeCommands(
-        registryManager,
-        scopeConflictResolver,
-        repositoryScopeService
-    );
-    
-    // Call the actual method that the VS Code command invokes
-    await bundleScopeCommands.moveToUser(bundleId);
-    
-    // Assert on end state
-    const userBundles = await storage.getInstalledBundles('user');
-    assert.ok(userBundles.some(b => b.bundleId === bundleId));
-});
-```
-
-### Test Infrastructure Overview
-
-| Test Type | Location | Runs In | Use For |
-|-----------|----------|---------|---------|
-| Unit Tests | `test/**/*.test.ts` | Node.js with mocked VS Code | Testing individual classes/methods |
-| Integration Tests | `test/e2e/*.test.ts` | Node.js with mocked VS Code | Testing multi-component workflows |
-| VS Code Extension Tests | `test/suite/*.test.ts` | Real VS Code instance | Testing actual commands and UI |
-
-**To run VS Code extension tests:**
-```bash
-node test/runExtensionTests.js
-```
-
-### 🚨 DECISION: When to Use Real VS Code Instance Tests 🚨
-
-**Before writing complex mock setups, ask: Would this test be simpler and more reliable in a real VS Code instance?**
+**Before writing complex mock setups, ask: would this be simpler in a real VS Code instance?**
 
 | Scenario | Recommendation |
 |----------|----------------|
-| Testing VS Code commands (`vscode.commands.executeCommand`) | ✅ Real VS Code (`test/suite/`) |
-| Testing UI interactions (TreeView, WebView, QuickPick) | ✅ Real VS Code (`test/suite/`) |
-| Testing file system operations with workspace folders | ✅ Real VS Code (`test/suite/`) |
-| Testing extension activation and lifecycle | ✅ Real VS Code (`test/suite/`) |
-| Testing pure business logic with no VS Code dependencies | ✅ Unit tests with mocks |
-| Testing HTTP/network interactions | ✅ Unit tests with nock |
-| Testing data transformations and utilities | ✅ Unit tests with mocks |
+| Testing `vscode.commands.executeCommand` | ✅ `test/suite/` |
+| Testing TreeView, WebView, QuickPick interactions | ✅ `test/suite/` |
+| Testing activation lifecycle | ✅ `test/suite/` |
+| Pure business logic, no VS Code | ✅ Unit test with mock |
+| HTTP / data transform | ✅ Unit test with nock |
 
-**Red flags that your test needs real VS Code:**
-- Mock setup exceeds 50 lines
-- You're mocking 5+ VS Code APIs in one test
-- Test logic duplicates production code to "simulate" VS Code behavior
-- Tests are brittle and break when VS Code API changes
-- You're fighting TypeScript to make mocks type-compatible
-
-**Benefits of real VS Code tests:**
-- No mock maintenance burden
-- Tests actual integration with VS Code APIs
-- Catches real-world issues mocks would miss
-- Simpler test code, easier to understand
-
-**Trade-offs:**
-- Slower execution (launches VS Code instance)
-- Requires display or xvfb for CI
-- Harder to isolate specific behaviors
-
-**When in doubt**: If your mock setup is becoming complex and error-prone, move the test to `test/suite/` and run it in a real VS Code instance. A working test in real VS Code is better than a broken test with elaborate mocks.
-
-### 🚨 Test Duplication (FORBIDDEN)
-
-❌ **NEVER** create multiple test files for the same class
-❌ **NEVER** write property tests that just repeat unit test assertions with random inputs
-❌ **NEVER** write E2E tests that call internal methods instead of commands
-❌ **NEVER** copy production code into test helper classes
-❌ **NEVER** test the same behavior in multiple files
-
-✅ **ALWAYS** search for existing tests before writing new ones
-✅ **ALWAYS** add tests to existing files rather than creating new files
-✅ **ALWAYS** ensure unit/property/E2E tests cover DIFFERENT concerns
-✅ **ALWAYS** test through actual VS Code commands in E2E tests
+**Red flags that you need real VS Code:** mock setup > 50 lines, mocking 5+ VS Code APIs, test duplicates production logic to simulate VS Code behavior.
 
 ### Other Anti-Patterns
 
-❌ Over-mocking: `sandbox.createStubInstance(MyService)`
-✅ Real instances: `new MyService(mockContext)` + stub externals only
+❌ Over-mocking: `sandbox.createStubInstance(MyService)` for the class under test
+✅ Real instances: `new MyService(mockContext)` + stub external boundaries only
 
-❌ Duplicate utilities when helpers exist
+❌ Duplicating utilities when helpers exist in `test/helpers/`
 ✅ Import from `test/helpers/`
 
 ❌ Repeatedly modifying test fixtures when tests fail
-✅ First verify if the bug is in production code by reading error messages carefully
+✅ First read the error message carefully — if output shows data transformation, the bug is in production code
 
 ---
 
@@ -497,20 +279,17 @@ node test/runExtensionTests.js
 
 ### Determine Fault Location First
 
-Before iterating on fixes, determine if the bug is in **test code** or **production code**:
+Before iterating on fixes, decide: bug in **test code** or **production code**?
 
-1. **Parse the error message**: `expected X, got Y` - where does `Y` come from?
-2. **If `Y` is a transformation of your input** (e.g., `v1.0.0` → `1.0.0`), the bug is likely in production code
-3. **Add debug logging to production code**: Use `LOG_LEVEL=DEBUG` and add temporary logging to trace data flow
-4. **Check multiple code paths**: Different methods may handle the same data differently
+1. **Parse the error**: `expected X, got Y` — where does `Y` come from?
+2. **If `Y` is a transformation of input** (e.g., `v1.0.0` → `1.0.0`), the bug is likely in production code
+3. **Add debug logging to production code**: `LOG_LEVEL=DEBUG` + temporary logs to trace data flow
+4. **Check multiple code paths**: different methods may handle the same data differently
 
 ### Debug Logging Strategy
 
 ```bash
-# Run with debug logging
 LOG_LEVEL=DEBUG npm run test:one -- test/path/to/test.ts 2>&1 | grep -E "(keyword1|keyword2)" | head -30
-
-# Capture full output for analysis
 LOG_LEVEL=DEBUG npm run test:one -- test/path/to/test.ts 2>&1 | tee debug.log | tail -50
 ```
 
@@ -526,11 +305,10 @@ LOG_LEVEL=DEBUG npm run test:one -- test/path/to/test.ts 2>&1 | tee debug.log | 
 
 ## Naming
 
-**Files**: `Component.test.ts`, `Component.behavior.test.ts`
-**Never**: `.fix.test.ts`, `.bugfix.test.ts`
-
-**Descriptions**: `'should find bundle via identity matching'`
-**Never**: `'should fix the bug'`
+- **Files**: `component.test.ts`, `component.property.test.ts`
+- **Never**: `.fix.test.ts`, `.bugfix.test.ts`
+- **Descriptions**: `'finds bundle via identity matching'`
+- **Never**: `'should fix the bug'`
 
 ---
 
@@ -551,14 +329,28 @@ const response = require('../fixtures/github/releases-response.json');
 
 ## Checklist
 
-- [ ] **Tests verify behavior through public entry points, NOT implementation details**
+- [ ] Tests verify behavior through public entry points, NOT implementation details
 - [ ] Checked `test/helpers/` for existing utilities
-- [ ] Found similar tests in same category
-- [ ] **Searched for existing tests covering this behavior** (`grep -r "behavior" test/`)
-- [ ] **Test file count for this class ≤ 2** (unit + property only)
-- [ ] **Unit and property tests cover DIFFERENT concerns** (no overlap)
-- [ ] **E2E tests use VS Code commands, not direct method calls**
-- [ ] Using Mocha TDD style (`suite`, `test`)
-- [ ] Behavior-focused names
+- [ ] Searched for existing tests covering this behavior (`grep -r "behavior" test/`)
+- [ ] Test file count for this class ≤ 2 (unit + property only)
+- [ ] Unit and property tests cover DIFFERENT concerns
+- [ ] E2E tests in `test/e2e/` use command handler classes or actual entry points
+- [ ] Integration tests in `test/suite/` use real VS Code commands
+- [ ] Mocha TDD style (`suite`, `test`, `assert`) throughout
 - [ ] Mocking only external boundaries (HTTP, file system, VS Code API)
-- [ ] **Considered if test would be simpler in real VS Code instance** (if mock setup is complex)
+
+---
+
+## Test Completion Criteria
+
+Before marking any test-related task as complete, verify:
+
+1. **Compilation**: Test files compile (`npm run compile-tests`) with no TS errors
+2. **Mock setup**: No `Property 'X' is private` errors, no type mismatches
+3. **Execution**: Tests are runnable (assertion failures are acceptable in RED phase)
+4. **RED phase (for TDD)**: Tests fail for the RIGHT reason (missing impl), not broken mocks or imports
+
+**If tests won't run due to setup issues YOU introduced, the task is incomplete.**
+
+- **Your responsibility**: mock setup, type errors, compilation, import errors from your changes
+- **Not your responsibility**: pre-existing failures, flaky tests, infrastructure issues

--- a/test/CLAUDE.md
+++ b/test/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/test/e2e/AGENTS.md
+++ b/test/e2e/AGENTS.md
@@ -1,105 +1,76 @@
 # E2E Test Writing Guide
 
-This guide provides patterns and best practices for writing End-to-End tests in the Prompt Registry extension.
+Patterns for End-to-End tests in `test/e2e/`. See `test/AGENTS.md` for the base test stack (Mocha TDD style).
 
 ---
 
-## 🚨 CRITICAL: NEVER Reimplement Production Code in E2E Tests 🚨
+## 🚨 CRITICAL: NEVER Reimplement Production Code 🚨
 
 **E2E tests must invoke the actual code path, NOT duplicate it.**
 
-### ❌ WRONG: Duplicating Production Code Logic
+### ❌ WRONG: Duplicating Production Logic
 
 ```typescript
-// This is NOT an E2E test - it reimplements BundleScopeCommands.moveToUser()!
-test('should migrate bundle from repository to user scope', async () => {
-    const scopeConflictResolver = new ScopeConflictResolver(storage);
-    
-    // ❌ WRONG: This duplicates the production code logic
-    const result = await scopeConflictResolver.migrateBundle(
-        bundleId,
-        'repository',
-        'user',
-        async () => {
-            await registryManager.uninstallBundle(bundleId, 'repository');
-        },
-        async (bundle, scope) => {
-            await registryManager.installBundle(bundleId, { scope, version: bundle.version });
-        }
-    );
-    
-    assert.ok(result.success);
+// Not an E2E test — this reimplements BundleScopeCommands.moveToUser()
+test('migrates bundle from repository to user scope', async () => {
+  const scopeConflictResolver = new ScopeConflictResolver(storage);
+
+  const result = await scopeConflictResolver.migrateBundle(
+    bundleId,
+    'repository',
+    'user',
+    async () => { await registryManager.uninstallBundle(bundleId, 'repository'); },
+    async (bundle, scope) => { await registryManager.installBundle(bundleId, { scope, version: bundle.version }); }
+  );
+
+  assert.ok(result.success);
 });
 ```
 
 **Why this is wrong:**
-1. If production code has a bug (e.g., wrong scope parameter), the test has the same bug
-2. If production code changes, the test doesn't catch regressions
-3. The test doesn't verify the actual command wiring in `extension.ts`
-4. You're testing your test code, not the production code
+1. If production has a bug (e.g., wrong scope param), the test has the same bug
+2. If production changes, the test doesn't catch regressions
+3. The test doesn't verify command wiring in `extension.ts`
+4. You're testing your test code, not production code
 
 ### ✅ CORRECT: Test Through Actual Entry Points
 
-**Option 1: VS Code Extension Tests** (runs in real VS Code via `@vscode/test-electron`)
-
-Location: `test/suite/*.test.ts`
+**Option 1: Real VS Code extension host (`test/suite/*.test.ts`, run via `npm run test:integration`)**
 
 ```typescript
-// This runs in a real VS Code instance where commands are registered
-test('should migrate bundle via moveToUser command', async () => {
-    // Setup: Install bundle at repository scope
-    await vscode.commands.executeCommand('promptRegistry.installBundle', bundleId, {
-        scope: 'repository', version: '1.0.0'
-    });
-    
-    // Act: Execute the actual VS Code command (the real entry point!)
-    await vscode.commands.executeCommand('promptRegistry.moveToUser', bundleId);
-    
-    // Assert: Verify end state
-    const userBundles = await storage.getInstalledBundles('user');
-    assert.ok(userBundles.some(b => b.bundleId === bundleId));
+test('migrates bundle via moveToUser command', async () => {
+  // Setup: Install at repository scope
+  await vscode.commands.executeCommand('promptRegistry.installBundle', bundleId, {
+    scope: 'repository', version: '1.0.0',
+  });
+
+  // Act: execute the actual VS Code command
+  await vscode.commands.executeCommand('promptRegistry.moveToUser', bundleId);
+
+  // Assert: verify end state
+  const userBundles = await storage.getInstalledBundles('user');
+  assert.ok(userBundles.some(b => b.bundleId === bundleId));
 });
 ```
 
-Run with: `node test/runExtensionTests.js`
-
-**Option 2: Test Through Command Handler Class** (when VS Code host isn't available)
+**Option 2: Call the command handler class directly (when VS Code host isn't available)**
 
 ```typescript
-// Create the actual command handler (like extension.ts does)
 const bundleScopeCommands = new BundleScopeCommands(
-    registryManager,
-    scopeConflictResolver,
-    repositoryScopeService
+  registryManager,
+  scopeConflictResolver,
+  repositoryScopeService
 );
 
-// Call the actual method that the VS Code command invokes
 await bundleScopeCommands.moveToUser(bundleId);
 
-// Assert on end state, NOT on how it was achieved
 const userBundles = await storage.getInstalledBundles('user');
 assert.ok(userBundles.some(b => b.bundleId === bundleId));
 ```
 
-### Test Infrastructure Overview
-
-| Test Type | Location | Runs In | Use For |
-|-----------|----------|---------|---------|
-| Unit Tests | `test/**/*.test.ts` | Node.js with mocked VS Code | Testing individual classes/methods |
-| Integration Tests | `test/e2e/*.test.ts` | Node.js with mocked VS Code | Testing multi-component workflows |
-| VS Code Extension Tests | `test/suite/*.test.ts` | Real VS Code instance | Testing actual commands and UI |
-
-### When to Use Each
-
-- **Unit tests**: Testing a single class's behavior with mocked dependencies
-- **Integration tests** (`test/e2e/`): Testing workflows across multiple real components (but mocked VS Code)
-- **VS Code extension tests** (`test/suite/`): Testing actual command registration and execution in real VS Code
-
 ---
 
 ## Test Structure
-
-E2E tests validate complete workflows across multiple components. Each test file should focus on a specific feature or workflow.
 
 ```
 test/e2e/
@@ -109,119 +80,104 @@ test/e2e/
 └── bundle-update-github.test.ts           # GitHub bundle update workflow
 ```
 
+Tests use Mocha TDD (`suite` / `test` / `assert`) — same as unit tests. VS Code is mocked via `test/mocha.setup.js`.
+
 ## Test Context Setup
 
-Use the `E2ETestContext` helper for isolated test environments:
-
 ```typescript
+import * as assert from 'node:assert';
 import { createE2ETestContext, E2ETestContext, generateTestId } from '../helpers/e2e-test-helpers';
 import {
-    setupReleaseMocks,
-    createMockGitHubSource,
-    cleanupReleaseMocks,
-    RepositoryTestConfig
+  setupReleaseMocks,
+  createMockGitHubSource,
+  cleanupReleaseMocks,
+  RepositoryTestConfig,
 } from '../helpers/repository-fixture-helpers';
 
 suite('E2E: My Feature Tests', () => {
-    let testContext: E2ETestContext;
-    let testId: string;
+  let testContext: E2ETestContext;
+  let testId: string;
 
-    setup(async function() {
-        this.timeout(30000);
-        testId = generateTestId('my-feature');
-        testContext = await createE2ETestContext();
-    });
+  setup(async function () {
+    this.timeout(30_000);
+    testId = generateTestId('my-feature');
+    testContext = await createE2ETestContext();
+  });
 
-    teardown(async function() {
-        this.timeout(10000);
-        await testContext.cleanup();
-        cleanupReleaseMocks();
-    });
+  teardown(async function () {
+    this.timeout(10_000);
+    await testContext.cleanup();
+    cleanupReleaseMocks();
+  });
 });
 ```
 
 ## Shared Repository Fixtures
 
-Use the shared repository fixture helpers for GitHub release mocking:
-
 ```typescript
 import {
-    setupReleaseMocks,
-    createBundleZip,
-    createDeploymentManifest,
-    createMockGitHubSource,
-    cleanupReleaseMocks,
-    RepositoryTestConfig,
-    ReleaseConfig
+  setupReleaseMocks,
+  createMockGitHubSource,
+  cleanupReleaseMocks,
+  RepositoryTestConfig,
+  ReleaseConfig,
 } from '../helpers/repository-fixture-helpers';
 
-// Configure test repository
 const config: RepositoryTestConfig = {
-    owner: 'test-owner',
-    repo: 'test-repo',
-    manifestId: 'test-bundle'
+  owner: 'test-owner',
+  repo: 'test-repo',
+  manifestId: 'test-bundle',
 };
 
-// Set up releases
 const releases: ReleaseConfig[] = [
-    { tag: 'v1.0.0', version: '1.0.0', content: 'initial' },
-    { tag: 'v2.0.0', version: '2.0.0', content: 'updated' }
+  { tag: 'v1.0.0', version: '1.0.0', content: 'initial' },
+  { tag: 'v2.0.0', version: '2.0.0', content: 'updated' },
 ];
 
 setupReleaseMocks(config, releases);
-
-// Create matching source
 const source = createMockGitHubSource('test-source', config);
 ```
 
-This replaces inline mock setup and ensures consistent test fixtures across E2E tests.
-
-## HTTP Mocking with Nock
-
-For custom HTTP mocking beyond the shared fixtures, use nock directly:
-
-### Basic Pattern
+## HTTP Mocking with nock
 
 ```typescript
 import nock from 'nock';
 
 // Use persist() for mocks called multiple times
 nock('https://api.github.com')
-    .persist()
-    .get('/repos/owner/repo/contents/collections?ref=main')
-    .reply(200, [{ name: 'file.yml', type: 'file' }]);
+  .persist()
+  .get('/repos/owner/repo/contents/collections?ref=main')
+  .reply(200, [{ name: 'file.yml', type: 'file' }]);
 
 // Include query strings directly in the path (not .query())
 nock('https://raw.githubusercontent.com')
-    .persist()
-    .get('/owner/repo/main/path/to/file.yml')
-    .reply(200, fileContent);
+  .persist()
+  .get('/owner/repo/main/path/to/file.yml')
+  .reply(200, fileContent);
 ```
 
-### Important: Clear Mocks Between Phases
-
-When testing update workflows, clear mocks and set up new ones for the "after" state:
+### Clear Mocks Between Phases
 
 ```typescript
-// Phase 1: Initial state
+// Phase 1: initial state
 nock('https://api.github.com').persist()
-    .get('/repos/owner/repo/contents?ref=main')
-    .reply(200, initialContent);
+  .get('/repos/owner/repo/contents?ref=main')
+  .reply(200, initialContent);
 
-// ... perform initial operations ...
+// ... initial operations ...
 
-// Phase 2: Updated state
+// Phase 2: updated state
 nock.cleanAll();
 nock.disableNetConnect();
 
 nock('https://api.github.com').persist()
-    .get('/repos/owner/repo/contents?ref=main')
-    .reply(200, updatedContent);
+  .get('/repos/owner/repo/contents?ref=main')
+  .reply(200, updatedContent);
 ```
 
 ## Authentication Handling
 
-Stub VS Code authentication to prevent real tokens from being used:
+Stub VS Code auth so no real tokens are used:
 
 ```typescript
 import * as sinon from 'sinon';
@@ -229,92 +185,73 @@ import * as vscode from 'vscode';
 
 let sandbox: sinon.SinonSandbox;
 
-setup(async function() {
-    sandbox = sinon.createSandbox();
-    
-    // Stub VS Code authentication
-    if (vscode.authentication && typeof vscode.authentication.getSession === 'function') {
-        sandbox.stub(vscode.authentication, 'getSession').resolves(undefined);
+setup(async () => {
+  sandbox = sinon.createSandbox();
+
+  if (vscode.authentication && typeof vscode.authentication.getSession === 'function') {
+    sandbox.stub(vscode.authentication, 'getSession').resolves(undefined);
+  }
+
+  const childProcess = require('child_process');
+  sandbox.stub(childProcess, 'exec').callsFake((...args: unknown[]) => {
+    const cmd = args[0] as string;
+    const callback = args[args.length - 1] as Function;
+    if (cmd === 'gh auth token') {
+      callback(new Error('gh not available'), '', '');
+    } else {
+      callback(null, '', '');
     }
-    
-    // Stub gh CLI to prevent token retrieval
-    const childProcess = require('child_process');
-    sandbox.stub(childProcess, 'exec').callsFake((...args: unknown[]) => {
-        const cmd = args[0] as string;
-        const callback = args[args.length - 1] as Function;
-        if (cmd === 'gh auth token') {
-            callback(new Error('gh not available'), '', '');
-        } else {
-            callback(null, '', '');
-        }
-    });
+  });
 });
 
-teardown(async function() {
-    sandbox.restore();
-});
+teardown(() => { sandbox.restore(); });
 ```
 
 ## Adapter Cache Handling
 
-The AwesomeCopilotAdapter caches bundles for 5 minutes. Clear the cache when simulating content changes:
+`AwesomeCopilotAdapter` caches bundles for 5 minutes. Clear it when simulating content changes:
 
 ```typescript
-// Clear adapter cache to force fresh fetch
 const adapters = (testContext.registryManager as any).adapters;
 for (const [, adapter] of adapters) {
-    if (adapter.collectionsCache) {
-        adapter.collectionsCache.clear();
-    }
+  if (adapter.collectionsCache) {
+    adapter.collectionsCache.clear();
+  }
 }
 ```
 
 ## Common Patterns
 
-### Testing Awesome Copilot Updates
-
-Awesome Copilot bundles auto-update when syncing the source:
+### Awesome Copilot Updates (auto-update on source sync)
 
 ```typescript
-// 1. Add source and sync
 await testContext.registryManager.addSource(source);
 await testContext.registryManager.syncSource(sourceId);
 
-// 2. Install bundle
 const bundles = await testContext.registryManager.searchBundles({ sourceId });
 await testContext.registryManager.installBundle(bundles[0].id, { scope: 'user' });
 
-// 3. Clear mocks and cache, set up updated content
 nock.cleanAll();
 clearAdapterCache();
 setupUpdatedMocks();
 
-// 4. Sync again - triggers auto-update
-await testContext.registryManager.syncSource(sourceId);
+await testContext.registryManager.syncSource(sourceId); // triggers auto-update
 
-// 5. Verify update
 const installed = await testContext.registryManager.listInstalledBundles();
 assert.strictEqual(installed[0].version, updatedVersion);
 ```
 
-### Testing GitHub Bundle Updates
-
-GitHub bundles use explicit version management:
+### GitHub Bundle Updates (explicit version management)
 
 ```typescript
-// 1. Install specific version
-await testContext.registryManager.installBundle(bundleId, { 
-    scope: 'user', 
-    version: '1.0.0' 
+await testContext.registryManager.installBundle(bundleId, {
+  scope: 'user',
+  version: '1.0.0',
 });
 
-// 2. Check for updates
 const updates = await testContext.registryManager.checkUpdates();
-
-// 3. Update to latest
 await testContext.registryManager.updateBundle(bundleId);
 
-// 4. Verify new version
 const installed = await testContext.registryManager.listInstalledBundles();
 assert.strictEqual(installed[0].version, '2.0.0');
 ```
@@ -323,99 +260,80 @@ assert.strictEqual(installed[0].version, '2.0.0');
 
 ### Copilot Sync Errors
 
-You may see errors like:
-```
-Failed to create Copilot file: /path/to/prompts/file.md
-```
-
-These are expected in test environments where the Copilot directory doesn't exist. They don't affect test results.
+Errors like `Failed to create Copilot file: /path/to/prompts/file.md` are expected in test environments where the Copilot directory doesn't exist. They don't affect test results.
 
 ### BundleId Differences
 
-- **Awesome Copilot**: bundleId = `collection-name` (no version)
-- **GitHub**: bundleId = `owner-repo-version` (includes version)
+- **Awesome Copilot**: `bundleId = collection-name` (no version)
+- **GitHub**: `bundleId = owner-repo-version` (includes version)
 
 This affects how installation records are managed during updates.
 
-## Test Naming Convention
-
-Use descriptive names that reference the requirement being tested:
-
-```typescript
-test('Example 1.1: Update command downloads from configured branch', async function() {
-    // Test implementation
-});
-```
-
 ## Timeouts
 
-Set appropriate timeouts for async operations:
+Mocha timeouts are set via `this.timeout(ms)` inside the test/setup:
 
 ```typescript
-test('My test', async function() {
-    this.timeout(60000); // 60 seconds for network operations
-    // ...
+test('my long test', async function () {
+  this.timeout(60_000);
+  // ... network operations ...
 });
 ```
 
-## Debugging Tips
+## Debugging
 
-1. **Enable verbose logging**: `LOG_LEVEL=DEBUG npm run test:one -- test/e2e/my-test.ts`
-2. **Check nock pending mocks**: `console.log(nock.pendingMocks())`
-3. **Verify mock was called**: `assert.ok(nock.isDone())`
+```bash
+LOG_LEVEL=DEBUG npm run test:one -- test/e2e/my-test.ts
+```
+
+- Check `nock.pendingMocks()` to spot missing mocks
+- Assert `nock.isDone()` to verify mocks were called
+- Use `tee` + `grep` for targeted analysis:
+  `LOG_LEVEL=DEBUG npm run test:one -- test/e2e/my-test.ts 2>&1 | tee debug.log | grep methodName`
 
 ---
 
-## Debugging E2E Test Failures
+## Debugging E2E Failures
 
-### Fault Isolation Strategy
+### Fault Isolation
 
-E2E tests exercise multiple components. When tests fail:
+1. Parse the error first: `expected X, got Y` — does `Y` show a transformation?
+2. Transformations (e.g., `v1.0.0` → `1.0.0`) usually indicate production-code bugs, not test fixtures
+3. Trace data flow with `LOG_LEVEL=DEBUG`
 
-1. **Parse the error message first**: `expected X, got Y` tells you what the system produced
-2. **If the error shows data transformation**, the bug is likely in production code, not test fixtures
-3. **Trace the data flow** through the system with debug logging
-
-### Common E2E Pitfalls
+### Common Pitfalls
 
 | Symptom | Likely Cause | Solution |
 |---------|--------------|----------|
-| Bundle ID mismatch | Inconsistent ID construction in `RegistryManager` | Check `applyVersionOverride` and `updateBundle` code paths |
-| "Bundle not found" | Version consolidation returns only latest | Use `version` option in `installBundle` for specific versions |
-| Update fails after install | Different code paths for install vs update | Verify both paths use same ID format |
+| Bundle ID mismatch | Inconsistent ID construction in `RegistryManager` | Check `applyVersionOverride` and `updateBundle` paths |
+| "Bundle not found" | Version consolidation returns only latest | Use `version` option in `installBundle` |
+| Update fails after install | Install/update use different ID formats | Verify both paths use same ID format |
 
 ### Version-Specific Installation
 
-When testing version-specific workflows, **always use the `version` option**:
-
 ```typescript
-// ❌ Wrong: May install latest version due to version consolidation
+// ❌ May install latest due to version consolidation
 await registryManager.installBundle('owner-repo-v1.0.0', { scope: 'user' });
 
-// ✅ Correct: Explicitly request specific version
-await registryManager.installBundle('owner-repo-v1.0.0', { 
-    scope: 'user', 
-    version: '1.0.0' 
+// ✅ Explicitly request specific version
+await registryManager.installBundle('owner-repo-v1.0.0', {
+  scope: 'user',
+  version: '1.0.0',
 });
 ```
 
-### Bundle ID Format Consistency
+### Bundle ID Format
 
-GitHub bundles have IDs in format `owner-repo-tag` where tag includes 'v' prefix (e.g., `owner-repo-v1.0.0`).
-
-The manifest `id` field must match exactly what the code expects. If you see mismatches:
-1. Check `VersionConsolidator.toBundleVersion()` - stores `bundleId` for each version
-2. Check `RegistryManager.applyVersionOverride()` - should use stored `bundleId`, not construct new one
-3. Verify adapter creates IDs consistently with manifest format
+GitHub bundle IDs follow `owner-repo-tag` with `v`-prefixed tag (e.g., `owner-repo-v1.0.0`). If you see mismatches:
+1. `VersionConsolidator.toBundleVersion()` — stores `bundleId` per version
+2. `RegistryManager.applyVersionOverride()` — must use stored `bundleId`, not reconstruct
+3. Verify adapter creates IDs consistent with manifest format
 
 ### Adding Debug Logging
 
-When production code behavior is unclear, add temporary logging:
-
 ```typescript
-// In RegistryManager.ts or relevant service
 this.logger.debug(`[methodName] Input: ${JSON.stringify(input)}`);
 this.logger.debug(`[methodName] Output: ${JSON.stringify(output)}`);
 ```
 
-Then run with: `LOG_LEVEL=DEBUG npm run test:one -- test/e2e/my-test.ts 2>&1 | grep methodName`
+Run: `LOG_LEVEL=DEBUG npm run test:one -- test/e2e/my-test.ts 2>&1 | grep methodName`

--- a/test/e2e/CLAUDE.md
+++ b/test/e2e/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Description

Realigns and optimizes the AGENTS.md files across the repo and adds CLAUDE.md pointer files so Claude Code picks up the same project conventions as other AI agents. This reduces duplication between the root and folder-scoped guidance documents and keeps behavioral rules close to the code they govern.

## Type of Change

- [x] 📝 Documentation update
- [x] ♻️ Code refactoring (no functional changes)

## Related Issues

Closes #
Fixes #
Relates to #

## Changes Made

- Trim `AGENTS.md` (root) to cross-cutting policy; move folder-specific guidance into folder-scoped files and fix stale references (`src/services/RegistryManager.ts` → `src/services/registry-manager.ts`, adapter list now includes `skills` and local variants).
- Rewrite `test/AGENTS.md` around a "test behavior, not implementation" rule, clarify the unit/property/e2e/integration test tiers, the Mocha TDD stack, and the test-deduplication rules (max 2 files per class, no `.fix.test.ts`).
- Rewrite `test/e2e/AGENTS.md` to emphasize "never reimplement production code" with before/after examples, and consolidate the e2e helpers, auth/nock/cache patterns, and debugging checklists.
- Update `src/adapters/AGENTS.md` to describe the real `IRepositoryAdapter` interface (`Buffer` downloads, `ValidationResult`, skills adapter) and the factory registration flow.
- Update `docs/AGENTS.md` to keep the documentation-discovery table and file-placement guidance in one place, referenced from the root.
- Rewrite `docs/contributor-guide/testing.md` as a commands/tooling reference that points at `test/AGENTS.md` for patterns, removing duplicated style guidance.
- Add `CLAUDE.md` pointer files at `docs/`, `src/adapters/`, `src/services/`, `test/`, and `test/e2e/` that re-export the sibling `AGENTS.md` via `@AGENTS.md` so Claude Code follows the same conventions.

## Testing

### Test Coverage

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

### Manual Testing Steps

1. Open the repo with Claude Code (or another AGENTS.md-aware agent) — the root `AGENTS.md` table should list each folder-scoped guide.
2. Open any of `docs/`, `src/adapters/`, `src/services/`, `test/`, `test/e2e/` — the new `CLAUDE.md` files re-export the sibling `AGENTS.md`.
3. Follow a link from the root `AGENTS.md` (e.g., `test/AGENTS.md`) and confirm the "Key Files" paths resolve (lowercase kebab-case names).

### Tested On

- [x] macOS
- [ ] Windows
- [ ] Linux

- [x] VS Code Stable
- [ ] VS Code Insiders

## Screenshots

N/A — documentation-only change.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Documentation

- [ ] README.md updated
- [ ] JSDoc comments added/updated
- [x] No documentation changes needed _(this PR **is** the documentation change)_

## Additional Notes

- No production code or test code changed — this is an AGENTS/CLAUDE guidance realignment only.
- File paths in the root `AGENTS.md` were corrected to match the actual kebab-case source file names.
- The `CLAUDE.md` files intentionally use `@AGENTS.md` so the two agent ecosystems stay in sync automatically going forward.

## Reviewer Guidelines

Please pay special attention to:

- Whether the folder-scoped AGENTS.md files still cover every rule that was trimmed from the root.
- Correctness of the file paths and adapter list in the root `AGENTS.md` "Key Files" / "Quick Examples" sections.

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)