### PR TITLE
fix(marketplace): show setup prompt instead of infinite spinner when no sources configured

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -417,9 +417,27 @@ export class PromptRegistryExtension {
         await this.setupStateManager.reset();
         // Clear active hub to ensure hub selector is shown
         await this.hubManager?.setActiveHub(null);
-        // Remove any ghost hubs left by failed imports
+        // Remove any ghost hubs left by failed imports (also removes hub-linked sources)
         await this.hubManager?.deleteAllHubs();
+        // Remove any remaining sources not linked to a hub (standalone sources)
+        if (this.registryManager) {
+          const remainingSources = await this.registryManager.listSources();
+          const results = await Promise.allSettled(
+            remainingSources.map((s) => this.registryManager.removeSource(s.id))
+          );
+          const failures = results.filter((r) => r.status === 'rejected');
+          if (failures.length > 0) {
+            this.logger.warn(`Failed to remove ${failures.length} standalone source(s) during reset`);
+          }
+        }
         this.logger.info('First run state reset via SetupStateManager');
+        if (this.registryManager) {
+          const leftover = await this.registryManager.listSources();
+          if (leftover.length > 0) {
+            vscode.window.showWarningMessage(`First run state reset, but ${leftover.length} source(s) could not be removed. Reload the window to retry.`);
+            return;
+          }
+        }
         vscode.window.showInformationMessage('First run state has been reset. Reload the window to trigger first-run initialization.');
       }),
 

--- a/src/ui/marketplace-view-provider.ts
+++ b/src/ui/marketplace-view-provider.ts
@@ -335,7 +335,8 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
             tags: availableTags,
             sources: availableSources
           },
-          setupState: setupState
+          setupState: setupState,
+          sourcesCount: sources.length
         });
       }
 

--- a/src/ui/webview/marketplace/marketplace.js
+++ b/src/ui/webview/marketplace/marketplace.js
@@ -9,6 +9,7 @@
   let selectedTags = [];
   let showInstalledOnly = false;
   let setupState = 'complete'; // Default to complete to avoid showing setup prompt unnecessarily
