### PR TITLE
perf: improve test speed and add IDE tsconfig

### DIFF
--- a/lib/test/tsconfig.json
+++ b/lib/test/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../tsconfig.test.json",
+  "compilerOptions": {
+    "rootDir": "..",
+    "outDir": "../dist-test",
+    "types": ["node", "mocha"]
+  },
+  "include": [
+    "**/*",
+    "../src/**/*"
+  ]
+}

--- a/test/adapters/apm-adapter.test.ts
+++ b/test/adapters/apm-adapter.test.ts
@@ -197,7 +197,8 @@ suite('ApmAdapter', () => {
     test('should return empty array when manifest not found', async () => {
       const adapter = new ApmAdapter(mockSource);
 
-      // Will return empty array for non-existent repo
+      sandbox.stub(adapter as any, 'httpsGet').rejects(new Error('Not Found'));
+
       const bundles = await adapter.fetchBundles();
 
       assert.ok(Array.isArray(bundles));
@@ -234,15 +235,15 @@ suite('ApmAdapter', () => {
     test('should cache results', async () => {
       const adapter = new ApmAdapter(mockSource);
 
-      // First call
-      const bundles1 = await adapter.fetchBundles();
+      const httpsGetStub = sandbox.stub(adapter as any, 'httpsGet');
+      httpsGetStub.resolves(JSON.stringify({ tree: [] }));
 
-      // Second call should use cache (same result, no network)
+      const bundles1 = await adapter.fetchBundles();
       const bundles2 = await adapter.fetchBundles();
 
-      // Both should return arrays
       assert.ok(Array.isArray(bundles1));
       assert.ok(Array.isArray(bundles2));
+      assert.strictEqual(httpsGetStub.callCount, 1, 'Should only make one network call due to caching');
     });
   });
 
@@ -266,9 +267,10 @@ suite('ApmAdapter', () => {
 
       const adapter = new ApmAdapter(mockSource);
 
+      sandbox.stub(adapter as any, 'httpsGet').resolves(JSON.stringify({ tree: [] }));
+
       const result = await adapter.validate();
 
-      // Should include validation info
       assert.ok('valid' in result);
       assert.ok('errors' in result);
     });
@@ -352,31 +354,32 @@ suite('ApmAdapter', () => {
     });
 
     test('should not execute arbitrary code from manifest', async () => {
-      // This test verifies that even if a manifest contains script fields,
-      // the adapter does not execute them - it only parses YAML data
       const adapter = new ApmAdapter(mockSource);
 
-      // Fetch bundles - internal https.get will fail for non-existent repo
-      // but this demonstrates the adapter doesn't execute scripts
+      const httpsGetStub = sandbox.stub(adapter as any, 'httpsGet');
+      httpsGetStub.onCall(0).resolves(JSON.stringify({
+        tree: [{ path: 'apm.yml', type: 'blob' }]
+      }));
+      httpsGetStub.onCall(1).resolves('name: malicious\nversion: 1.0.0\nscripts:\n  preinstall: "rm -rf /"');
+
       const bundles = await adapter.fetchBundles();
 
-      // Should return array (empty or with bundles) without executing any scripts
       assert.ok(Array.isArray(bundles));
+      assert.strictEqual(bundles.length, 1);
+      assert.strictEqual(bundles[0].name, 'malicious');
     });
   });
 
   suite('Error Handling', () => {
     test('should handle network errors gracefully', async () => {
-      // When network fails, adapter should return empty array (internal error handling)
-      // Network errors are caught internally and result in empty bundle array
       const adapter = new ApmAdapter(mockSource);
 
-      // The adapter uses https.get internally which will fail for non-existent repos
-      // This tests the graceful handling - no unhandled rejections
+      sandbox.stub(adapter as any, 'httpsGet').rejects(new Error('ECONNREFUSED'));
+
       const bundles = await adapter.fetchBundles();
 
-      // Should return empty array on failure (repo doesn't exist)
       assert.ok(Array.isArray(bundles));
+      assert.strictEqual(bundles.length, 0);
     });
 
     test('should provide helpful error messages when runtime not installed', async () => {

--- a/test/adapters/github-adapter.property.test.ts
+++ b/test/adapters/github-adapter.property.test.ts
@@ -311,36 +311,22 @@ suite('GitHubAdapter Property-Based Tests', () => {
           )
         }),
         async (config) => {
-          const iterationSandbox = sinon.createSandbox();
+          const source = createTestSource();
+          const adapter = new GitHubAdapter(source);
+          const htmlBody = config.htmlTemplate(config.errorText);
+
+          stubHttpsWithResponse(sandbox, 401, htmlBody, 'text/html');
 
           try {
-            const source = createTestSource();
-            const adapter = new GitHubAdapter(source);
-            const htmlBody = config.htmlTemplate(config.errorText);
+            await (adapter as any).makeRequest('https://api.github.com/test');
+            assert.fail('Should have thrown error for HTML response');
+          } catch (error: unknown) {
+            const err = error as Error;
 
-            stubHttpsWithResponse(iterationSandbox, 401, htmlBody, 'text/html');
-
-            // Attempt to make a request
-            try {
-              await (adapter as any).makeRequest('https://api.github.com/test');
-              assert.fail('Should have thrown error for HTML response');
-            } catch (error: unknown) {
-              const err = error as Error;
-
-              // Always verify HTML was recognized
-              assert.ok(
-                ErrorCheckers.indicatesHtmlDetection(err),
-                'Error should indicate HTML response was detected'
-              );
-
-              // Check if extraction occurred (best-effort, non-failing)
-              const hasExtractedText = err.message.includes(config.errorText);
-              if (!hasExtractedText) {
-                console.log(`Note: HTML text extraction didn't capture: "${config.errorText.substring(0, 30)}..."`);
-              }
-            }
-          } finally {
-            iterationSandbox.restore();
+            assert.ok(
+              ErrorCheckers.indicatesHtmlDetection(err),
+              'Error should indicate HTML response was detected'
+            );
           }
         }
       ),
@@ -366,35 +352,21 @@ suite('GitHubAdapter Property-Based Tests', () => {
           htmlBody: fc.string({ minLength: 20, maxLength: 200 })
         }),
         async (config) => {
-          const iterationSandbox = sinon.createSandbox();
+          const source = createTestSource();
+          const adapter = new GitHubAdapter(source);
+          const htmlContent = `<html><body>${config.htmlBody}</body></html>`;
+
+          stubHttpsWithResponse(sandbox, config.statusCode, htmlContent, 'text/html');
 
           try {
-            const source = createTestSource();
-            const adapter = new GitHubAdapter(source);
-            const htmlContent = `<html><body>${config.htmlBody}</body></html>`;
+            await (adapter as any).makeRequest('https://api.github.com/test');
+            assert.fail('Should have thrown error for HTML response');
+          } catch (error: unknown) {
+            const err = error as Error;
 
-            stubHttpsWithResponse(iterationSandbox, config.statusCode, htmlContent, 'text/html');
-
-            // Attempt to make a request
-            try {
-              await (adapter as any).makeRequest('https://api.github.com/test');
-              assert.fail('Should have thrown error for HTML response');
-            } catch (error: unknown) {
-              const err = error as Error;
-
-              // Verify error is NOT a JSON parse error
-              if (ErrorCheckers.isJsonParseError(err)) {
-                console.log(`HTML messaging test failed: Error is about JSON parsing, not auth: ${err.message}`);
-                assert.fail('Error should indicate authentication issue, not JSON parsing');
-              }
-
-              // Verify error indicates auth issue (lenient check)
-              if (!ErrorCheckers.indicatesAuthIssue(err)) {
-                console.log(`HTML messaging test: Error doesn't clearly indicate auth issue: ${err.message}`);
-              }
+            if (ErrorCheckers.isJsonParseError(err)) {
+              assert.fail('Error should indicate authentication issue, not JSON parsing');
             }
-          } finally {
-            iterationSandbox.restore();
           }
         }
       ),
@@ -459,54 +431,19 @@ suite('GitHubAdapter Property-Based Tests', () => {
           urlPath: fc.constantFrom('/repos/owner/repo', '/repos/test/test-repo', '/user')
         }),
         async (config) => {
-          const iterationSandbox = sinon.createSandbox();
+          const source = createTestSource(config.token);
+          const adapter = new GitHubAdapter(source);
+          const testUrl = `https://api.github.com${config.urlPath}`;
+
+          stubHttpsWithResponse(sandbox, config.statusCode);
+          loggerHelpers.resetHistory();
 
           try {
-            const source = createTestSource(config.token);
-            const adapter = new GitHubAdapter(source);
-            const testUrl = `https://api.github.com${config.urlPath}`;
-
-            stubHttpsWithResponse(iterationSandbox, config.statusCode);
-            loggerHelpers.resetHistory();
-
-            // Attempt to make a request
-            try {
-              await (adapter as any).makeRequest(testUrl);
-              assert.fail('Should have thrown error');
-            } catch {
-              const errorCalls = loggerStub.error.getCalls();
-
-              if (errorCalls.length === 0) {
-                console.log('Comprehensive logging test failed: No error logs captured');
-                assert.fail('Should have logged error');
-              }
-
-              // Check that logs include authentication method
-              const hasAuthMethodLog = errorCalls.some((call) => {
-                const message = call.args[0]?.toString().toLowerCase() || '';
-                return message.includes('auth')
-                  && (message.includes('method') || message.includes('explicit')
-                    || message.includes('vscode') || message.includes('gh-cli'));
-              });
-
-              if (!hasAuthMethodLog) {
-                console.log('Comprehensive logging test: No log mentions auth method');
-              }
-
-              // Check that logs include URL
-              const hasUrlLog = errorCalls.some((call) => {
-                const message = call.args[0]?.toString() || '';
-                return message.includes('URL') || message.includes('api.github.com');
-              });
-
-              if (!hasUrlLog) {
-                console.log('Comprehensive logging test: No log mentions URL');
-              }
-
-              assert.ok(errorCalls.length > 0, 'Should have logged error details');
-            }
-          } finally {
-            iterationSandbox.restore();
+            await (adapter as any).makeRequest(testUrl);
+            assert.fail('Should have thrown error');
+          } catch {
+            const errorCalls = loggerStub.error.getCalls();
+            assert.ok(errorCalls.length > 0, 'Should have logged error details');
           }
         }
       ),
@@ -531,45 +468,25 @@ suite('GitHubAdapter Property-Based Tests', () => {
           token: fc.string({ minLength: 20, maxLength: 50 }).filter((s) => s.trim().length > 0)
         }),
         async (config) => {
-          const iterationSandbox = sinon.createSandbox();
+          const source = createTestSource(config.token);
+          const adapter = new GitHubAdapter(source);
 
-          try {
-            const source = createTestSource(config.token);
-            const adapter = new GitHubAdapter(source);
+          loggerHelpers.resetHistory();
+          await (adapter as any).getAuthenticationToken();
 
-            loggerHelpers.resetHistory();
-            await (adapter as any).getAuthenticationToken();
+          const allLogCalls = loggerHelpers.collectAllCalls();
 
-            const allLogCalls = loggerHelpers.collectAllCalls();
-
-            // Check that no log contains the full token (beyond first 8 chars)
-            const fullTokenInLogs = allLogCalls.some((call) => {
-              const message = call.args[0]?.toString() || '';
-              if (config.token.length > 8) {
-                const tokenSuffix = config.token.substring(8);
-                return message.includes(tokenSuffix);
-              }
-              return false;
-            });
-
-            if (fullTokenInLogs) {
-              console.log('Token sanitization test failed: Full token found in logs');
-              assert.fail('Full token should not appear in logs');
+          const fullTokenInLogs = allLogCalls.some((call) => {
+            const message = call.args[0]?.toString() || '';
+            if (config.token.length > 8) {
+              const tokenSuffix = config.token.substring(8);
+              return message.includes(tokenSuffix);
             }
+            return false;
+          });
 
-            // Check that token prefix appears with ellipsis or truncation (optional)
-            const tokenPrefix = config.token.substring(0, 8);
-            const hasTokenPreview = allLogCalls.some((call) => {
-              const message = call.args[0]?.toString() || '';
-              return message.includes(tokenPrefix)
-                && (message.includes('...') || message.includes('preview'));
-            });
-
-            if (!hasTokenPreview) {
-              console.log('Token sanitization test: No token preview found in logs');
-            }
-          } finally {
-            iterationSandbox.restore();
+          if (fullTokenInLogs) {
+            assert.fail('Full token should not appear in logs');
           }
         }
       ),
@@ -595,50 +512,20 @@ suite('GitHubAdapter Property-Based Tests', () => {
           token: fc.string({ minLength: 10, maxLength: 50 }).filter((s) => s.trim().length > 0)
         }),
         async (config) => {
-          const iterationSandbox = sinon.createSandbox();
+          const source = createTestSource(config.token);
+          const adapter = new GitHubAdapter(source);
+
+          stubHttpsWithResponse(sandbox, config.statusCode);
 
           try {
-            const source = createTestSource(config.token);
-            const adapter = new GitHubAdapter(source);
+            await (adapter as any).makeRequest('https://api.github.com/test');
+            assert.fail('Should have thrown error');
+          } catch (error: unknown) {
+            const err = error as Error;
+            const errorMsg = err.message.toLowerCase();
 
-            stubHttpsWithResponse(iterationSandbox, config.statusCode);
-
-            try {
-              await (adapter as any).makeRequest('https://api.github.com/test');
-              assert.fail('Should have thrown error');
-            } catch (error: unknown) {
-              const err = error as Error;
-              const errorMsg = err.message.toLowerCase();
-
-              // Verify error-specific suggestions based on status code
-              const suggestionChecks: Record<number, { keywords: string[]; description: string }> = {
-                401: {
-                  keywords: ['token', 'invalid', 'expired', 'valid'],
-                  description: 'token validity suggestion'
-                },
-                403: {
-                  keywords: ['scope', 'permission', 'access', 'forbidden'],
-                  description: 'scope/permission suggestion'
-                },
-                404: {
-                  keywords: ['not found', 'repository', 'exist', 'accessible'],
-                  description: 'repository suggestion'
-                }
-              };
-
-              const check = suggestionChecks[config.statusCode];
-              if (check) {
-                const hasSuggestion = check.keywords.some((keyword) => errorMsg.includes(keyword));
-                if (!hasSuggestion) {
-                  console.log(`Error-specific suggestions test: ${config.statusCode} error missing ${check.description}: ${err.message}`);
-                }
-              }
-
-              assert.ok(errorMsg.includes(config.statusCode.toString()),
-                'Error should mention status code');
-            }
-          } finally {
-            iterationSandbox.restore();
+            assert.ok(errorMsg.includes(config.statusCode.toString()),
+              'Error should mention status code');
           }
         }
       ),
@@ -657,6 +544,14 @@ suite('GitHubAdapter Property-Based Tests', () => {
   test('Property 15: Exhaustion Method Listing', async function () {
     this.timeout(TEST_CONFIG.TIMEOUT);
 
+    sandbox.stub(vscode.authentication, 'getSession').resolves(undefined);
+
+    const childProcess = require('node:child_process');
+    sandbox.stub(childProcess, 'exec')
+      .callsFake((...args: any[]) => {
+        args[1](new Error('gh not found'), null);
+      });
+
     await fc.assert(
       fc.asyncProperty(
         fc.record({
@@ -664,50 +559,17 @@ suite('GitHubAdapter Property-Based Tests', () => {
           failureCount: fc.integer({ min: 2, max: 3 })
         }),
         async (config) => {
-          const iterationSandbox = sinon.createSandbox();
+          const source = createTestSource(config.explicitToken);
+          const adapter = new GitHubAdapter(source);
+
+          stubHttpsWithResponse(sandbox, 401, JSON.stringify({ message: 'Bad credentials' }));
 
           try {
-            const source = createTestSource(config.explicitToken);
-
-            // Mock all auth methods to fail
-            iterationSandbox.stub(vscode.authentication, 'getSession')
-              .resolves(undefined);
-
-            const childProcess = require('node:child_process');
-            iterationSandbox.stub(childProcess, 'exec')
-              .callsFake((...args: any[]) => {
-                args[1](new Error('gh not found'), null);
-              });
-
-            const adapter = new GitHubAdapter(source);
-
-            stubHttpsWithResponse(iterationSandbox, 401, JSON.stringify({ message: 'Bad credentials' }));
-
-            try {
-              await (adapter as any).makeRequest('https://api.github.com/test');
-              assert.fail('Should have thrown error after exhausting methods');
-            } catch (error: unknown) {
-              const err = error as Error;
-              const errorMsg = err.message.toLowerCase();
-
-              // Verify error message mentions attempted methods
-              const mentionsAttemptedMethods = errorMsg.includes('attempted')
-                || errorMsg.includes('tried')
-                || errorMsg.includes('method');
-
-              if (!mentionsAttemptedMethods) {
-                console.log(`Exhaustion listing test: Error doesn't mention attempted methods: ${err.message}`);
-              }
-
-              const mentionsExplicit = errorMsg.includes('explicit');
-              if (!mentionsExplicit) {
-                console.log(`Exhaustion listing test: Error doesn't mention explicit method: ${err.message}`);
-              }
-
-              assert.ok(err.message.length > 0, 'Should have error message');
-            }
-          } finally {
-            iterationSandbox.restore();
+            await (adapter as any).makeRequest('https://api.github.com/test');
+            assert.fail('Should have thrown error after exhausting methods');
+          } catch (error: unknown) {
+            const err = error as Error;
+            assert.ok(err.message.length > 0, 'Should have error message');
           }
         }
       ),

--- a/test/e2e/github-scaffold-integration.test.ts
+++ b/test/e2e/github-scaffold-integration.test.ts
@@ -352,16 +352,52 @@ suite('E2E: GitHub Scaffold Integration Tests', () => {
 suite('E2E: Script Execution Tests', () => {
   const templateRoot = path.join(process.cwd(), 'templates/scaffolds/github');
   let testDir: string;
+  let npmInstalled: boolean;
 
-  setup(() => {
-    // Create unique temp directory for each test
+  suiteSetup(async function () {
+    this.timeout(60_000);
+
     testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scaffold-script-e2e-'));
+
+    const scaffoldCommand = new ScaffoldCommand(templateRoot, ScaffoldType.GitHub);
+    await scaffoldCommand.execute(testDir, {
+      projectName: 'script-test-project'
+    });
+
+    try {
+      execSync('npm install --prefer-offline', {
+        cwd: testDir,
+        stdio: 'pipe',
+        timeout: 30_000
+      });
+      npmInstalled = true;
+    } catch {
+      npmInstalled = false;
+    }
+
+    if (npmInstalled) {
+      execSync('git init && git config user.email "test@test.com" && git config user.name "Test" && git add -A && git commit -m "initial"', {
+        cwd: testDir,
+        stdio: 'pipe',
+        timeout: 10_000
+      });
+    }
   });
 
-  teardown(() => {
-    // Clean up test directory
+  suiteTeardown(() => {
     if (fs.existsSync(testDir)) {
       fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  setup(function () {
+    if (!npmInstalled) {
+      this.skip();
+    }
+    // Clean artifacts from previous tests to maintain isolation
+    const distDir = path.join(testDir, 'dist');
+    if (fs.existsSync(distDir)) {
+      fs.rmSync(distDir, { recursive: true, force: true });
     }
   });
 
@@ -370,28 +406,8 @@ suite('E2E: Script Execution Tests', () => {
    * Requirements: 5.5 - Test validation scripts in generated projects
    */
   test('E2E: Validation script validates example collection successfully', async function () {
-    this.timeout(60_000);
+    this.timeout(30_000);
 
-    const scaffoldCommand = new ScaffoldCommand(templateRoot, ScaffoldType.GitHub);
-
-    await scaffoldCommand.execute(testDir, {
-      projectName: 'validation-test-project'
-    });
-
-    // Install dependencies (includes @prompt-registry/collection-scripts)
-    try {
-      execSync('npm install', {
-        cwd: testDir,
-        stdio: 'pipe',
-        timeout: 30_000
-      });
-    } catch {
-      // npm install may fail in test environment, skip if so
-      this.skip();
-      return;
-    }
-
-    // Run validation via npm script (backed by @prompt-registry/collection-scripts)
     try {
       const result = execSync('npm run validate --silent', {
         cwd: testDir,
@@ -399,7 +415,6 @@ suite('E2E: Script Execution Tests', () => {
         timeout: 30_000
       });
 
-      // Validation should succeed for the example collection
       const output = result.toString();
       assert.ok(
         !output.toLowerCase().includes('error') || output.toLowerCase().includes('0 error'),
@@ -409,7 +424,6 @@ suite('E2E: Script Execution Tests', () => {
       const stderr = error.stderr?.toString() || '';
       const stdout = error.stdout?.toString() || '';
 
-      // Allow failure due to missing dependencies
       if (stderr.includes('Cannot find module') || stdout.includes('Cannot find module')) {
         this.skip();
       } else {
@@ -423,27 +437,8 @@ suite('E2E: Script Execution Tests', () => {
    * Requirements: 5.5 - Test validation scripts in generated projects
    */
   test('E2E: List collections script finds example collection', async function () {
-    this.timeout(60_000);
+    this.timeout(30_000);
 
-    const scaffoldCommand = new ScaffoldCommand(templateRoot, ScaffoldType.GitHub);
-
-    await scaffoldCommand.execute(testDir, {
-      projectName: 'list-test-project'
-    });
-
-    // Install dependencies
-    try {
-      execSync('npm install', {
-        cwd: testDir,
-        stdio: 'pipe',
-        timeout: 30_000
-      });
-    } catch {
-      this.skip();
-      return;
-    }
-
-    // Run list-collections via npm script
     try {
       const result = execSync('npm run list-collections --silent', {
         cwd: testDir,
@@ -452,7 +447,6 @@ suite('E2E: Script Execution Tests', () => {
       });
 
       const output = result.toString();
-      // Should list the example collection
       assert.ok(
         output.includes('example') || output.includes('collection'),
         'List script should find example collection'
@@ -461,7 +455,6 @@ suite('E2E: Script Execution Tests', () => {
       const stderr = error.stderr?.toString() || '';
       const stdout = error.stdout?.toString() || '';
 
-      // Allow failure due to missing dependencies
       if (stderr.includes('Cannot find module') || stdout.includes('Cannot find module')) {
         this.skip();
       } else {
@@ -475,43 +468,22 @@ suite('E2E: Script Execution Tests', () => {
    * Requirements: 5.5 - Test build scripts produce correct output
    */
   test('E2E: Build script creates bundle with correct structure', async function () {
-    this.timeout(60_000);
+    this.timeout(30_000);
 
-    const scaffoldCommand = new ScaffoldCommand(templateRoot, ScaffoldType.GitHub);
-    const projectName = 'build-test-project';
-
-    await scaffoldCommand.execute(testDir, { projectName });
-
-    // Install dependencies
-    try {
-      execSync('npm install', {
-        cwd: testDir,
-        stdio: 'pipe',
-        timeout: 30_000
-      });
-    } catch {
-      this.skip();
-      return;
-    }
-
-    // Create output directory
     const outputDir = path.join(testDir, 'dist');
     fs.mkdirSync(outputDir, { recursive: true });
 
     try {
-      // Build the example collection via npm script with required arguments
       execSync(`npm run build-collection-bundle -- --collection-file collections/example.collection.yml --version 1.0.0 --repo-slug test-repo --out-dir ${outputDir}`, {
         cwd: testDir,
         stdio: 'pipe',
         timeout: 30_000
       });
 
-      // Verify output files exist
-      const collectionOutDir = path.join(outputDir, projectName);
+      const collectionOutDir = path.join(outputDir, 'script-test-project');
       if (fs.existsSync(collectionOutDir)) {
         const outputFiles = fs.readdirSync(collectionOutDir);
 
-        // Should have created deployment-manifest.yml and zip file
         const hasManifest = outputFiles.some((f) => f.includes('manifest') || f.endsWith('.yml'));
         const hasZip = outputFiles.some((f) => f.endsWith('.zip'));
 
@@ -520,7 +492,6 @@ suite('E2E: Script Execution Tests', () => {
           'Build script should produce manifest and/or zip files'
         );
       } else {
-        // Check if any output was created
         const distFiles = fs.readdirSync(outputDir);
         assert.ok(
           distFiles.length > 0,
@@ -531,7 +502,6 @@ suite('E2E: Script Execution Tests', () => {
       const stderr = error.stderr?.toString() || '';
       const stdout = error.stdout?.toString() || '';
 
-      // Allow failure due to missing dependencies
       if (stderr.includes('Cannot find module') || stdout.includes('Cannot find module')) {
         this.skip();
       } else {
@@ -545,34 +515,8 @@ suite('E2E: Script Execution Tests', () => {
    * Requirements: 5.5 - Test build scripts produce correct output
    */
   test('E2E: Compute version script returns valid version', async function () {
-    this.timeout(60_000);
+    this.timeout(30_000);
 
-    const scaffoldCommand = new ScaffoldCommand(templateRoot, ScaffoldType.GitHub);
-
-    await scaffoldCommand.execute(testDir, {
-      projectName: 'version-test-project'
-    });
-
-    // Install dependencies
-    try {
-      execSync('npm install', {
-        cwd: testDir,
-        stdio: 'pipe',
-        timeout: 30_000
-      });
-    } catch {
-      this.skip();
-      return;
-    }
-
-    // Initialize git repo (required for version computation from git tags)
-    execSync('git init && git config user.email "test@test.com" && git config user.name "Test" && git add -A && git commit -m "initial"', {
-      cwd: testDir,
-      stdio: 'pipe',
-      timeout: 10_000
-    });
-
-    // Run compute-collection-version via npm script
     try {
       const result = execSync('npm run compute-collection-version -- --collection-file collections/example.collection.yml', {
         cwd: testDir,
@@ -581,7 +525,6 @@ suite('E2E: Script Execution Tests', () => {
       });
 
       const output = result.toString().trim();
-      // Should return a valid semver version
       const semverPattern = /\d+\.\d+\.\d+/;
       assert.ok(
         semverPattern.test(output),
@@ -591,11 +534,9 @@ suite('E2E: Script Execution Tests', () => {
       const stderr = error.stderr?.toString() || '';
       const stdout = error.stdout?.toString() || '';
 
-      // Allow failure due to missing dependencies
       if (stderr.includes('Cannot find module') || stdout.includes('Cannot find module')) {
         this.skip();
       } else if (stderr.includes('Usage:') || stdout.includes('Usage:')) {
-        // Script ran but needs different arguments - that's OK
         assert.ok(true, 'Compute version script is executable');
       } else {
         assert.fail(`Compute version script failed: ${stderr || stdout}`);

--- a/test/services/repository-activation-service.property.test.ts
+++ b/test/services/repository-activation-service.property.test.ts
@@ -34,6 +34,9 @@ import {
   LOCKFILE_DEFAULTS,
   LockfileGenerators,
 } from '../helpers/lockfile-test-helpers';
+import {
+  PropertyTestConfig,
+} from '../helpers/property-test-helpers';
 
 const TEST_WORKSPACE_ROOT = '/test/workspace';
 
@@ -46,11 +49,18 @@ const TEST_WORKSPACE_ROOT = '/test/workspace';
 suite('RepositoryActivationService - Property Tests', () => {
   let sandbox: sinon.SinonSandbox;
   let showInformationMessageStub: sinon.SinonStub;
+  let mockLockfileManager: sinon.SinonStubbedInstance<LockfileManager>;
+  let mockHubManager: sinon.SinonStubbedInstance<HubManager>;
+  let mockStorage: sinon.SinonStubbedInstance<RegistryStorage>;
+  let mockContextGetStub: sinon.SinonStub;
 
   setup(() => {
     sandbox = sinon.createSandbox();
     showInformationMessageStub = sandbox.stub(vscode.window, 'showInformationMessage');
-    // Reset all instances before each test
+    mockLockfileManager = sandbox.createStubInstance(LockfileManager);
+    mockHubManager = sandbox.createStubInstance(HubManager);
+    mockStorage = sandbox.createStubInstance(RegistryStorage);
+    mockContextGetStub = sandbox.stub();
     RepositoryActivationService.resetInstance();
   });
 
@@ -59,32 +69,38 @@ suite('RepositoryActivationService - Property Tests', () => {
     RepositoryActivationService.resetInstance();
   });
 
+  /** Resets all stubs for this suite: lockfile, hub, storage, and context stubs */
+  const resetStubs = (): void => {
+    showInformationMessageStub.reset();
+    mockLockfileManager.read.reset();
+    mockLockfileManager.getLockfilePath.reset();
+    mockHubManager.listHubs.reset();
+    mockStorage.getSources.reset();
+    mockStorage.getContext.reset();
+    mockStorage.getInstalledBundles.reset();
+    mockContextGetStub.reset();
+  };
+
+  const configureMockContext = (declinedRepos: string[] = []): void => {
+    mockContextGetStub.returns(declinedRepos);
+    mockStorage.getContext.returns({
+      globalState: { get: mockContextGetStub }
+    } as any);
+  };
+
   test('Property 11: Repository Activation - lockfile presence triggers source detection (no activation prompt per Requirement 1.6)', () => {
     return fc.assert(
       fc.asyncProperty(
         LockfileGenerators.lockfile({ minBundles: 1, maxBundles: 10 }),
         async (lockfile) => {
-          // Reset stub history for each iteration
-          showInformationMessageStub.resetHistory();
+          resetStubs();
           showInformationMessageStub.resolves('Not now');
           RepositoryActivationService.resetInstance();
 
-          // Arrange
-          const mockLockfileManager = sandbox.createStubInstance(LockfileManager);
-          const mockHubManager = sandbox.createStubInstance(HubManager);
-          const mockStorage = sandbox.createStubInstance(RegistryStorage);
-
           mockLockfileManager.read.resolves(lockfile);
           mockLockfileManager.getLockfilePath.returns('/repo/prompt-registry.lock.json');
+          configureMockContext();
 
-          // Mock context with no declined repositories
-          const mockContext = {
-            globalState: {
-              get: sandbox.stub().returns([])
-            }
-          } as any;
-          mockStorage.getContext.returns(mockContext);
-          // Configure all sources so no missing sources prompt is shown
           const sourceIds = Object.keys(lockfile.sources || {});
           const configuredSources = sourceIds.map((id) => ({
             id,
@@ -104,16 +120,13 @@ suite('RepositoryActivationService - Property Tests', () => {
             TEST_WORKSPACE_ROOT
           );
 
-          // Act
           await service.checkAndPromptActivation();
 
-          // Assert - lockfile should be read (source detection happens)
-          // No activation prompt is shown per Requirement 1.6
           assert.ok(mockLockfileManager.read.calledOnce,
             'Should read lockfile for source detection');
         }
       ),
-      { numRuns: 100 }
+      { numRuns: PropertyTestConfig.RUNS.THOROUGH }
     );
   });
 
@@ -123,25 +136,12 @@ suite('RepositoryActivationService - Property Tests', () => {
         LockfileGenerators.lockfile({ minBundles: 1, maxBundles: 10 }),
         fc.string({ minLength: 5, maxLength: 50 }).map((s) => `/repo/${s.replace(/[^a-zA-Z0-9-]/g, 'a')}`),
         async (lockfile, repositoryPath) => {
-          // Reset stub history for each iteration
-          showInformationMessageStub.resetHistory();
+          resetStubs();
           RepositoryActivationService.resetInstance();
-
-          // Arrange
-          const mockLockfileManager = sandbox.createStubInstance(LockfileManager);
-          const mockHubManager = sandbox.createStubInstance(HubManager);
-          const mockStorage = sandbox.createStubInstance(RegistryStorage);
 
           mockLockfileManager.read.resolves(lockfile);
           mockLockfileManager.getLockfilePath.returns(`${repositoryPath}/prompt-registry.lock.json`);
-
-          // Mock context with this repository already declined
-          const mockContext = {
-            globalState: {
-              get: sandbox.stub().returns([repositoryPath])
-            }
-          } as any;
-          mockStorage.getContext.returns(mockContext);
+          configureMockContext([repositoryPath]);
 
           const service = new RepositoryActivationService(
             mockLockfileManager,
@@ -150,15 +150,13 @@ suite('RepositoryActivationService - Property Tests', () => {
             repositoryPath
           );
 
-          // Act
           await service.checkAndPromptActivation();
 
-          // Assert - should never prompt for declined repositories
           assert.ok(!showInformationMessageStub.called,
             'Should never prompt for previously declined repositories');
         }
       ),
-      { numRuns: 100 }
+      { numRuns: PropertyTestConfig.RUNS.THOROUGH }
     );
   });
 
@@ -167,26 +165,13 @@ suite('RepositoryActivationService - Property Tests', () => {
       fc.asyncProperty(
         LockfileGenerators.lockfile({ minBundles: 1, maxBundles: 20 }),
         async (lockfile) => {
-          // Reset stub history for each iteration
-          showInformationMessageStub.resetHistory();
+          resetStubs();
           showInformationMessageStub.resolves('Not now');
           RepositoryActivationService.resetInstance();
 
-          // Arrange
-          const mockLockfileManager = sandbox.createStubInstance(LockfileManager);
-          const mockHubManager = sandbox.createStubInstance(HubManager);
-          const mockStorage = sandbox.createStubInstance(RegistryStorage);
-
           mockLockfileManager.read.resolves(lockfile);
           mockLockfileManager.getLockfilePath.returns('/repo/prompt-registry.lock.json');
-
-          const mockContext = {
-            globalState: {
-              get: sandbox.stub().returns([])
-            }
-          } as any;
-          mockStorage.getContext.returns(mockContext);
-          // No sources configured - will trigger missing sources detection
+          configureMockContext();
           mockStorage.getSources.resolves([]);
           mockHubManager.listHubs.resolves([]);
 
@@ -197,15 +182,13 @@ suite('RepositoryActivationService - Property Tests', () => {
             TEST_WORKSPACE_ROOT
           );
 
-          // Act
           await service.checkAndPromptActivation();
 
-          // Assert - should check for missing sources (no activation prompt per Requirement 1.6)
           assert.ok(mockLockfileManager.read.calledOnce,
             'Should read lockfile to check for missing sources');
         }
       ),
-      { numRuns: 100 }
+      { numRuns: PropertyTestConfig.RUNS.THOROUGH }
     );
   });
 
@@ -214,29 +197,14 @@ suite('RepositoryActivationService - Property Tests', () => {
       fc.asyncProperty(
         LockfileGenerators.lockfile({ minBundles: 1, maxBundles: 5 }),
         async (lockfile) => {
-          // Reset stub history for each iteration
-          showInformationMessageStub.resetHistory();
+          resetStubs();
           showInformationMessageStub.resolves('Not now');
           RepositoryActivationService.resetInstance();
 
-          // Arrange
-          const mockLockfileManager = sandbox.createStubInstance(LockfileManager);
-          const mockHubManager = sandbox.createStubInstance(HubManager);
-          const mockStorage = sandbox.createStubInstance(RegistryStorage);
-
           mockLockfileManager.read.resolves(lockfile);
           mockLockfileManager.getLockfilePath.returns('/repo/prompt-registry.lock.json');
+          configureMockContext();
 
-          const updateStub = sandbox.stub();
-          const mockContext = {
-            globalState: {
-              get: sandbox.stub().returns([]),
-              update: updateStub
-            }
-          } as any;
-          mockStorage.getContext.returns(mockContext);
-
-          // All sources configured - no missing sources prompt
           const sourceIds = Object.keys(lockfile.sources || {});
           const configuredSources = sourceIds.map((id) => ({
             id,
@@ -256,11 +224,8 @@ suite('RepositoryActivationService - Property Tests', () => {
             TEST_WORKSPACE_ROOT
           );
 
-          // Act
           await service.checkAndPromptActivation();
 
-          // Assert - no activation prompt should be shown (Requirement 1.6)
-          // Files are already in repository, no need to ask user to "enable"
           if (showInformationMessageStub.called) {
             const message = showInformationMessageStub.firstCall.args[0] as string;
             assert.ok(!message.toLowerCase().includes('enable'),
@@ -268,7 +233,7 @@ suite('RepositoryActivationService - Property Tests', () => {
           }
         }
       ),
-      { numRuns: 100 }
+      { numRuns: PropertyTestConfig.RUNS.THOROUGH }
     );
   });
 
@@ -277,27 +242,14 @@ suite('RepositoryActivationService - Property Tests', () => {
       fc.asyncProperty(
         LockfileGenerators.lockfile({ minBundles: 1, maxBundles: 5 }),
         async (lockfile) => {
-          // Reset stub history for each iteration
-          showInformationMessageStub.resetHistory();
+          resetStubs();
           showInformationMessageStub.resolves('Not now');
           RepositoryActivationService.resetInstance();
 
-          // Arrange
-          const mockLockfileManager = sandbox.createStubInstance(LockfileManager);
-          const mockHubManager = sandbox.createStubInstance(HubManager);
-          const mockStorage = sandbox.createStubInstance(RegistryStorage);
-
           mockLockfileManager.read.resolves(lockfile);
           mockLockfileManager.getLockfilePath.returns('/repo/prompt-registry.lock.json');
+          configureMockContext();
 
-          const mockContext = {
-            globalState: {
-              get: sandbox.stub().returns([])
-            }
-          } as any;
-          mockStorage.getContext.returns(mockContext);
-
-          // All sources configured
           const sourceIds = Object.keys(lockfile.sources || {});
           const configuredSources = sourceIds.map((id) => ({
             id,
@@ -318,32 +270,23 @@ suite('RepositoryActivationService - Property Tests', () => {
             TEST_WORKSPACE_ROOT
           );
 
-          // Act
           await service.checkAndPromptActivation();
 
-          // Assert - should NOT call getInstalledBundles (no automatic enablement)
-          // Files are already in repository per Requirement 1.6
           assert.ok(!mockStorage.getInstalledBundles.called,
             'Should not call getInstalledBundles - files already in repository');
         }
       ),
-      { numRuns: 100 }
+      { numRuns: PropertyTestConfig.RUNS.THOROUGH }
     );
   });
 
   test('Property 11: Repository Activation Prompt Behavior - no lockfile means no prompt', () => {
     return fc.assert(
       fc.asyncProperty(
-        fc.constant(null), // No lockfile
+        fc.constant(null),
         async (lockfile) => {
-          // Reset stub history for each iteration
-          showInformationMessageStub.resetHistory();
+          resetStubs();
           RepositoryActivationService.resetInstance();
-
-          // Arrange
-          const mockLockfileManager = sandbox.createStubInstance(LockfileManager);
-          const mockHubManager = sandbox.createStubInstance(HubManager);
-          const mockStorage = sandbox.createStubInstance(RegistryStorage);
 
           mockLockfileManager.read.resolves(lockfile);
 
@@ -354,15 +297,13 @@ suite('RepositoryActivationService - Property Tests', () => {
             TEST_WORKSPACE_ROOT
           );
 
-          // Act
           await service.checkAndPromptActivation();
 
-          // Assert - should never prompt without lockfile
           assert.ok(!showInformationMessageStub.called,
             'Should never prompt when no lockfile exists');
         }
       ),
-      { numRuns: 100 }
+      { numRuns: PropertyTestConfig.RUNS.THOROUGH }
     );
   });
 
@@ -372,35 +313,24 @@ suite('RepositoryActivationService - Property Tests', () => {
         LockfileGenerators.lockfile({ minBundles: 1, maxBundles: 5 }),
         fc.string({ minLength: 5, maxLength: 50 }).map((s) => `/repo/${s.replace(/[^a-zA-Z0-9-]/g, 'a')}`),
         async (lockfile, repositoryPath) => {
-          // Reset stub history for each iteration
-          showInformationMessageStub.resetHistory();
+          resetStubs();
           RepositoryActivationService.resetInstance();
-
-          // Arrange
-          const mockLockfileManager = sandbox.createStubInstance(LockfileManager);
-          const mockHubManager = sandbox.createStubInstance(HubManager);
-          const mockStorage = sandbox.createStubInstance(RegistryStorage);
 
           mockLockfileManager.read.resolves(lockfile);
           mockLockfileManager.getLockfilePath.returns(`${repositoryPath}/prompt-registry.lock.json`);
 
-          // Repository is already in declined list
-          const declinedList = [repositoryPath];
-          const getStub = sandbox.stub().callsFake((key: string, defaultValue: any) => {
+          mockContextGetStub.callsFake((key: string, defaultValue: any) => {
             if (key === 'repositoryActivation.declined') {
-              return [...declinedList];
+              return [repositoryPath];
             }
             return defaultValue;
           });
-
-          const mockContext = {
+          mockStorage.getContext.returns({
             globalState: {
-              get: getStub,
+              get: mockContextGetStub,
               update: sandbox.stub()
             }
-          } as any;
-
-          mockStorage.getContext.returns(mockContext);
+          } as any);
           mockStorage.getSources.resolves([]);
           mockHubManager.listHubs.resolves([]);
 
@@ -411,15 +341,13 @@ suite('RepositoryActivationService - Property Tests', () => {
             repositoryPath
           );
 
-          // Act
           await service.checkAndPromptActivation();
 
-          // Assert - should not show any prompt for declined repositories
           assert.ok(!showInformationMessageStub.called,
             'Should not show any prompt for declined repositories');
         }
       ),
-      { numRuns: 100 }
+      { numRuns: PropertyTestConfig.RUNS.THOROUGH }
     );
   });
 });
@@ -433,10 +361,16 @@ suite('RepositoryActivationService - Property Tests', () => {
 suite('RepositoryActivationService - Property Tests (Missing Sources/Hubs)', () => {
   let sandbox: sinon.SinonSandbox;
   let showInformationMessageStub: sinon.SinonStub;
+  let mockLockfileManager: sinon.SinonStubbedInstance<LockfileManager>;
+  let mockHubManager: sinon.SinonStubbedInstance<HubManager>;
+  let mockStorage: sinon.SinonStubbedInstance<RegistryStorage>;
 
   setup(() => {
     sandbox = sinon.createSandbox();
     showInformationMessageStub = sandbox.stub(vscode.window, 'showInformationMessage');
+    mockLockfileManager = sandbox.createStubInstance(LockfileManager);
+    mockHubManager = sandbox.createStubInstance(HubManager);
+    mockStorage = sandbox.createStubInstance(RegistryStorage);
     RepositoryActivationService.resetInstance();
   });
 
@@ -445,19 +379,21 @@ suite('RepositoryActivationService - Property Tests (Missing Sources/Hubs)', () 
     RepositoryActivationService.resetInstance();
   });
 
+  /** Resets stubs for this suite: sources and hubs only (no lockfile/context stubs needed) */
+  const resetStubs = (): void => {
+    showInformationMessageStub.reset();
+    mockStorage.getSources.reset();
+    mockHubManager.listHubs.reset();
+  };
+
   test('Property 14: Missing Source/Hub Detection - detects all missing sources', () => {
     return fc.assert(
       fc.asyncProperty(
         LockfileGenerators.lockfile({ minBundles: 1, maxBundles: 5 }),
         async (lockfile) => {
+          resetStubs();
           RepositoryActivationService.resetInstance();
 
-          // Arrange
-          const mockLockfileManager = sandbox.createStubInstance(LockfileManager);
-          const mockHubManager = sandbox.createStubInstance(HubManager);
-          const mockStorage = sandbox.createStubInstance(RegistryStorage);
-
-          // No sources configured
           mockStorage.getSources.resolves([]);
           mockHubManager.listHubs.resolves([]);
 
@@ -468,10 +404,8 @@ suite('RepositoryActivationService - Property Tests (Missing Sources/Hubs)', () 
             TEST_WORKSPACE_ROOT
           );
 
-          // Act
           const result = await service.checkAndOfferMissingSources(lockfile);
 
-          // Assert - should detect all sources in lockfile
           const lockfileSourceIds = Object.keys(lockfile.sources);
           assert.strictEqual(result.missingSources.length, lockfileSourceIds.length,
             'Should detect all missing sources');
@@ -482,7 +416,7 @@ suite('RepositoryActivationService - Property Tests (Missing Sources/Hubs)', () 
           }
         }
       ),
-      { numRuns: 100 }
+      { numRuns: PropertyTestConfig.RUNS.THOROUGH }
     );
   });
 
@@ -491,14 +425,9 @@ suite('RepositoryActivationService - Property Tests (Missing Sources/Hubs)', () 
       fc.asyncProperty(
         LockfileGenerators.lockfile({ minBundles: 1, maxBundles: 5, includeHubs: true }),
         async (lockfile) => {
+          resetStubs();
           RepositoryActivationService.resetInstance();
 
-          // Arrange
-          const mockLockfileManager = sandbox.createStubInstance(LockfileManager);
-          const mockHubManager = sandbox.createStubInstance(HubManager);
-          const mockStorage = sandbox.createStubInstance(RegistryStorage);
-
-          // No hubs configured
           mockStorage.getSources.resolves([]);
           mockHubManager.listHubs.resolves([]);
 
@@ -509,10 +438,8 @@ suite('RepositoryActivationService - Property Tests (Missing Sources/Hubs)', () 
             TEST_WORKSPACE_ROOT
           );
 
-          // Act
           const result = await service.checkAndOfferMissingSources(lockfile);
 
-          // Assert - should detect all hubs in lockfile
           if (lockfile.hubs) {
             const lockfileHubIds = Object.keys(lockfile.hubs);
             assert.strictEqual(result.missingHubs.length, lockfileHubIds.length,
@@ -525,7 +452,7 @@ suite('RepositoryActivationService - Property Tests (Missing Sources/Hubs)', () 
           }
         }
       ),
-      { numRuns: 100 }
+      { numRuns: PropertyTestConfig.RUNS.THOROUGH }
     );
   });
 
@@ -534,14 +461,9 @@ suite('RepositoryActivationService - Property Tests (Missing Sources/Hubs)', () 
       fc.asyncProperty(
         LockfileGenerators.consistentLockfile({ minBundles: 1, maxBundles: 5 }),
         async (lockfile) => {
+          resetStubs();
           RepositoryActivationService.resetInstance();
 
-          // Arrange
-          const mockLockfileManager = sandbox.createStubInstance(LockfileManager);
-          const mockHubManager = sandbox.createStubInstance(HubManager);
-          const mockStorage = sandbox.createStubInstance(RegistryStorage);
-
-          // Configure all sources from lockfile
           const configuredSources = Object.entries(lockfile.sources).map(([id, source]) => ({
             id,
             type: source.type,
@@ -558,15 +480,13 @@ suite('RepositoryActivationService - Property Tests (Missing Sources/Hubs)', () 
             TEST_WORKSPACE_ROOT
           );
 
-          // Act
           const result = await service.checkAndOfferMissingSources(lockfile);
 
-          // Assert - should not report any missing sources
           assert.strictEqual(result.missingSources.length, 0,
             'Should not report configured sources as missing');
         }
       ),
-      { numRuns: 100 }
+      { numRuns: PropertyTestConfig.RUNS.THOROUGH }
     );
   });
 
@@ -575,16 +495,11 @@ suite('RepositoryActivationService - Property Tests (Missing Sources/Hubs)', () 
       fc.asyncProperty(
         LockfileGenerators.lockfile({ minBundles: 1, maxBundles: 5, includeHubs: true }),
         async (lockfile) => {
+          resetStubs();
           RepositoryActivationService.resetInstance();
-
-          // Arrange
-          const mockLockfileManager = sandbox.createStubInstance(LockfileManager);
-          const mockHubManager = sandbox.createStubInstance(HubManager);
-          const mockStorage = sandbox.createStubInstance(RegistryStorage);
 
           mockStorage.getSources.resolves([]);
 
-          // Configure all hubs from lockfile
           if (lockfile.hubs) {
             const configuredHubs = Object.keys(lockfile.hubs).map((id) => ({
               id,
@@ -604,15 +519,13 @@ suite('RepositoryActivationService - Property Tests (Missing Sources/Hubs)', () 
             TEST_WORKSPACE_ROOT
           );
 
-          // Act
           const result = await service.checkAndOfferMissingSources(lockfile);
 
-          // Assert - should not report any missing hubs
           assert.strictEqual(result.missingHubs.length, 0,
             'Should not report configured hubs as missing');
         }
       ),
-      { numRuns: 100 }
+      { numRuns: PropertyTestConfig.RUNS.THOROUGH }
     );
   });
 
@@ -622,17 +535,10 @@ suite('RepositoryActivationService - Property Tests (Missing Sources/Hubs)', () 
         LockfileGenerators.lockfile({ minBundles: 1, maxBundles: 5 }),
         fc.constantFrom('Add Sources', 'Not now', undefined),
         async (lockfile, userChoice) => {
-          // Reset stub history for each iteration
-          showInformationMessageStub.resetHistory();
+          resetStubs();
           showInformationMessageStub.resolves(userChoice);
           RepositoryActivationService.resetInstance();
 
-          // Arrange
-          const mockLockfileManager = sandbox.createStubInstance(LockfileManager);
-          const mockHubManager = sandbox.createStubInstance(HubManager);
-          const mockStorage = sandbox.createStubInstance(RegistryStorage);
-
-          // No sources configured
           mockStorage.getSources.resolves([]);
           mockHubManager.listHubs.resolves([]);
 
@@ -643,10 +549,8 @@ suite('RepositoryActivationService - Property Tests (Missing Sources/Hubs)', () 
             TEST_WORKSPACE_ROOT
           );
 
-          // Act
           const result = await service.checkAndOfferMissingSources(lockfile);
 
-          // Assert - should offer to add missing sources
           if (result.missingSources.length > 0) {
             assert.ok(showInformationMessageStub.called,
               'Should show prompt when sources are missing');
@@ -655,7 +559,7 @@ suite('RepositoryActivationService - Property Tests (Missing Sources/Hubs)', () 
           }
         }
       ),
-      { numRuns: 100 }
+      { numRuns: PropertyTestConfig.RUNS.THOROUGH }
     );
   });
 
@@ -664,14 +568,9 @@ suite('RepositoryActivationService - Property Tests (Missing Sources/Hubs)', () 
       fc.asyncProperty(
         LockfileGenerators.lockfile({ minBundles: 2, maxBundles: 5 }),
         async (lockfile) => {
+          resetStubs();
           RepositoryActivationService.resetInstance();
 
-          // Arrange
-          const mockLockfileManager = sandbox.createStubInstance(LockfileManager);
-          const mockHubManager = sandbox.createStubInstance(HubManager);
-          const mockStorage = sandbox.createStubInstance(RegistryStorage);
-
-          // Configure only first source
           const sourceIds = Object.keys(lockfile.sources);
           if (sourceIds.length > 1) {
             const firstSourceId = sourceIds[0];
@@ -695,10 +594,8 @@ suite('RepositoryActivationService - Property Tests (Missing Sources/Hubs)', () 
             TEST_WORKSPACE_ROOT
           );
 
-          // Act
           const result = await service.checkAndOfferMissingSources(lockfile);
 
-          // Assert - should detect only unconfigured sources
           const totalSources = Object.keys(lockfile.sources).length;
           const configuredCount = sourceIds.length > 1 ? 1 : 0;
           const expectedMissing = totalSources - configuredCount;
@@ -707,18 +604,18 @@ suite('RepositoryActivationService - Property Tests (Missing Sources/Hubs)', () 
             `Should detect ${expectedMissing} missing sources (${totalSources} total - ${configuredCount} configured)`);
         }
       ),
-      { numRuns: 100 }
+      { numRuns: PropertyTestConfig.RUNS.THOROUGH }
     );
   });
 
   test('Property 14: Missing Source/Hub Detection - empty lockfile returns empty results', () => {
     return fc.assert(
       fc.asyncProperty(
-        fc.constant(null), // Just run once with a manually created empty lockfile
+        fc.constant(null),
         async () => {
+          resetStubs();
           RepositoryActivationService.resetInstance();
 
-          // Create a truly empty lockfile (no bundles, no sources)
           const lockfile: Lockfile = {
             $schema: LOCKFILE_DEFAULTS.SCHEMA_URL,
             version: '1.0.0',
@@ -728,11 +625,6 @@ suite('RepositoryActivationService - Property Tests (Missing Sources/Hubs)', () 
             sources: {}
           };
 
-          // Arrange
-          const mockLockfileManager = sandbox.createStubInstance(LockfileManager);
-          const mockHubManager = sandbox.createStubInstance(HubManager);
-          const mockStorage = sandbox.createStubInstance(RegistryStorage);
-
           mockStorage.getSources.resolves([]);
           mockHubManager.listHubs.resolves([]);
 
@@ -743,10 +635,8 @@ suite('RepositoryActivationService - Property Tests (Missing Sources/Hubs)', () 
             TEST_WORKSPACE_ROOT
           );
 
-          // Act
           const result = await service.checkAndOfferMissingSources(lockfile);
 
-          // Assert - empty lockfile should have no missing sources/hubs
           assert.strictEqual(result.missingSources.length, 0,
             'Empty lockfile should have no missing sources');
           assert.strictEqual(result.missingHubs.length, 0,
@@ -755,7 +645,7 @@ suite('RepositoryActivationService - Property Tests (Missing Sources/Hubs)', () 
             'Should not offer to add when nothing is missing');
         }
       ),
-      { numRuns: 100 }
+      { numRuns: PropertyTestConfig.RUNS.THOROUGH }
     );
   });
 
@@ -764,12 +654,8 @@ suite('RepositoryActivationService - Property Tests (Missing Sources/Hubs)', () 
       fc.asyncProperty(
         LockfileGenerators.lockfile({ minBundles: 1, maxBundles: 5 }),
         async (lockfile) => {
+          resetStubs();
           RepositoryActivationService.resetInstance();
-
-          // Arrange
-          const mockLockfileManager = sandbox.createStubInstance(LockfileManager);
-          const mockHubManager = sandbox.createStubInstance(HubManager);
-          const mockStorage = sandbox.createStubInstance(RegistryStorage);
 
           mockStorage.getSources.resolves([]);
           mockHubManager.listHubs.resolves([]);
@@ -781,18 +667,16 @@ suite('RepositoryActivationService - Property Tests (Missing Sources/Hubs)', () 
             TEST_WORKSPACE_ROOT
           );
 
-          // Act - call twice with same inputs
           const result1 = await service.checkAndOfferMissingSources(lockfile);
           const result2 = await service.checkAndOfferMissingSources(lockfile);
 
-          // Assert - results should be identical
           assert.deepStrictEqual(result1.missingSources.toSorted(), result2.missingSources.toSorted(),
             'Missing sources detection should be deterministic');
           assert.deepStrictEqual(result1.missingHubs.toSorted(), result2.missingHubs.toSorted(),
             'Missing hubs detection should be deterministic');
         }
       ),
-      { numRuns: 100 }
+      { numRuns: PropertyTestConfig.RUNS.THOROUGH }
     );
   });
 });
@@ -811,10 +695,20 @@ suite('RepositoryActivationService - Property Tests (Missing Sources/Hubs)', () 
 suite('RepositoryActivationService - Setup Timing Properties', () => {
   let sandbox: sinon.SinonSandbox;
   let showInformationMessageStub: sinon.SinonStub;
+  let mockLockfileManager: sinon.SinonStubbedInstance<LockfileManager>;
+  let mockHubManager: sinon.SinonStubbedInstance<HubManager>;
+  let mockStorage: sinon.SinonStubbedInstance<RegistryStorage>;
+  let mockSetupStateManager: sinon.SinonStubbedInstance<SetupStateManager>;
+  let mockContextGetStub: sinon.SinonStub;
 
   setup(() => {
     sandbox = sinon.createSandbox();
     showInformationMessageStub = sandbox.stub(vscode.window, 'showInformationMessage');
+    mockLockfileManager = sandbox.createStubInstance(LockfileManager);
+    mockHubManager = sandbox.createStubInstance(HubManager);
+    mockStorage = sandbox.createStubInstance(RegistryStorage);
+    mockSetupStateManager = sandbox.createStubInstance(SetupStateManager);
+    mockContextGetStub = sandbox.stub();
     RepositoryActivationService.resetInstance();
   });
 
@@ -823,17 +717,30 @@ suite('RepositoryActivationService - Setup Timing Properties', () => {
     RepositoryActivationService.resetInstance();
   });
 
+  /** Resets all stubs for this suite: includes SetupStateManager stubs */
+  const resetStubs = (): void => {
+    showInformationMessageStub.reset();
+    mockLockfileManager.read.reset();
+    mockLockfileManager.getLockfilePath.reset();
+    mockHubManager.listHubs.reset();
+    mockStorage.getSources.reset();
+    mockStorage.getContext.reset();
+    mockSetupStateManager.isComplete.reset();
+    mockSetupStateManager.getState.reset();
+    mockContextGetStub.reset();
+  };
+
+  const configureMockContext = (): void => {
+    mockContextGetStub.returns([]);
+    mockStorage.getContext.returns({
+      globalState: { get: mockContextGetStub }
+    } as any);
+  };
+
   /**
    * Property 1: Setup Timing Invariant
    *
    * **Validates: Requirements 1.1, 1.4**
-   *
-   * Statement: Source/hub detection MUST NOT occur before setup is complete.
-   *
-   * ∀ activation events:
-   *   IF SetupStateManager.isComplete() = false
-   *   THEN RepositoryActivationService.checkAndPromptActivation() returns early
-   *   AND no user prompts are shown
    */
   test('Property 1: Setup Timing Invariant - detection never occurs when setup incomplete', () => {
     return fc.assert(
@@ -841,298 +748,18 @@ suite('RepositoryActivationService - Setup Timing Properties', () => {
         LockfileGenerators.lockfile({ minBundles: 1, maxBundles: 10 }),
         fc.constantFrom('not_started', 'in_progress', 'incomplete'),
         async (lockfile, setupState) => {
-          // Reset stub history for each iteration
-          showInformationMessageStub.resetHistory();
+          resetStubs();
           RepositoryActivationService.resetInstance();
 
-          // Arrange
-          const mockLockfileManager = sandbox.createStubInstance(LockfileManager);
-          const mockHubManager = sandbox.createStubInstance(HubManager);
-          const mockStorage = sandbox.createStubInstance(RegistryStorage);
-          const mockSetupStateManager = sandbox.createStubInstance(SetupStateManager);
-
-          // Setup state is NOT complete
           mockSetupStateManager.isComplete.resolves(false);
           mockSetupStateManager.getState.resolves(setupState as any);
 
           mockLockfileManager.read.resolves(lockfile);
           mockLockfileManager.getLockfilePath.returns('/repo/prompt-registry.lock.json');
 
-          // Mock storage to return no configured sources (so prompt would be shown if detection proceeds)
           mockStorage.getSources.resolves([]);
           mockHubManager.listHubs.resolves([]);
-
-          // Mock context with no declined repositories
-          const mockContext = {
-            globalState: {
-              get: sandbox.stub().returns([])
-            }
-          } as any;
-          mockStorage.getContext.returns(mockContext);
-
-          const service = new RepositoryActivationService(
-            mockLockfileManager,
-            mockHubManager,
-            mockStorage,
-            TEST_WORKSPACE_ROOT,
-            undefined, // bundleInstaller
-            mockSetupStateManager
-          );
-
-          // Act
-          await service.checkAndPromptActivation();
-
-          // Assert - no prompts should be shown when setup is incomplete
-          assert.ok(!showInformationMessageStub.called,
-            `Should NOT show any prompts when setup state is '${setupState}' (not complete)`);
-
-          // Verify that storage.getSources was NOT called (early return before source check)
-          assert.ok(!mockStorage.getSources.called,
-            'Should NOT check for missing sources when setup is incomplete');
-        }
-      ),
-      { numRuns: 100 }
-    );
-  });
-
-  /**
-   * Property 1 (continued): Setup Timing Invariant - detection proceeds when setup IS complete
-   *
-   * **Validates: Requirements 1.2**
-   *
-   * Statement: When setup IS complete, detection should proceed normally.
-   * This is verified by checking that the service attempts to check for missing sources.
-   */
-  test('Property 1: Setup Timing Invariant - detection proceeds when setup is complete', () => {
-    return fc.assert(
-      fc.asyncProperty(
-        LockfileGenerators.lockfile({ minBundles: 1, maxBundles: 10 }),
-        async (lockfile) => {
-          // Reset stub history for each iteration
-          showInformationMessageStub.resetHistory();
-          showInformationMessageStub.resolves('Not now');
-          RepositoryActivationService.resetInstance();
-
-          // Arrange
-          const mockLockfileManager = sandbox.createStubInstance(LockfileManager);
-          const mockHubManager = sandbox.createStubInstance(HubManager);
-          const mockStorage = sandbox.createStubInstance(RegistryStorage);
-          const mockSetupStateManager = sandbox.createStubInstance(SetupStateManager);
-
-          // Setup state IS complete
-          mockSetupStateManager.isComplete.resolves(true);
-
-          mockLockfileManager.read.resolves(lockfile);
-          mockLockfileManager.getLockfilePath.returns('/repo/prompt-registry.lock.json');
-
-          // Mock storage to return no configured sources (so prompt will be shown)
-          mockStorage.getSources.resolves([]);
-          mockHubManager.listHubs.resolves([]);
-
-          // Mock context with no declined repositories
-          const mockContext = {
-            globalState: {
-              get: sandbox.stub().returns([])
-            }
-          } as any;
-          mockStorage.getContext.returns(mockContext);
-
-          const service = new RepositoryActivationService(
-            mockLockfileManager,
-            mockHubManager,
-            mockStorage,
-            TEST_WORKSPACE_ROOT,
-            undefined, // bundleInstaller
-            mockSetupStateManager
-          );
-
-          // Act
-          await service.checkAndPromptActivation();
-
-          // Assert - detection should proceed when setup is complete
-          // Verify by checking that storage.getSources was called (source detection proceeded)
-          assert.ok(mockStorage.getSources.called,
-            'Should check for missing sources when setup is complete');
-        }
-      ),
-      { numRuns: 100 }
-    );
-  });
-
-  /**
-   * Property 5: Fail-Open Behavior
-   *
-   * **Validates: Requirements 6.4**
-   *
-   * Statement: If SetupStateManager is unavailable, detection MUST proceed.
-   *
-   * IF setupStateManager = undefined
-   * THEN isSetupComplete() = true
-   * AND detection proceeds normally
-   */
-  test('Property 5: Fail-Open Behavior - detection proceeds when SetupStateManager undefined', () => {
-    return fc.assert(
-      fc.asyncProperty(
-        LockfileGenerators.lockfile({ minBundles: 1, maxBundles: 10 }),
-        async (lockfile) => {
-          // Reset stub history for each iteration
-          showInformationMessageStub.resetHistory();
-          showInformationMessageStub.resolves('Not now');
-          RepositoryActivationService.resetInstance();
-
-          // Arrange
-          const mockLockfileManager = sandbox.createStubInstance(LockfileManager);
-          const mockHubManager = sandbox.createStubInstance(HubManager);
-          const mockStorage = sandbox.createStubInstance(RegistryStorage);
-
-          mockLockfileManager.read.resolves(lockfile);
-          mockLockfileManager.getLockfilePath.returns('/repo/prompt-registry.lock.json');
-
-          // Mock storage to return no configured sources (so prompt will be shown)
-          mockStorage.getSources.resolves([]);
-          mockHubManager.listHubs.resolves([]);
-
-          // Mock context with no declined repositories
-          const mockContext = {
-            globalState: {
-              get: sandbox.stub().returns([])
-            }
-          } as any;
-          mockStorage.getContext.returns(mockContext);
-
-          // Create service WITHOUT SetupStateManager (undefined)
-          const service = new RepositoryActivationService(
-            mockLockfileManager,
-            mockHubManager,
-            mockStorage,
-            TEST_WORKSPACE_ROOT,
-            undefined, // bundleInstaller
-            undefined // setupStateManager - explicitly undefined for fail-open
-          );
-
-          // Act
-          await service.checkAndPromptActivation();
-
-          // Assert - detection should proceed (fail-open behavior)
-          // When SetupStateManager is undefined, the service should assume setup is complete
-          // Verify by checking that storage.getSources was called (source detection proceeded)
-          assert.ok(mockStorage.getSources.called,
-            'Should proceed with source detection when SetupStateManager is undefined (fail-open)');
-        }
-      ),
-      { numRuns: 100 }
-    );
-  });
-
-  /**
-   * Property 5 (continued): Fail-Open Behavior - contrast with defined SetupStateManager
-   *
-   * **Validates: Requirements 6.4**
-   *
-   * This test verifies that when SetupStateManager IS defined and returns incomplete,
-   * detection is blocked - contrasting with the fail-open behavior when undefined.
-   */
-  test('Property 5: Fail-Open Behavior - contrast: defined SetupStateManager blocks when incomplete', () => {
-    return fc.assert(
-      fc.asyncProperty(
-        LockfileGenerators.lockfile({ minBundles: 1, maxBundles: 10 }),
-        async (lockfile) => {
-          // Reset stub history for each iteration
-          showInformationMessageStub.resetHistory();
-          RepositoryActivationService.resetInstance();
-
-          // Arrange
-          const mockLockfileManager = sandbox.createStubInstance(LockfileManager);
-          const mockHubManager = sandbox.createStubInstance(HubManager);
-          const mockStorage = sandbox.createStubInstance(RegistryStorage);
-          const mockSetupStateManager = sandbox.createStubInstance(SetupStateManager);
-
-          // Setup state is NOT complete (defined but incomplete)
-          mockSetupStateManager.isComplete.resolves(false);
-
-          mockLockfileManager.read.resolves(lockfile);
-          mockLockfileManager.getLockfilePath.returns('/repo/prompt-registry.lock.json');
-
-          // Mock storage to return no configured sources
-          mockStorage.getSources.resolves([]);
-          mockHubManager.listHubs.resolves([]);
-
-          // Mock context with no declined repositories
-          const mockContext = {
-            globalState: {
-              get: sandbox.stub().returns([])
-            }
-          } as any;
-          mockStorage.getContext.returns(mockContext);
-
-          // Create service WITH SetupStateManager that returns incomplete
-          const service = new RepositoryActivationService(
-            mockLockfileManager,
-            mockHubManager,
-            mockStorage,
-            TEST_WORKSPACE_ROOT,
-            undefined, // bundleInstaller
-            mockSetupStateManager // defined SetupStateManager
-          );
-
-          // Act
-          await service.checkAndPromptActivation();
-
-          // Assert - detection should be blocked when SetupStateManager is defined and incomplete
-          assert.ok(!mockStorage.getSources.called,
-            'Should NOT check for missing sources when SetupStateManager is defined and returns incomplete');
-        }
-      ),
-      { numRuns: 100 }
-    );
-  });
-
-  /**
-   * Property 1 & 5 Combined: Deterministic behavior across setup states
-   *
-   * **Validates: Requirements 1.1, 1.2, 6.4**
-   *
-   * This test verifies that the behavior is deterministic:
-   * - undefined SetupStateManager -> always proceeds (fail-open)
-   * - defined SetupStateManager with isComplete=true -> always proceeds
-   * - defined SetupStateManager with isComplete=false -> always blocks
-   */
-  test('Property 1 & 5: Deterministic behavior across setup states', () => {
-    return fc.assert(
-      fc.asyncProperty(
-        LockfileGenerators.lockfile({ minBundles: 1, maxBundles: 5 }),
-        fc.constantFrom('undefined', 'complete', 'incomplete'),
-        async (lockfile, setupManagerState) => {
-          // Reset stub history for each iteration
-          showInformationMessageStub.resetHistory();
-          showInformationMessageStub.resolves('Not now');
-          RepositoryActivationService.resetInstance();
-
-          // Arrange
-          const mockLockfileManager = sandbox.createStubInstance(LockfileManager);
-          const mockHubManager = sandbox.createStubInstance(HubManager);
-          const mockStorage = sandbox.createStubInstance(RegistryStorage);
-
-          mockLockfileManager.read.resolves(lockfile);
-          mockLockfileManager.getLockfilePath.returns('/repo/prompt-registry.lock.json');
-
-          // Mock storage to return no configured sources
-          mockStorage.getSources.resolves([]);
-          mockHubManager.listHubs.resolves([]);
-
-          const mockContext = {
-            globalState: {
-              get: sandbox.stub().returns([])
-            }
-          } as any;
-          mockStorage.getContext.returns(mockContext);
-
-          // Configure SetupStateManager based on test case
-          let mockSetupStateManager: sinon.SinonStubbedInstance<SetupStateManager> | undefined;
-          if (setupManagerState !== 'undefined') {
-            mockSetupStateManager = sandbox.createStubInstance(SetupStateManager);
-            mockSetupStateManager.isComplete.resolves(setupManagerState === 'complete');
-          }
+          configureMockContext();
 
           const service = new RepositoryActivationService(
             mockLockfileManager,
@@ -1143,10 +770,180 @@ suite('RepositoryActivationService - Setup Timing Properties', () => {
             mockSetupStateManager
           );
 
-          // Act
           await service.checkAndPromptActivation();
 
-          // Assert - behavior should be deterministic based on setup state
+          assert.ok(!showInformationMessageStub.called,
+            `Should NOT show any prompts when setup state is '${setupState}' (not complete)`);
+          assert.ok(!mockStorage.getSources.called,
+            'Should NOT check for missing sources when setup is incomplete');
+        }
+      ),
+      { numRuns: PropertyTestConfig.RUNS.THOROUGH }
+    );
+  });
+
+  /**
+   * Property 1 (continued): Setup Timing Invariant - detection proceeds when setup IS complete
+   *
+   * **Validates: Requirements 1.2**
+   */
+  test('Property 1: Setup Timing Invariant - detection proceeds when setup is complete', () => {
+    return fc.assert(
+      fc.asyncProperty(
+        LockfileGenerators.lockfile({ minBundles: 1, maxBundles: 10 }),
+        async (lockfile) => {
+          resetStubs();
+          showInformationMessageStub.resolves('Not now');
+          RepositoryActivationService.resetInstance();
+
+          mockSetupStateManager.isComplete.resolves(true);
+
+          mockLockfileManager.read.resolves(lockfile);
+          mockLockfileManager.getLockfilePath.returns('/repo/prompt-registry.lock.json');
+
+          mockStorage.getSources.resolves([]);
+          mockHubManager.listHubs.resolves([]);
+          configureMockContext();
+
+          const service = new RepositoryActivationService(
+            mockLockfileManager,
+            mockHubManager,
+            mockStorage,
+            TEST_WORKSPACE_ROOT,
+            undefined,
+            mockSetupStateManager
+          );
+
+          await service.checkAndPromptActivation();
+
+          assert.ok(mockStorage.getSources.called,
+            'Should check for missing sources when setup is complete');
+        }
+      ),
+      { numRuns: PropertyTestConfig.RUNS.THOROUGH }
+    );
+  });
+
+  /**
+   * Property 5: Fail-Open Behavior
+   *
+   * **Validates: Requirements 6.4**
+   */
+  test('Property 5: Fail-Open Behavior - detection proceeds when SetupStateManager undefined', () => {
+    return fc.assert(
+      fc.asyncProperty(
+        LockfileGenerators.lockfile({ minBundles: 1, maxBundles: 10 }),
+        async (lockfile) => {
+          resetStubs();
+          showInformationMessageStub.resolves('Not now');
+          RepositoryActivationService.resetInstance();
+
+          mockLockfileManager.read.resolves(lockfile);
+          mockLockfileManager.getLockfilePath.returns('/repo/prompt-registry.lock.json');
+
+          mockStorage.getSources.resolves([]);
+          mockHubManager.listHubs.resolves([]);
+          configureMockContext();
+
+          const service = new RepositoryActivationService(
+            mockLockfileManager,
+            mockHubManager,
+            mockStorage,
+            TEST_WORKSPACE_ROOT,
+            undefined,
+            undefined
+          );
+
+          await service.checkAndPromptActivation();
+
+          assert.ok(mockStorage.getSources.called,
+            'Should proceed with source detection when SetupStateManager is undefined (fail-open)');
+        }
+      ),
+      { numRuns: PropertyTestConfig.RUNS.THOROUGH }
+    );
+  });
+
+  /**
+   * Property 5 (continued): Fail-Open Behavior - contrast with defined SetupStateManager
+   *
+   * **Validates: Requirements 6.4**
+   */
+  test('Property 5: Fail-Open Behavior - contrast: defined SetupStateManager blocks when incomplete', () => {
+    return fc.assert(
+      fc.asyncProperty(
+        LockfileGenerators.lockfile({ minBundles: 1, maxBundles: 10 }),
+        async (lockfile) => {
+          resetStubs();
+          RepositoryActivationService.resetInstance();
+
+          mockSetupStateManager.isComplete.resolves(false);
+
+          mockLockfileManager.read.resolves(lockfile);
+          mockLockfileManager.getLockfilePath.returns('/repo/prompt-registry.lock.json');
+
+          mockStorage.getSources.resolves([]);
+          mockHubManager.listHubs.resolves([]);
+          configureMockContext();
+
+          const service = new RepositoryActivationService(
+            mockLockfileManager,
+            mockHubManager,
+            mockStorage,
+            TEST_WORKSPACE_ROOT,
+            undefined,
+            mockSetupStateManager
+          );
+
+          await service.checkAndPromptActivation();
+
+          assert.ok(!mockStorage.getSources.called,
+            'Should NOT check for missing sources when SetupStateManager is defined and returns incomplete');
+        }
+      ),
+      { numRuns: PropertyTestConfig.RUNS.THOROUGH }
+    );
+  });
+
+  /**
+   * Property 1 & 5 Combined: Deterministic behavior across setup states
+   *
+   * **Validates: Requirements 1.1, 1.2, 6.4**
+   */
+  test('Property 1 & 5: Deterministic behavior across setup states', () => {
+    return fc.assert(
+      fc.asyncProperty(
+        LockfileGenerators.lockfile({ minBundles: 1, maxBundles: 5 }),
+        fc.constantFrom('undefined', 'complete', 'incomplete'),
+        async (lockfile, setupManagerState) => {
+          resetStubs();
+          showInformationMessageStub.resolves('Not now');
+          RepositoryActivationService.resetInstance();
+
+          mockLockfileManager.read.resolves(lockfile);
+          mockLockfileManager.getLockfilePath.returns('/repo/prompt-registry.lock.json');
+
+          mockStorage.getSources.resolves([]);
+          mockHubManager.listHubs.resolves([]);
+          configureMockContext();
+
+          let setupMgr: sinon.SinonStubbedInstance<SetupStateManager> | undefined;
+          if (setupManagerState !== 'undefined') {
+            mockSetupStateManager.isComplete.resolves(setupManagerState === 'complete');
+            setupMgr = mockSetupStateManager;
+          }
+
+          const service = new RepositoryActivationService(
+            mockLockfileManager,
+            mockHubManager,
+            mockStorage,
+            TEST_WORKSPACE_ROOT,
+            undefined,
+            setupMgr
+          );
+
+          await service.checkAndPromptActivation();
+
           const shouldProceed = setupManagerState === 'undefined' || setupManagerState === 'complete';
 
           if (shouldProceed) {
@@ -1158,7 +955,7 @@ suite('RepositoryActivationService - Setup Timing Properties', () => {
           }
         }
       ),
-      { numRuns: 100 }
+      { numRuns: PropertyTestConfig.RUNS.THOROUGH }
     );
   });
 });

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.test.json",
+  "compilerOptions": {
+    "rootDir": "..",
+    "outDir": "../test-dist"
+  },
+  "include": [
+    "**/*",
+    "../src/**/*"
+  ]
+}

--- a/test/ui/ui-source-sync-refresh.test.ts
+++ b/test/ui/ui-source-sync-refresh.test.ts
@@ -37,9 +37,11 @@ function simulateDebouncedRefresh(
 
 suite('UI Source Sync Refresh', () => {
   let sandbox: sinon.SinonSandbox;
+  let clock: sinon.SinonFakeTimers;
 
   setup(() => {
     sandbox = sinon.createSandbox();
+    clock = sandbox.useFakeTimers();
   });
 
   teardown(() => {
@@ -47,7 +49,7 @@ suite('UI Source Sync Refresh', () => {
   });
 
   suite('Debouncing Logic', () => {
-    test('should debounce single event correctly', (done) => {
+    test('should debounce single event correctly', () => {
       // Requirement 11.2: WHEN a source synced event is emitted THEN the TreeView SHALL automatically refresh
       // Requirement 11.3: WHEN a source synced event is emitted THEN the MarketplaceView SHALL automatically refresh
 
@@ -58,14 +60,11 @@ suite('UI Source Sync Refresh', () => {
 
       simulateDebouncedRefresh(events, 500, refreshCallback);
 
-      // Wait for debounce
-      setTimeout(() => {
-        assert.strictEqual(refreshCallback.callCount, 1, 'Should call refresh once after debounce');
-        done();
-      }, 600);
+      clock.tick(500);
+      assert.strictEqual(refreshCallback.callCount, 1, 'Should call refresh once after debounce');
     });
 
-    test('should debounce multiple rapid events to single refresh', (done) => {
+    test('should debounce multiple rapid events to single refresh', () => {
       // Requirement 11.4: WHEN the update check triggers source syncs THEN the UI SHALL reflect the latest bundle metadata without user intervention
 
       const refreshCallback = sandbox.spy();
@@ -77,11 +76,8 @@ suite('UI Source Sync Refresh', () => {
 
       simulateDebouncedRefresh(events, 500, refreshCallback);
 
-      // Wait for debounce
-      setTimeout(() => {
-        assert.strictEqual(refreshCallback.callCount, 1, 'Should call refresh only once after debounce');
-        done();
-      }, 600);
+      clock.tick(500);
+      assert.strictEqual(refreshCallback.callCount, 1, 'Should call refresh only once after debounce');
     });
 
     test('should use 500ms debounce delay', () => {


### PR DESCRIPTION
## Summary

- Add `test/tsconfig.json` and `lib/test/tsconfig.json` for VS Code IDE resolution (eliminates red squiggles in test files)
- Property tests: hoist stub creation to suite-level, use `resetStubs()` per iteration instead of per-iteration `createSandbox()`/`restore()`
- E2E scaffold tests: move scaffold + `npm install` + `git init` into `suiteSetup()` (once per suite)
- UI debounce tests: convert `setTimeout` + `done()` to `sandbox.useFakeTimers()` + `clock.tick()` — deterministic, no flakiness
- ApmAdapter tests: stub `httpsGet` explicitly instead of relying on network failures

## Dependencies

⚠️ **Merge #264 first** — this PR is based on the dependency upgrade branch and requires those changes.

## Test plan

- [ ] All existing tests pass
- [ ] Verify VS Code IDE no longer shows type errors in test files
- [ ] Verify test execution time improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)