### PR TITLE
feat: expose docs as GitHub Pages with MkDocs Material (#257)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,36 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'README.md'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: docs-deploy
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install MkDocs Material
+        run: pip install mkdocs-material
+
+      - name: Deploy to GitHub Pages
+        run: mkdocs gh-deploy --force

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,20 +7,33 @@ on:
       - 'docs/**'
       - 'mkdocs.yml'
       - 'README.md'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'README.md'
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
 
 concurrency:
-  group: docs-deploy
+  group: pages
   cancel-in-progress: true
 
 jobs:
-  deploy:
-    name: Deploy to GitHub Pages
+  build:
+    name: Build Documentation
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -30,7 +43,33 @@ jobs:
           python-version: '3.x'
 
       - name: Install MkDocs Material
-        run: pip install mkdocs-material
+        run: pip install mkdocs-material==9.7.6 pytest
 
+      - name: Test hooks
+        run: pytest docs/_hooks/ -v
+
+      - name: Build documentation (strict)
+        run: mkdocs build --strict
+
+      - name: Setup Pages
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
       - name: Deploy to GitHub Pages
-        run: mkdocs gh-deploy --force
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,5 @@ post-compile-fixes-cross-platform.js
 
 # Claude local settings file
 .claude/settings.local.json
+# MkDocs build output
+site/

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 > A visual marketplace for discovering, installing, and managing GitHub Copilot prompt libraries from multiple sources.
 
 [![VS Code Marketplace](https://img.shields.io/badge/VS%20Code-Marketplace-blue?logo=visual-studio-code)](https://marketplace.visualstudio.com/items?itemName=AmadeusITGroup.prompt-registry)
+[![Documentation](https://img.shields.io/badge/docs-GitHub%20Pages-blue?logo=github)](https://amadeustitgroup.github.io/prompt-registry/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Version](https://img.shields.io/badge/version-0.0.2-green.svg)](https://github.com/AmadeusITGroup/prompt-registry)
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -87,6 +87,17 @@ Update documentation when:
 ## Style Notes
 
 - Use relative links within docs/ (e.g., `../user-guide/getting-started.md`)
+- Links to files outside `docs/` (e.g., `../../CONTRIBUTING.md`) are automatically rewritten to absolute GitHub URLs at build time by `docs/_hooks/readme_hook.py`
 - Include "See Also" sections to connect related topics
 - Add screenshot placeholders with descriptive alt text when UI changes
 - Keep each file focused on one topic
+
+### GitHub Pages / MkDocs Maintenance
+
+When adding or modifying documentation:
+
+1. **New doc pages** must be added to the `nav:` section in `mkdocs.yml`
+2. **Links to root-level files** (CONTRIBUTING.md, LICENSE.txt, etc.) should use relative paths — the build hook rewrites them automatically
+3. **Root README links** must use the `./` prefix (e.g., `](./CONTRIBUTING.md)`) so the hook can detect and rewrite them for the docs site
+4. **Excluding files** from the MkDocs build: add them to `exclude_docs` in `mkdocs.yml` and to `excluded_files` in `docs/_hooks/readme_hook.py`
+5. **Verify changes** by running `mkdocs build --strict` — it must pass with 0 warnings

--- a/docs/_hooks/readme_hook.py
+++ b/docs/_hooks/readme_hook.py
@@ -1,0 +1,83 @@
+"""MkDocs hook: injects root README into the home page and converts
+relative links that escape docs/ into absolute GitHub URLs.
+
+This avoids duplicating the project README and keeps source links
+IDE-friendly (relative) while producing correct URLs on the built site.
+"""
+
+import os
+import re
+from pathlib import Path
+
+REPO_URL = "https://github.com/AmadeusITGroup/prompt-registry/blob/main"
+
+
+def on_page_read_source(page, config):
+    """Inject root README.md as the docs home page."""
+    if page.file.src_path != "index.md":
+        return None
+
+    readme = Path(config["config_file_path"]).parent / "README.md"
+    content = readme.read_text(encoding="utf-8")
+
+    # Fix image/link paths: ./docs/X  →  X  (now relative to docs/)
+    content = content.replace("](./docs/", "](")
+
+    # Remove the "Full Documentation Index" link (nav tabs replace it)
+    content = content.replace(
+        "\u2192 [Full Documentation Index](README.md)\n", ""
+    )
+
+    # Root-relative ./X links must escape docs/ so on_page_markdown
+    # can detect and convert them to absolute GitHub URLs.
+    content = content.replace("](./", "](../")
+
+    return content
+
+
+def on_page_markdown(markdown, page, config, files):
+    """Convert relative links that point outside docs/ to absolute GitHub URLs."""
+    docs_dir = Path(config["docs_dir"]).resolve()
+    repo_root = Path(config["config_file_path"]).parent.resolve()
+    page_dir = (Path(config["docs_dir"]) / page.file.src_path).parent.resolve()
+
+    # Files excluded from the MkDocs build that need link rewriting.
+    # docs/README.md is excluded because MkDocs treats README.md as index.md,
+    # which would conflict with our actual index.md (populated by the hook).
+    excluded_files = {"README.md"}
+
+    def _replace(match):
+        text, url = match.group(1), match.group(2)
+
+        if url.startswith(("http://", "https://", "#", "mailto:")):
+            return match.group(0)
+
+        path_part, _, anchor = url.partition("#")
+        if not path_part:
+            return match.group(0)
+
+        resolved = (page_dir / path_part).resolve()
+
+        # Links inside docs/ — check if target is an excluded file
+        try:
+            rel_to_docs = resolved.relative_to(docs_dir)
+            if str(rel_to_docs) in excluded_files:
+                # Compute relative path from the current page to docs/index.md
+                rel_index = Path(os.path.relpath(
+                    docs_dir / "index.md", page_dir
+                ))
+                suffix = f"#{anchor}" if anchor else ""
+                return f"[{text}]({rel_index}{suffix})"
+            return match.group(0)
+        except ValueError:
+            pass
+
+        # Outside docs/ — rewrite to absolute GitHub URL
+        try:
+            rel = resolved.relative_to(repo_root)
+            suffix = f"#{anchor}" if anchor else ""
+            return f"[{text}]({REPO_URL}/{rel}{suffix})"
+        except ValueError:
+            return match.group(0)
+
+    return re.sub(r"\[([^\]]*)\]\(([^)]+)\)", _replace, markdown)

--- a/docs/_hooks/readme_hook.py
+++ b/docs/_hooks/readme_hook.py
@@ -7,7 +7,7 @@ IDE-friendly (relative) while producing correct URLs on the built site.
 
 import os
 import re
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 REPO_URL = "https://github.com/AmadeusITGroup/prompt-registry/blob/main"
 
@@ -23,13 +23,8 @@ def on_page_read_source(page, config):
     # Fix image/link paths: ./docs/X  →  X  (now relative to docs/)
     content = content.replace("](./docs/", "](")
 
-    # Remove the "Full Documentation Index" link (nav tabs replace it)
-    content = content.replace(
-        "\u2192 [Full Documentation Index](README.md)\n", ""
-    )
-
-    # Root-relative ./X links must escape docs/ so on_page_markdown
-    # can detect and convert them to absolute GitHub URLs.
+    # Root-relative links: both ./X and bare X (without ./ prefix) must
+    # escape docs/ so on_page_markdown can detect and convert them.
     content = content.replace("](./", "](../")
 
     return content
@@ -61,9 +56,9 @@ def on_page_markdown(markdown, page, config, files):
         # Links inside docs/ — check if target is an excluded file
         try:
             rel_to_docs = resolved.relative_to(docs_dir)
-            if str(rel_to_docs) in excluded_files:
+            if str(PurePosixPath(rel_to_docs)) in excluded_files:
                 # Compute relative path from the current page to docs/index.md
-                rel_index = Path(os.path.relpath(
+                rel_index = PurePosixPath(os.path.relpath(
                     docs_dir / "index.md", page_dir
                 ))
                 suffix = f"#{anchor}" if anchor else ""
@@ -74,7 +69,7 @@ def on_page_markdown(markdown, page, config, files):
 
         # Outside docs/ — rewrite to absolute GitHub URL
         try:
-            rel = resolved.relative_to(repo_root)
+            rel = PurePosixPath(resolved.relative_to(repo_root))
             suffix = f"#{anchor}" if anchor else ""
             return f"[{text}]({REPO_URL}/{rel}{suffix})"
         except ValueError:

--- a/docs/_hooks/test_readme_hook.py
+++ b/docs/_hooks/test_readme_hook.py
@@ -1,0 +1,161 @@
+"""Tests for the MkDocs readme_hook link-rewriting logic."""
+
+import os
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from readme_hook import on_page_read_source, on_page_markdown
+
+# ---------------------------------------------------------------------------
+# Fixtures: fake project tree
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def project(tmp_path):
+    """Create a minimal project tree that mirrors the real layout."""
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "index.md").write_text("stub")
+    (docs / "README.md").write_text("# Docs README")
+
+    author = docs / "author-guide"
+    author.mkdir()
+    (author / "guide.md").write_text("guide")
+
+    contrib = docs / "contributor-guide"
+    contrib.mkdir()
+    (contrib / "testing.md").write_text("testing")
+
+    # Root-level files that live outside docs/
+    (tmp_path / "CONTRIBUTING.md").write_text("contrib")
+    (tmp_path / "LICENSE.txt").write_text("license")
+    (tmp_path / "README.md").write_text(
+        "# Prompt Registry\n"
+        "\n"
+        "![screenshot](./docs/assets/screenshot.png)\n"
+        "\n"
+        "→ [Full Documentation Index](./docs/README.md)\n"
+        "\n"
+        "See [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines.\n"
+        "\n"
+        "[Apache 2.0](./LICENSE.txt)\n"
+    )
+
+    # Fake mkdocs.yml path (config_file_path points to it)
+    config_file = tmp_path / "mkdocs.yml"
+    config_file.write_text("")
+
+    return SimpleNamespace(
+        root=tmp_path,
+        docs=docs,
+        config={
+            "config_file_path": str(config_file),
+            "docs_dir": str(docs),
+        },
+    )
+
+
+def _make_page(src_path):
+    """Create a minimal page object with file.src_path."""
+    return SimpleNamespace(file=SimpleNamespace(src_path=src_path))
+
+
+# ---------------------------------------------------------------------------
+# on_page_read_source tests
+# ---------------------------------------------------------------------------
+
+class TestOnPageReadSource:
+    def test_returns_none_for_non_index(self, project):
+        page = _make_page("guide.md")
+        assert on_page_read_source(page, project.config) is None
+
+    def test_injects_readme_content(self, project):
+        page = _make_page("index.md")
+        result = on_page_read_source(page, project.config)
+        assert result is not None
+        assert "# Prompt Registry" in result
+
+    def test_rewrites_docs_image_paths(self, project):
+        page = _make_page("index.md")
+        result = on_page_read_source(page, project.config)
+        # ./docs/assets/screenshot.png  →  assets/screenshot.png
+        assert "](assets/screenshot.png)" in result
+        assert "](./docs/" not in result
+
+    def test_converts_root_relative_links(self, project):
+        page = _make_page("index.md")
+        result = on_page_read_source(page, project.config)
+        # ./CONTRIBUTING.md  →  ../CONTRIBUTING.md  (escapes docs/)
+        assert "](../CONTRIBUTING.md)" in result
+        assert "](./CONTRIBUTING.md)" not in result
+
+
+# ---------------------------------------------------------------------------
+# on_page_markdown tests
+# ---------------------------------------------------------------------------
+
+class TestOnPageMarkdown:
+    def test_preserves_internal_docs_links(self, project):
+        md = "[Getting Started](../user-guide/getting-started.md)"
+        page = _make_page("contributor-guide/testing.md")
+        # Create the target so it resolves inside docs/
+        ug = project.docs / "user-guide"
+        ug.mkdir(exist_ok=True)
+        (ug / "getting-started.md").write_text("")
+
+        result = on_page_markdown(md, page, project.config, files=None)
+        assert result == md  # unchanged
+
+    def test_rewrites_link_outside_docs(self, project):
+        md = "[CONTRIBUTING](../../CONTRIBUTING.md)"
+        page = _make_page("contributor-guide/testing.md")
+        result = on_page_markdown(md, page, project.config, files=None)
+        expected = (
+            "[CONTRIBUTING](https://github.com/AmadeusITGroup/"
+            "prompt-registry/blob/main/CONTRIBUTING.md)"
+        )
+        assert result == expected
+
+    def test_rewrites_link_outside_docs_with_anchor(self, project):
+        md = "[Contributing](../../CONTRIBUTING.md#how-to)"
+        page = _make_page("contributor-guide/testing.md")
+        result = on_page_markdown(md, page, project.config, files=None)
+        assert result.endswith("CONTRIBUTING.md#how-to)")
+
+    def test_remaps_excluded_readme_to_index(self, project):
+        md = "[Docs](../README.md)"
+        page = _make_page("author-guide/guide.md")
+        result = on_page_markdown(md, page, project.config, files=None)
+        assert "index.md" in result
+        assert "README.md" not in result
+
+    def test_preserves_absolute_urls(self, project):
+        md = "[GitHub](https://github.com)"
+        page = _make_page("index.md")
+        result = on_page_markdown(md, page, project.config, files=None)
+        assert result == md
+
+    def test_preserves_anchor_only_links(self, project):
+        md = "[section](#overview)"
+        page = _make_page("index.md")
+        result = on_page_markdown(md, page, project.config, files=None)
+        assert result == md
+
+    def test_preserves_mailto_links(self, project):
+        md = "[email](mailto:test@example.com)"
+        page = _make_page("index.md")
+        result = on_page_markdown(md, page, project.config, files=None)
+        assert result == md
+
+    def test_multiple_links_in_one_line(self, project):
+        md = (
+            "[CONTRIBUTING](../../CONTRIBUTING.md) and "
+            "[LICENSE](../../LICENSE.txt)"
+        )
+        page = _make_page("contributor-guide/testing.md")
+        result = on_page_markdown(md, page, project.config, files=None)
+        assert "prompt-registry/blob/main/CONTRIBUTING.md" in result
+        assert "prompt-registry/blob/main/LICENSE.txt" in result

--- a/docs/author-guide/agentic-primitives-guide.md
+++ b/docs/author-guide/agentic-primitives-guide.md
@@ -289,6 +289,6 @@ flowchart LR
 ## Resources
 
 - [Prompt Registry Documentation](../README.md)
-- [Collection Authoring Guide](creating-collections.md)
+- [Collection Authoring Guide](creating-source-bundle.md)
 - [Skill Development Guide](creating-skills.md)
-- [Hub Configuration Guide](../reference/hub-config.md)
+- [Hub Configuration Guide](../reference/hub-schema.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,1 @@
+<!-- Content injected from root README.md at build time via docs/_hooks/readme_hook.py -->

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -71,4 +71,4 @@ Search your codebase for any remaining references to chatmode files and update t
 ## Need Help?
 
 - [GitHub Scaffold Documentation](https://github.com/prompt-registry/docs)
-- [Collection Schema Reference](../docs/author-guide/collection-schema.md)
+- [Collection Schema Reference](author-guide/collection-schema.md)

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,13 @@
+/* Amadeus brand colors: Dark Sky + Vivid Sky */
+:root {
+  --md-primary-fg-color: #000835;
+  --md-primary-fg-color--light: #0a1a5c;
+  --md-primary-fg-color--dark: #000520;
+  --md-accent-fg-color: #3A8BFF;
+  --md-accent-fg-color--transparent: #3A8BFF1a;
+}
+
+[data-md-color-scheme="slate"] {
+  --md-accent-fg-color: #3A8BFF;
+  --md-accent-fg-color--transparent: #3A8BFF1a;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,109 @@
+site_name: Prompt Registry
+site_description: Marketplace and registry for Copilot prompt bundles in VS Code
+site_url: https://amadeustitgroup.github.io/prompt-registry/
+repo_url: https://github.com/AmadeusITGroup/prompt-registry
+repo_name: GitHub
+
+theme:
+  name: material
+  font: false
+  icon:
+    repo: fontawesome/brands/github
+  palette:
+    - scheme: default
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - navigation.instant
+    - navigation.footer
+    - search.highlight
+    - search.suggest
+    - content.code.copy
+
+extra_css:
+  - stylesheets/extra.css
+
+docs_dir: docs
+
+exclude_docs: |
+  AGENTS.md
+  CLAUDE.md
+  README.md
+  _hooks/
+
+hooks:
+  - docs/_hooks/readme_hook.py
+
+nav:
+  - Home: index.md
+  - User Guide:
+      - Getting Started: user-guide/getting-started.md
+      - Marketplace: user-guide/marketplace.md
+      - Repository Installation: user-guide/repository-installation.md
+      - Sources: user-guide/sources.md
+      - Profiles and Hubs: user-guide/profiles-and-hubs.md
+      - Configuration: user-guide/configuration.md
+      - Troubleshooting: user-guide/troubleshooting.md
+  - Author Guide:
+      - Creating Collections: author-guide/creating-source-bundle.md
+      - Creating Skills: author-guide/creating-skills.md
+      - Collection Scripts: author-guide/collection-scripts.md
+      - Collection Schema: author-guide/collection-schema.md
+      - Agentic Primitives: author-guide/agentic-primitives-guide.md
+      - Adding Sources to Hubs: author-guide/adding-profile-source-to-hub.md
+      - Validation: author-guide/validation.md
+      - Publishing: author-guide/publishing.md
+  - Contributor Guide:
+      - Development Setup: contributor-guide/development-setup.md
+      - Architecture: contributor-guide/architecture.md
+      - Architecture Details:
+          - Adapters: contributor-guide/architecture/adapters.md
+          - Authentication: contributor-guide/architecture/authentication.md
+          - Installation Flow: contributor-guide/architecture/installation-flow.md
+          - Update System: contributor-guide/architecture/update-system.md
+          - UI Components: contributor-guide/architecture/ui-components.md
+          - MCP Integration: contributor-guide/architecture/mcp-integration.md
+          - Scaffolding: contributor-guide/architecture/scaffolding.md
+          - Validation: contributor-guide/architecture/validation.md
+      - Core Flows: contributor-guide/core-flows.md
+      - Testing: contributor-guide/testing.md
+      - Testing SSH Remote: contributor-guide/testing-ssh-remote.md
+      - Validation: contributor-guide/validation.md
+      - Coding Standards: contributor-guide/coding-standards.md
+      - Collection Scripts Spec: contributor-guide/spec-collection-scripts-lib.md
+      - Releasing: contributor-guide/releasing.md
+  - Reference:
+      - Commands: reference/commands.md
+      - Settings: reference/settings.md
+      - Adapter API: reference/adapter-api.md
+      - Hub Schema: reference/hub-schema.md
+  - Migration Guide: migration-guide.md
+
+plugins:
+  - search
+
+markdown_extensions:
+  - admonition
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+      pygments_lang_class: true
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format


### PR DESCRIPTION
## Description

Expose the existing \`docs/\` directory as a GitHub Pages site using MkDocs with the Material theme, styled with Amadeus brand colors. The root README.md is injected as the home page at build time via a hook — no content duplication. A second hook automatically rewrites relative links that escape the \`docs/\` directory into absolute GitHub URLs, so source files stay IDE-friendly (relative links work in VS Code) while the built site links correctly.


## Type of Change

<!-- Mark relevant items with an [x] -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [x] 🔧 Configuration/build changes

## Related Issues

<!-- Link to related issues using #issue_number -->

Closes #257 
Fixes #257 
Relates to #257 

## Changes Made

<!-- Provide a detailed list of changes -->

- Add \`mkdocs.yml\` with Material theme, full navigation (~30 pages), search, and code copy features
- Add \`.github/workflows/docs.yml\` — builds docs on PRs and deploys to GitHub Pages on push to \`main\` using the GitHub Actions Pages artifact flow (path-filtered to \`docs/**\`, \`mkdocs.yml\`, \`README.md\`)
- Add \`docs/_hooks/readme_hook.py\`:
  - \`on_page_read_source\`: injects root \`README.md\` as the docs home page (no duplication)
  - \`on_page_markdown\`: rewrites relative links that escape \`docs/\` to absolute GitHub URLs, and remaps excluded files (e.g., \`docs/README.md\` → \`index.md\`)
- Add \`docs/stylesheets/extra.css\` with Amadeus Dark Sky (\`#000835\`) and Vivid Sky (\`#3A8BFF\`) color scheme, including dark mode support
- Add \`docs/index.md\` stub (content replaced by hook at build time)
- Add Documentation badge to root \`README.md\`
- Add \`site/\` to \`.gitignore\`
- Fix broken cross-references in \`docs/migration-guide.md\` and \`docs/author-guide/agentic-primitives-guide.md\`


## Testing

<!-- Describe the testing you've done -->

### Test Coverage

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

### Manual Testing Steps

1. Run \`pip install mkdocs-material && mkdocs build --strict\` — builds with 0 warnings
2. Run \`mkdocs serve\` — verify home page shows root README content
3. Click links to CONTRIBUTING.md, SECURITY.md, LICENSE.txt — should open on GitHub
4. Navigate all nav sections — all pages render correctly
5. Verify links in \`docs/\` files work in VS Code markdown preview (relative paths)
6. Merge to \`main\` on fork with GitHub Pages set to \`GitHub Actions\` → verify the workflow publishes the built site

### Tested On

- [x] macOS
- [ ] Windows
- [ ] Linux

- [x] VS Code Stable
- [ ] VS Code Insiders

## Screenshots

<img width="2030" height="1270" alt="Screenshot 2026-05-13 at 1 09 17 PM" src="https://github.com/user-attachments/assets/6bf7e970-201b-44af-82c1-2a43d321a303" />

## Checklist

<!-- Mark completed items with an [x] -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Documentation

<!-- Describe any documentation changes needed -->

- [x] README.md updated
- [ ] JSDoc comments added/updated
- [ ] No documentation changes needed

## Additional Notes

<!-- Add any additional notes for reviewers -->
**Admin setup required after merge:** Enable GitHub Pages in the repo Settings → Pages → Source: \`GitHub Actions\`.

The \`site_url\` in \`mkdocs.yml\` is set to \`https://amadeustitgroup.github.io/prompt-registry/\`.


## Reviewer Guidelines

<!-- For reviewers: What should they focus on? -->

Please pay special attention to:

- The build hook logic in \`docs/_hooks/readme_hook.py\` — ensures links work in both IDE and built site
- The GitHub Actions Pages workflow configuration (\`pages: write\`, \`id-token: write\`, artifact upload, and \`actions/deploy-pages\`)

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**