+  let sourcesCount = 0;
 
   // Handle messages from extension
   window.addEventListener('message', (event) => {
@@ -18,6 +19,7 @@
       allBundles = message.bundles;
       filterOptions = message.filterOptions || { tags: [], sources: [] };
       setupState = message.setupState || 'complete';
+      sourcesCount = message.sourcesCount || 0;
       updateFilterUI();
       renderBundles();
     }
@@ -361,14 +363,18 @@
       var hasFiltersApplied = searchTerm || selectedSource !== 'all' || selectedTags.length > 0 || showInstalledOnly;
 
       if (allBundles.length === 0) {
-        // No bundles at all - check if setup is incomplete or in progress
-        var isSetupIncomplete = setupState === 'incomplete' || setupState === 'not_started' || setupState === 'in_progress';
+        var hasNoSources = setupState === 'complete' && sourcesCount === 0;
+        var shouldShowSetupPrompt = setupState === 'incomplete' || setupState === 'not_started' || setupState === 'in_progress' || hasNoSources;
 
-        marketplace.innerHTML = isSetupIncomplete
+        var setupMessage = hasNoSources
+          ? 'No sources are configured. Complete setup to browse bundles.'
+          : 'No hub is configured. Complete setup to browse bundles.';
+
+        marketplace.innerHTML = shouldShowSetupPrompt
           ? '<div class="empty-state">'
           + '<div class="empty-state-icon">⚙️</div>'
           + '<div class="empty-state-title">Setup Not Complete</div>'
-          + '<p>No hub is configured. Complete setup to browse bundles.</p>'
+          + '<p>' + setupMessage + '</p>'
           + '<button class="primary-button" data-action="completeSetup">'
           + 'Complete Setup'
           + '</button>'

--- a/test/ui/marketplace-view-provider.emptyState.test.ts
+++ b/test/ui/marketplace-view-provider.emptyState.test.ts
@@ -153,6 +153,38 @@ suite('MarketplaceViewProvider - Empty State UI', () => {
       assert.strictEqual(postedMessages[0].setupState, SetupState.COMPLETE);
     });
 
+    test('should include sourcesCount in bundlesLoaded message', async () => {
+      // WHEN setup is complete but no sources are configured, sourcesCount must be 0
+      // so the webview can show "Setup Not Complete" instead of the infinite spinner
+      mockSetupStateManager.getState.resolves(SetupState.COMPLETE);
+      mockRegistryManager.searchBundles.resolves([]);
+      mockRegistryManager.listInstalledBundles.resolves([]);
+      mockRegistryManager.listSources.resolves([]);
+
+      await (marketplaceProvider as any).loadBundles();
+
+      assert.strictEqual(postedMessages.length, 1);
+      assert.strictEqual(postedMessages[0].type, 'bundlesLoaded');
+      assert.strictEqual(postedMessages[0].sourcesCount, 0,
+        'sourcesCount should be 0 when no sources configured');
+    });
+
+    test('should include correct sourcesCount when sources are configured', async () => {
+      mockSetupStateManager.getState.resolves(SetupState.COMPLETE);
+      mockRegistryManager.searchBundles.resolves([]);
+      mockRegistryManager.listInstalledBundles.resolves([]);
+      mockRegistryManager.listSources.resolves([
+        { id: 'source-1' } as any,
+        { id: 'source-2' } as any
+      ]);
+
+      await (marketplaceProvider as any).loadBundles();
+
+      assert.strictEqual(postedMessages.length, 1);
+      assert.strictEqual(postedMessages[0].sourcesCount, 2,
+        'sourcesCount should reflect actual number of sources');
+    });
+
     test('should include setup state in bundlesLoaded message when setup is in progress', async () => {
       mockSetupStateManager.getState.resolves(SetupState.IN_PROGRESS);
       mockRegistryManager.searchBundles.resolves([]);
@@ -341,6 +373,8 @@ suite('MarketplaceViewProvider - Empty State UI', () => {
         'marketplace.js should include "Setup Not Complete" message');
       assert.ok(jsContent.includes('No hub is configured'),
         'marketplace.js should include explanation about no hub configured');
+      assert.ok(jsContent.includes('No sources are configured'),
+        'marketplace.js should include explanation for complete+no-sources case');
     });
 
     test('external marketplace JS should include syncing message', () => {


### PR DESCRIPTION
## Description

When `setupState` is `'complete'` (persisted from a previous session) but no sources are configured, the Prompt Marketplace was stuck showing a "Syncing sources..." spinner indefinitely. Since no sources exist, no `onSourceSynced` events ever fire, so the spinner never resolves and the user has no guidance on how to fix it.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🧪 Test coverage improvement

## Related Issues

Relates to #

## Changes Made

- **`src/ui/marketplace-view-provider.ts`** — `loadBundles()` now includes `sourcesCount: sources.length` in the `bundlesLoaded` message sent to the webview
- **`src/ui/webview/marketplace/marketplace.js`** — The empty-state check now treats `setupState === 'complete' && sourcesCount === 0` as setup-incomplete, showing the "Setup Not Complete" prompt with a "Complete Setup" button instead of the infinite spinner. Message is context-aware: "No sources are configured" vs "No hub is configured"
- **`src/extension.ts`** — The `resetFirstRun` command now removes all remaining standalone sources (not hub-linked) after `deleteAllHubs()`, ensuring a true clean slate on reset
- **`test/ui/marketplace-view-provider.emptyState.test.ts`** — Added tests verifying `sourcesCount` is included in `bundlesLoaded` messages with correct values

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

### Manual Testing Steps

1. Install the extension fresh (or run `promptRegistry.resetFirstRun`)
2. Complete setup to configure a hub/sources, then delete all sources/hubs manually
3. Reload VS Code — observe the Marketplace now shows "Setup Not Complete" with a "Complete Setup" button instead of the infinite "Syncing sources..." spinner
4. Click "Complete Setup" — hub selector appears and flow completes normally

### Tested On

- [x] macOS
- [ ] Windows
- [ ] Linux

- [x] VS Code Insiders

## Screenshots

**Before:** Infinite "Syncing sources..." spinner with no action available

**After:** "Setup Not Complete" with "No sources are configured. Complete setup to browse bundles." and a "Complete Setup" button

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes