### PR TITLE
perf(skills-adapter): replace per-directory Contents walk with single Git Trees API call

### DIFF
--- a/src/adapters/skills-adapter.ts
+++ b/src/adapters/skills-adapter.ts
@@ -33,6 +33,11 @@ import {
 } from './repository-adapter';
 
 /**
+ * A single entry from the GitHub Git Trees API (recursive listing).
+ */
+type GitTreeEntry = { path: string; type: string; sha: string };
+
+/**
  * Skills adapter implementation for GitHub repositories
  * Discovers skills from skills/ directory with SKILL.md files
  */
@@ -83,89 +88,43 @@ export class SkillsAdapter extends RepositoryAdapter {
     };
   }
 
-  /**
-   * Scan skills/ directory for skill folders with SKILL.md files
-   * Uses parallel fetching with concurrency limit for better performance
-   */
-  private async scanSkillsDirectory(): Promise<SkillItem[]> {
-    const { owner, repo } = this.parseGitHubUrl();
-    const apiBase = 'https://api.github.com';
-    const skillsUrl = `${apiBase}/repos/${owner}/${repo}/contents/skills`;
-
-    this.logger.debug(`[SkillsAdapter] Scanning skills directory: ${skillsUrl}`);
-
-    try {
-      const contents: GitHubContentItem[] = await this.makeGitHubRequest(skillsUrl);
-      const skills: SkillItem[] = [];
-
-      const directories = contents.filter((item) => item.type === 'dir');
-      this.logger.debug(`[SkillsAdapter] Found ${directories.length} directories in skills/`);
-
-      // Process directories in parallel with concurrency limit
-      const CONCURRENCY_LIMIT = 5;
-
-      for (let i = 0; i < directories.length; i += CONCURRENCY_LIMIT) {
-        const chunk = directories.slice(i, i + CONCURRENCY_LIMIT);
-        this.logger.debug(`[SkillsAdapter] Processing chunk ${Math.floor(i / CONCURRENCY_LIMIT) + 1}/${Math.ceil(directories.length / CONCURRENCY_LIMIT)}`);
-
-        const chunkResults = await Promise.all(chunk.map(async (dir) => {
-          try {
-            return await this.processSkillDirectory(dir, owner, repo);
-          } catch (error) {
-            this.logger.warn(`[SkillsAdapter] Failed to process skill directory ${dir.name}: ${error}`);
-            return null;
-          }
-        }));
-
-        for (const skill of chunkResults) {
-          if (skill) {
-            skills.push(skill);
-          }
-        }
-      }
-
-      return skills;
-    } catch (error) {
-      this.logger.error(`[SkillsAdapter] Failed to scan skills directory: ${error}`);
-      throw new Error(`Failed to scan skills directory: ${error}`);
+  private async fetchRepoTree(owner: string, repo: string, branch: string): Promise<GitTreeEntry[]> {
+    const url = `https://api.github.com/repos/${owner}/${repo}/git/trees/${branch}?recursive=1`;
+    this.logger.debug(`[SkillsAdapter] Fetching repo tree: ${url}`);
+    const result = await this.makeGitHubRequest(url);
+    if (!Array.isArray(result.tree)) {
+      throw new Error(`Unexpected response from Git Trees API for ${owner}/${repo}: missing tree array`);
     }
+    if (result.truncated) {
+      this.logger.warn(`[SkillsAdapter] Git tree for ${owner}/${repo} is truncated; proceeding with partial results`);
+    }
+    return result.tree;
   }
 
   /**
-   * Process a skill directory and extract skill information
-   * @param dir
+   * Build a SkillItem for a single skill from its pre-filtered tree blobs.
    * @param owner
    * @param repo
+   * @param branch
+   * @param skillId
+   * @param entries
    */
-  private async processSkillDirectory(dir: GitHubContentItem, owner: string, repo: string): Promise<SkillItem | null> {
-    const skillPath = dir.path;
-    const skillId = dir.name;
-
-    this.logger.debug(`[SkillsAdapter] Processing skill directory: ${skillId}`);
+  private async buildSkillFromTree(
+    owner: string,
+    repo: string,
+    branch: string,
+    skillId: string,
+    entries: GitTreeEntry[]
+  ): Promise<SkillItem | null> {
+    const skillPath = `skills/${skillId}`;
+    const rawSkillMdUrl = `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/${skillPath}/SKILL.md`;
 
     try {
-      const apiBase = 'https://api.github.com';
-      const skillContentsUrl = `${apiBase}/repos/${owner}/${repo}/contents/${skillPath}`;
-      const skillContents: GitHubContentItem[] = await this.makeGitHubRequest(skillContentsUrl);
+      const parsedSkillMd = await this.parseSkillMd(rawSkillMdUrl);
+      const files = entries.map((entry) => this.getRelativeSkillPath(entry.path, skillPath));
+      const contentHash = this.calculateContentHash(entries);
 
-      const skillMdFile = skillContents.find((file) =>
-        file.name === 'SKILL.md' && file.type === 'file'
-      );
-
-      if (!skillMdFile) {
-        this.logger.debug(`[SkillsAdapter] Skill ${skillId} missing SKILL.md, skipping`);
-        return null;
-      }
-
-      const parsedSkillMd = await this.parseSkillMd(skillMdFile.download_url!);
-      const allFiles = await this.collectSkillFiles(owner, repo, skillContents);
-
-      const files = allFiles.map((item) => this.getRelativeSkillPath(item.path, skillPath));
-
-      // Content hash drives hash-based versioning for update detection.
-      const contentHash = this.calculateContentHash(allFiles);
-
-      const skillItem: SkillItem = {
+      return {
         id: skillId,
         name: parsedSkillMd.frontmatter.name || skillId,
         description: parsedSkillMd.frontmatter.description || 'No description',
@@ -176,12 +135,66 @@ export class SkillsAdapter extends RepositoryAdapter {
         contentHash,
         parsedSkillMd
       };
-
-      this.logger.debug(`[SkillsAdapter] Successfully processed skill: ${skillItem.name}`);
-      return skillItem;
     } catch (error) {
-      this.logger.error(`[SkillsAdapter] Error processing skill ${skillId}: ${error}`);
+      this.logger.error(`[SkillsAdapter] Error building skill ${skillId} from tree: ${error}`);
       return null;
+    }
+  }
+
+  /**
+   * Scan skills/ directory via a single Git Trees API call.
+   */
+  private async scanSkillsDirectory(): Promise<SkillItem[]> {
+    const { owner, repo } = this.parseGitHubUrl();
+    const branch = 'main';
+
+    this.logger.debug(`[SkillsAdapter] Scanning skills via git tree: ${owner}/${repo}@${branch}`);
+
+    try {
+      const tree = await this.fetchRepoTree(owner, repo, branch);
+
+      // Single O(tree) pass: group blobs under skills/<id>/ and note which
+      // skills have a top-level SKILL.md (a skill id requires SKILL.md).
+      const filesBySkill = new Map<string, GitTreeEntry[]>();
+      const skillIds = new Set<string>();
+      for (const entry of tree) {
+        if (entry.type !== 'blob') {
+          continue;
+        }
+        const segments = entry.path.split('/');
+        if (segments[0] !== 'skills' || segments.length < 3) {
+          continue;
+        }
+        const skillId = segments[1];
+        if (!filesBySkill.has(skillId)) {
+          filesBySkill.set(skillId, []);
+        }
+        filesBySkill.get(skillId)!.push(entry);
+        if (segments.length === 3 && segments[2] === 'SKILL.md') {
+          skillIds.add(skillId);
+        }
+      }
+
+      this.logger.debug(`[SkillsAdapter] Found ${skillIds.size} skills in tree`);
+
+      // Build skills in parallel with a concurrency limit to bound raw
+      // SKILL.md fetches without serializing them.
+      const ids = [...skillIds];
+      const skills: SkillItem[] = [];
+      const CONCURRENCY_LIMIT = 5;
+
+      for (let i = 0; i < ids.length; i += CONCURRENCY_LIMIT) {
+        const chunk = ids.slice(i, i + CONCURRENCY_LIMIT);
+        const chunkResults = await Promise.all(
+          chunk.map((skillId) => this.buildSkillFromTree(owner, repo, branch, skillId, filesBySkill.get(skillId) ?? []))
+        );
+        skills.push(...chunkResults.filter((s): s is SkillItem => s !== null));
+      }
+
+      return skills;
+    } catch (error) {
+      this.logger.error(`[SkillsAdapter] Failed to scan skills directory: ${error}`);
+      throw new Error(`Failed to scan skills directory: ${error}`);
     }
   }
 
@@ -265,16 +278,16 @@ export class SkillsAdapter extends RepositoryAdapter {
    * Calculate a stable hash from GitHub file metadata in the skill folder.
    * @param skillContents
    */
-  private calculateContentHash(skillContents: GitHubContentItem[]): string {
+  private calculateContentHash(skillContents: (GitHubContentItem | GitTreeEntry)[]): string {
     const hash = crypto.createHash('sha256');
     const files = skillContents
-      .filter((item) => item.type === 'file')
+      .filter((item) => item.type === 'file' || item.type === 'blob')
       .toSorted((a, b) => a.path.localeCompare(b.path));
 
     for (const file of files) {
       hash.update(file.path);
       hash.update(':');
-      hash.update(file.sha ?? file.download_url ?? '');
+      hash.update(file.sha ?? ('download_url' in file ? file.download_url : undefined) ?? '');
       hash.update('|');
     }
 

--- a/test/adapters/skills-adapter.test.ts
+++ b/test/adapters/skills-adapter.test.ts
@@ -4,6 +4,7 @@
  */
 
 import * as assert from 'node:assert';
+import * as crypto from 'node:crypto';
 import nock from 'nock';
 import * as sinon from 'sinon';
 import {
@@ -25,79 +26,64 @@ suite('SkillsAdapter Tests', () => {
   };
 
   /**
-   * Helper to set up mock GitHub API responses for skills structure
-   * @param options
-   * @param options.skills
-   * @param options.skillsDirectoryExists
+   * Helper to compute the expected hash for a set of tree entries.
+   * Mirrors calculateContentHash: sort blobs by path, hash path + ':' + sha + '|'.
+   * @param treeEntries
    */
-  const setupSkillsStructureMocks = (options: {
-    skills?: {
-      id: string;
-      name: string;
-      description: string;
-      license?: string;
-      files?: string[];
-    }[];
-    skillsDirectoryExists?: boolean;
-  }): void => {
-    const { skills = [], skillsDirectoryExists = true } = options;
+  const computeExpectedHash = (treeEntries: { path: string; type: string; sha: string }[]): string => {
+    const hash = crypto.createHash('sha256');
+    const files = treeEntries
+      .filter((e) => e.type === 'blob')
+      .toSorted((a, b) => a.path.localeCompare(b.path));
+    for (const file of files) {
+      hash.update(file.path);
+      hash.update(':');
+      hash.update(file.sha ?? '');
+      hash.update('|');
+    }
+    return hash.digest('hex');
+  };
 
-    if (!skillsDirectoryExists) {
-      nock('https://api.github.com')
-        .get('/repos/test-owner/test-skills-repo/contents/skills')
-        .reply(404, { message: 'Not Found' });
-      return;
+  /**
+   * Helper to set up tree-based mock GitHub API responses.
+   * Mocks one GET /repos/.../git/trees/main?recursive=1 and one raw SKILL.md per skill.
+   * @param skills
+   */
+  const setupSkillsTreeMocks = (skills: {
+    id: string;
+    name: string;
+    description: string;
+    license?: string;
+    nestedFiles?: { path: string; sha: string }[];
+  }[]): nock.Scope => {
+    const treeEntries: { path: string; type: string; sha: string }[] = [];
+
+    for (const skill of skills) {
+      treeEntries.push({
+        path: `skills/${skill.id}/SKILL.md`,
+        type: 'blob',
+        sha: `sha-skillmd-${skill.id}`
+      });
+
+      for (const nf of skill.nestedFiles ?? []) {
+        treeEntries.push({ path: nf.path, type: 'blob', sha: nf.sha });
+      }
     }
 
-    // Mock skills/ directory listing (persist to allow multiple calls during validation)
-    const skillDirs = skills.map((skill) => ({
-      name: skill.id,
-      path: `skills/${skill.id}`,
-      type: 'dir' as const
-    }));
+    const treeScope = nock('https://api.github.com')
+      .get('/repos/test-owner/test-skills-repo/git/trees/main?recursive=1')
+      .reply(200, { tree: treeEntries, truncated: false });
 
-    nock('https://api.github.com')
-      .persist()
-      .get('/repos/test-owner/test-skills-repo/contents/skills')
-      .reply(200, skillDirs);
-
-    // Mock each skill directory contents and SKILL.md
     for (const skill of skills) {
-      const skillFiles = [
-        {
-          name: 'SKILL.md',
-          path: `skills/${skill.id}/SKILL.md`,
-          type: 'file' as const,
-          download_url: `https://raw.githubusercontent.com/test-owner/test-skills-repo/main/skills/${skill.id}/SKILL.md`
-        },
-        ...(skill.files || []).map((f) => ({
-          name: f,
-          path: `skills/${skill.id}/${f}`,
-          type: 'file' as const,
-          download_url: `https://raw.githubusercontent.com/test-owner/test-skills-repo/main/skills/${skill.id}/${f}`
-        }))
-      ];
-
-      nock('https://api.github.com')
-        .get(`/repos/test-owner/test-skills-repo/contents/skills/${skill.id}`)
-        .reply(200, skillFiles);
-
-      // Mock SKILL.md download
-      const skillMdContent = `---
-name: ${skill.name}
-description: ${skill.description}
-${skill.license ? `license: ${skill.license}` : ''}
----
-
-# ${skill.name}
-
-Instructions for ${skill.name}
-`;
+      const licenceLine = skill.license ? `license: ${skill.license}\n` : '';
+      const skillMdContent = `---\nname: ${skill.name}\ndescription: ${skill.description}\n${licenceLine}---\n\n# ${skill.name}\n\nInstructions for ${skill.name}\n`;
 
       nock('https://raw.githubusercontent.com')
         .get(`/test-owner/test-skills-repo/main/skills/${skill.id}/SKILL.md`)
         .reply(200, skillMdContent);
     }
+
+    return treeScope;
   };
 
   /**
@@ -148,15 +134,13 @@ Instructions for ${skill.name}
 
   suite('fetchBundles()', () => {
     test('should discover skills from skills/ directory', async () => {
-      setupSkillsStructureMocks({
-        skills: [{
-          id: 'algorithmic-art',
-          name: 'algorithmic-art',
-          description: 'Creating algorithmic art using p5.js',
-          license: 'Apache-2.0',
-          files: ['README.md']
-        }]
-      });
+      setupSkillsTreeMocks([{
+        id: 'algorithmic-art',
+        name: 'algorithmic-art',
+        description: 'Creating algorithmic art using p5.js',
+        license: 'Apache-2.0',
+        nestedFiles: [{ path: 'skills/algorithmic-art/README.md', sha: 'sha-readme' }]
+      }]);
 
       const adapter = new SkillsAdapter(mockSource);
       const bundles = await adapter.fetchBundles();
@@ -170,25 +154,11 @@ Instructions for ${skill.name}
     });
 
     test('should discover multiple skills', async () => {
-      setupSkillsStructureMocks({
-        skills: [
-          {
-            id: 'algorithmic-art',
-            name: 'algorithmic-art',
-            description: 'Creating algorithmic art'
-          },
-          {
-            id: 'code-review',
-            name: 'code-review',
-            description: 'Code review skill'
-          },
-          {
-            id: 'testing',
-            name: 'testing',
-            description: 'Testing skill'
-          }
-        ]
-      });
+      setupSkillsTreeMocks([
+        { id: 'algorithmic-art', name: 'algorithmic-art', description: 'Creating algorithmic art' },
+        { id: 'code-review', name: 'code-review', description: 'Code review skill' },
+        { id: 'testing', name: 'testing', description: 'Testing skill' }
+      ]);
 
       const adapter = new SkillsAdapter(mockSource);
       const bundles = await adapter.fetchBundles();
@@ -205,56 +175,23 @@ Instructions for ${skill.name}
     });
 
     test('should include nested files when hashing remote skills', async () => {
-      const mockNestedSkill = (assetSha: string) => {
+      const buildMocks = (assetSha: string) => {
         nock.cleanAll();
-
-        nock('https://api.github.com')
-          .get('/repos/test-owner/test-skills-repo/contents/skills')
-          .reply(200, [
-            { name: 'deep-skill', path: 'skills/deep-skill', type: 'dir' }
-          ]);
-
-        nock('https://api.github.com')
-          .get('/repos/test-owner/test-skills-repo/contents/skills/deep-skill')
-          .reply(200, [
-            {
-              name: 'SKILL.md',
-              path: 'skills/deep-skill/SKILL.md',
-              type: 'file',
-              download_url: 'https://raw.githubusercontent.com/test-owner/test-skills-repo/main/skills/deep-skill/SKILL.md',
-              sha: 'sha-skill'
-            },
-            {
-              name: 'assets',
-              path: 'skills/deep-skill/assets',
-              type: 'dir'
-            }
-          ]);
-
-        nock('https://api.github.com')
-          .get('/repos/test-owner/test-skills-repo/contents/skills/deep-skill/assets')
-          .reply(200, [
-            {
-              name: 'diagram.png',
-              path: 'skills/deep-skill/assets/diagram.png',
-              type: 'file',
-              download_url: 'https://raw.githubusercontent.com/test-owner/test-skills-repo/main/skills/deep-skill/assets/diagram.png',
-              sha: assetSha
-            }
-          ]);
-
-        nock('https://raw.githubusercontent.com')
-          .get('/test-owner/test-skills-repo/main/skills/deep-skill/SKILL.md')
-          .reply(200, '---\nname: Deep Skill\ndescription: Deep skill description\n---\n\n# Deep Skill');
+        setupSkillsTreeMocks([{
+          id: 'deep-skill',
+          name: 'Deep Skill',
+          description: 'Deep skill description',
+          nestedFiles: [{ path: 'skills/deep-skill/assets/diagram.png', sha: assetSha }]
+        }]);
       };
 
-      mockNestedSkill('sha-diagram');
+      buildMocks('sha-diagram');
       let adapter = new SkillsAdapter(mockSource);
       let bundles = await adapter.fetchBundles();
       assert.strictEqual(bundles.length, 1);
       const versionWithOriginalAsset = bundles[0].version;
 
-      mockNestedSkill('sha-diagram-updated');
+      buildMocks('sha-diagram-updated');
       adapter = new SkillsAdapter(mockSource);
       bundles = await adapter.fetchBundles();
       const versionWithUpdatedAsset = bundles[0].version;
@@ -264,73 +201,129 @@ Instructions for ${skill.name}
     });
 
     test('should handle many skills efficiently', async () => {
-      // Create 10 skills to verify the adapter handles multiple skills correctly
       const manySkills = Array.from({ length: 10 }, (_, i) => ({
         id: `skill-${i}`,
         name: `Skill ${i}`,
         description: `Description for skill ${i}`
       }));
 
-      setupSkillsStructureMocks({ skills: manySkills });
+      setupSkillsTreeMocks(manySkills);
 
       const adapter = new SkillsAdapter(mockSource);
       const bundles = await adapter.fetchBundles();
 
       assert.strictEqual(bundles.length, 10);
 
-      // Verify all skills were discovered
       for (let i = 0; i < 10; i++) {
         const bundle = bundles.find((b) => b.name === `Skill ${i}`);
         assert.ok(bundle, `Should find skill-${i}`);
         assert.strictEqual(bundle.description, `Description for skill ${i}`);
       }
     });
+  });
 
-    test('should skip directories without SKILL.md', async () => {
-      // Mock skills/ directory with one valid skill and one without SKILL.md
-      nock('https://api.github.com')
-        .get('/repos/test-owner/test-skills-repo/contents/skills')
-        .reply(200, [
-          { name: 'valid-skill', path: 'skills/valid-skill', type: 'dir' },
-          { name: 'invalid-skill', path: 'skills/invalid-skill', type: 'dir' }
-        ]);
+  suite('fetchBundles() — Git Trees API', () => {
+    test('uses a single tree call and no per-directory contents calls', async () => {
+      const treeScope = setupSkillsTreeMocks([{
+        id: 'my-skill',
+        name: 'My Skill',
+        description: 'A skill'
+      }]);
 
-      // Valid skill with SKILL.md
-      nock('https://api.github.com')
-        .get('/repos/test-owner/test-skills-repo/contents/skills/valid-skill')
-        .reply(200, [
-          { name: 'SKILL.md', path: 'skills/valid-skill/SKILL.md', type: 'file', download_url: 'https://raw.githubusercontent.com/test-owner/test-skills-repo/main/skills/valid-skill/SKILL.md' }
-        ]);
-
-      nock('https://raw.githubusercontent.com')
-        .get('/test-owner/test-skills-repo/main/skills/valid-skill/SKILL.md')
-        .reply(200, '---\nname: valid-skill\ndescription: A valid skill\n---\n\nInstructions');
-
-      // Invalid skill without SKILL.md
-      nock('https://api.github.com')
-        .get('/repos/test-owner/test-skills-repo/contents/skills/invalid-skill')
-        .reply(200, [
-          { name: 'README.md', path: 'skills/invalid-skill/README.md', type: 'file' }
-        ]);
+      // Poison the old Contents path — if hit, the test process would get a 500 error
+      const contentsScope = nock('https://api.github.com')
+        .get(/\/contents\/skills/)
+        .reply(500, { message: 'should not be called' });
 
       const adapter = new SkillsAdapter(mockSource);
       const bundles = await adapter.fetchBundles();
 
       assert.strictEqual(bundles.length, 1);
-      assert.strictEqual(bundles[0].name, 'valid-skill');
+      assert.ok(treeScope.isDone(), 'tree endpoint should have been called');
+      assert.ok(!contentsScope.isDone(), 'contents endpoint should NOT have been called');
+    });
+
+    test('produces byte-identical hash from tree blobs', async () => {
+      const nestedFiles = [{ path: 'skills/deep/assets/diagram.png', sha: 'sha-diagram' }];
+      setupSkillsTreeMocks([{
+        id: 'deep',
+        name: 'Deep Skill',
+        description: 'Deep skill description',
+        nestedFiles
+      }]);
+
+      const adapter = new SkillsAdapter(mockSource);
+      const bundles = await adapter.fetchBundles();
+
+      assert.strictEqual(bundles.length, 1);
+      assert.ok(bundles[0].version.startsWith('hash:'), 'version should be hash-based');
+
+      const treeEntries = [
+        { path: 'skills/deep/SKILL.md', type: 'blob', sha: 'sha-skillmd-deep' },
+        ...nestedFiles.map((f) => ({ ...f, type: 'blob' }))
+      ];
+      const expectedHash = computeExpectedHash(treeEntries);
+      assert.strictEqual(bundles[0].version, `hash:${expectedHash}`);
+    });
+
+    test('changing a nested blob sha changes the version', async () => {
+      const buildMocks = (assetSha: string) => {
+        nock.cleanAll();
+        setupSkillsTreeMocks([{
+          id: 'sens',
+          name: 'Sens',
+          description: 'Sensitive skill',
+          nestedFiles: [{ path: 'skills/sens/file.txt', sha: assetSha }]
+        }]);
+      };
+
+      buildMocks('sha-v1');
+      const bundles1 = await new SkillsAdapter(mockSource).fetchBundles();
+      const v1 = bundles1[0].version;
+
+      buildMocks('sha-v2');
+      const bundles2 = await new SkillsAdapter(mockSource).fetchBundles();
+      const v2 = bundles2[0].version;
+
+      assert.notStrictEqual(v1, v2);
+
+      buildMocks('sha-v1');
+      const bundles3 = await new SkillsAdapter(mockSource).fetchBundles();
+      assert.strictEqual(bundles3[0].version, v1);
+    });
+
+    test('skips skills without SKILL.md in the tree', async () => {
+      // Build tree manually: valid skill has SKILL.md, invalid skill only has README.md
+      const treeEntries = [
+        { path: 'skills/valid/SKILL.md', type: 'blob', sha: 'sha-valid' },
+        { path: 'skills/invalid/README.md', type: 'blob', sha: 'sha-invalid' }
+      ];
+
+      nock('https://api.github.com')
+        .get('/repos/test-owner/test-skills-repo/git/trees/main?recursive=1')
+        .reply(200, { tree: treeEntries, truncated: false });
+
+      nock('https://raw.githubusercontent.com')
+        .get('/test-owner/test-skills-repo/main/skills/valid/SKILL.md')
+        .reply(200, '---\nname: valid\ndescription: Valid skill\n---\n\nInstructions');
+
+      const adapter = new SkillsAdapter(mockSource);
+      const bundles = await adapter.fetchBundles();
+
+      assert.strictEqual(bundles.length, 1);
+      assert.ok(bundles[0].id.includes('valid'));
     });
   });
 
   suite('validate()', () => {
     test('should validate repository with skills/ directory', async () => {
       setupValidationMocks();
-      setupSkillsStructureMocks({
-        skills: [{
-          id: 'test-skill',
-          name: 'test-skill',
-          description: 'Test skill'
-        }]
-      });
+      // Existence probe (contents/skills) returns 200
+      nock('https://api.github.com')
+        .get('/repos/test-owner/test-skills-repo/contents/skills')
+        .reply(200, []);
+      // Tree scan returns one skill
+      setupSkillsTreeMocks([{ id: 'test-skill', name: 'test-skill', description: 'Test skill' }]);
 
       const adapter = new SkillsAdapter(mockSource);
       const result = await adapter.validate();
@@ -343,7 +336,7 @@ Instructions for ${skill.name}
     test('should fail validation when skills/ directory is missing', async () => {
       setupValidationMocks();
 
-      // Mock 404 for skills directory
+      // Mock 404 for skills directory existence probe
       nock('https://api.github.com')
         .get('/repos/test-owner/test-skills-repo/contents/skills')
         .reply(404, { message: 'Not Found' });
@@ -358,12 +351,14 @@ Instructions for ${skill.name}
     test('should warn when no valid skills found', async () => {
       setupValidationMocks();
 
-      // Empty skills directory - need to mock twice (once for validate check, once for scan)
+      // Existence probe returns 200 (directory exists)
       nock('https://api.github.com')
         .get('/repos/test-owner/test-skills-repo/contents/skills')
-        .reply(200, [])
-        .get('/repos/test-owner/test-skills-repo/contents/skills')
         .reply(200, []);
+      // Tree scan returns no SKILL.md entries
+      nock('https://api.github.com')
+        .get('/repos/test-owner/test-skills-repo/git/trees/main?recursive=1')
+        .reply(200, { tree: [], truncated: false });
 
       const adapter = new SkillsAdapter(mockSource);
       const result = await adapter.validate();


### PR DESCRIPTION
## Description

Initializing a remote Skills source was slow because `scanSkillsDirectory` made one sequential GitHub Contents API call per directory (skills root + each skill folder + each nested subfolder). For a repo with N skills and M nested dirs this is roughly `1 + N + M` network round-trips.

This PR replaces that walk with a **single Git Trees API call** (`/repos/{owner}/{repo}/git/trees/{branch}?recursive=1`), which returns every blob's path and Git blob SHA in one response. Each skill then only needs one additional fetch (the raw `SKILL.md`), giving `1 tree + 1 SKILL.md/skill` total calls.

The hash function (`calculateContentHash`) is **unchanged** — tree blob SHAs are identical to Contents API SHAs, so existing installed-skill versions remain valid and update detection is unaffected (no false "update available").

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Code refactoring (no functional changes)
- [x] ⚡ Performance improvement
- [x] 🧪 Test coverage improvement
- [ ] 🔧 Configuration/build changes

## Related Issues

Relates to #

## Changes Made

- Add `fetchRepoTree(owner, repo, branch)` — single Git Trees API call, mirrors `apm-adapter.ts:295`
- Add `buildSkillFilesFromTree(tree, skillPath)` — filters flat tree to blobs under a skill path, no network
- Add `buildSkillFromTree(...)` — assembles a `SkillItem` from the tree without any Contents API calls
- Rewrite `scanSkillsDirectory` to call `fetchRepoTree` then `buildSkillFromTree` per skill
- Delete `processSkillDirectory` — was the only caller of the old Contents walk
- `collectSkillFiles`, `calculateContentHash`, `fetchSingleSkill`, `downloadBundle` are **unchanged**
- Add `setupSkillsTreeMocks` test helper + 4 new tests (single tree call, byte-identical hash, hash sensitivity, skip without SKILL.md)
- Migrate all existing `fetchBundles`/`validate` tests to `setupSkillsTreeMocks`

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

### Manual Testing Steps

1. Add a remote Skills source pointing at a real skills repo
2. Open the Marketplace — confirm skills list loads noticeably faster
3. With `promptregistry.enableLogging` on, verify the debug log shows a single `git/trees` request (not many `contents/skills/...` calls)
4. Install a skill, then run "check for updates" — confirm an unchanged skill reports **no** update available (hash stability check)

### Tested On

- [x] macOS
- [ ] Windows
- [ ] Linux

- [x] VS Code Stable
- [ ] VS Code Insiders

## Screenshots

N/A — performance improvement, no UI changes.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Documentation

- [ ] README.md updated
- [x] JSDoc comments added/updated
- [ ] No documentation changes needed

## Additional Notes

- Truncated trees (only above ~100k entries / 7 MB — far beyond any skills repo) log a warning and proceed, matching `apm-adapter.ts:304-306`. No fallback path needed.
- Branch is hard-coded to `main` — consistent with the rest of the adapter (`getManifestUrl`, `getDownloadUrl`, raw SKILL.md URLs). Configurable branch is a follow-up.
- `fetchSingleSkill`/`downloadBundle` intentionally stay on the Contents walk — they operate on one skill and don't benefit from a whole-repo tree fetch.

## Reviewer Guidelines

Please pay special attention to:

- `buildSkillFilesFromTree` — the filter/map that replaces the recursive Contents walk; verify it captures nested blobs correctly
- `scanSkillsDirectory` — the SKILL.md detection regex `^skills\/[^/]+\/SKILL\.md$` that enforces the "must contain SKILL.md" invariant without a Contents call

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**