### PR TITLE
fix: skip mandatory .agent.md suffix for custom agent detection (#307)

### DIFF
--- a/docs/author-guide/agentic-primitives-guide.md
+++ b/docs/author-guide/agentic-primitives-guide.md
@@ -32,7 +32,7 @@ flowchart TD
 |-----------|---------|------------|-------------|-------------|--------------|
 | **Prompt** | Single-task instructions | Low | Quick, specific tasks | `.prompt.md` | Simple, focused, reusable |
 | **Instruction** | Team standards & guidelines | Medium | Sharing best practices | `.instructions.md` | Contextual, educational |
-| **Agent** | AI persona with behavior | Medium-High | Specialized AI roles | `.agent.md` | Personality, expertise areas |
+| **Agent** | AI persona with behavior | Medium-High | Specialized AI roles | `.agent.md` or `.md` in `agents/` | Personality, expertise areas |
 | **Skill** | Complex capabilities with assets | High | Multi-file functionality | `SKILL.md` + assets | Bundled resources, tools |
 | **Collection** | Organized groups of primitives | Variable | Curating related content | `.collection.yml` | Metadata-driven grouping |
 
@@ -91,7 +91,7 @@ Guidelines for creating React components in our projects.
 [Code examples and patterns]
 ```
 
-### 🤖 Agents (.agent.md)
+### 🤖 Agents (.agent.md or agents/ directory)
 
 **Use when you need:**
 - Specialized AI personas
@@ -240,7 +240,7 @@ category: Development
 - Follow consistent patterns:
   - `task-name.prompt.md`
   - `standard-name.instructions.md`
-  - `role-name.agent.md`
+  - `role-name.agent.md` (or any `.md` file in an `agents/` directory)
   - `capability-name/` (for skills)
 
 ### 3. Content Quality

--- a/docs/author-guide/creating-source-bundle.md
+++ b/docs/author-guide/creating-source-bundle.md
@@ -17,7 +17,7 @@ my-collection/
 ├── instructions/
 │   └── *.instructions.md
 ├── agents/
-│   └── *.agent.md
+│   └── *.md (any markdown file)
 └── README.md
 ```
 
@@ -43,7 +43,7 @@ See [Collection Schema](./collection-schema.md) for full reference.
 |------|-----------|---------|
 | Prompt | `.prompt.md` | Reusable prompt templates |
 | Instruction | `.instructions.md` | System guidelines |
-| Agent | `.agent.md` | Autonomous task patterns |
+| Agent | `.agent.md` or `.md` in `agents/` | Autonomous task patterns |
 
 ## Scaffolding a Project
 

--- a/docs/contributor-guide/architecture/installation-flow.md
+++ b/docs/contributor-guide/architecture/installation-flow.md
@@ -126,7 +126,7 @@ Files are placed in `.github/` subdirectories based on type:
 |-----------|------------------|
 | Prompts (`.prompt.md`) | `.github/prompts/` |
 | Instructions (`.instructions.md`) | `.github/instructions/` |
-| Agents (`.agent.md`) | `.github/agents/` |
+| Agents (`.agent.md` or `.md` in `agents/`) | `.github/agents/` |
 | Skills | `.github/skills/<skill-name>/` |
 | MCP Servers | `.vscode/mcp.json` |
 

--- a/docs/user-guide/repository-installation.md
+++ b/docs/user-guide/repository-installation.md
@@ -200,7 +200,7 @@ If you've modified bundle files locally, you'll see a warning before updating wi
 |-----------|---------------------|
 | Prompts (`.prompt.md`) | `.github/prompts/` |
 | Instructions (`.instructions.md`) | `.github/instructions/` |
-| Agents (`.agent.md`) | `.github/agents/` |
+| Agents (`.agent.md` or `.md` in `agents/`) | `.github/agents/` |
 | Skills | `.github/skills/<skill-name>/` |
 | MCP Servers | `.vscode/mcp.json` |
 

--- a/src/adapters/apm-adapter.ts
+++ b/src/adapters/apm-adapter.ts
@@ -469,14 +469,14 @@ export class ApmAdapter extends RepositoryAdapter {
 
     const prompts = promptFiles.map((file) => {
       const filename = path.basename(file);
-      const id = filename.replace(/\.(prompt|instructions|agent|chatmode)\.md$/, '');
+      const id = filename.replace(/\.(prompt|instructions|agent|chatmode)\.md$/, '').replace(/\.md$/, '');
 
       return {
         id,
         name: this.titleCase(id.replace(/-/g, ' ')),
         description: `From ${bundle.name}`,
         file: `prompts/${filename}`,
-        type: this.detectFileType(filename),
+        type: this.detectFileType(file),
         tags: apmManifest.tags || []
       };
     });
@@ -534,6 +534,9 @@ export class ApmAdapter extends RepositoryAdapter {
             }
           } else if (PROMPT_EXTENSIONS.some((ext) => entry.name.endsWith(ext))) {
             files.push(fullPath);
+          } else if (entry.name.endsWith('.md') && /(?:^|[/])agents[/]/i.test(fullPath.replace(/\\/g, '/'))) {
+            // VS Code no longer requires .agent.md suffix — any .md in agents/ is an agent
+            files.push(fullPath);
           }
         }
       } catch {
@@ -547,9 +550,10 @@ export class ApmAdapter extends RepositoryAdapter {
 
   /**
    * Detect file type from extension
-   * @param filename
+   * @param filePath
    */
-  private detectFileType(filename: string): 'prompt' | 'instructions' | 'chatmode' | 'agent' {
+  private detectFileType(filePath: string): 'prompt' | 'instructions' | 'chatmode' | 'agent' {
+    const filename = path.basename(filePath);
     if (filename.endsWith('.instructions.md')) {
       return 'instructions';
     }
@@ -557,6 +561,11 @@ export class ApmAdapter extends RepositoryAdapter {
       return 'chatmode';
     }
     if (filename.endsWith('.agent.md')) {
+      return 'agent';
+    }
+    // VS Code no longer requires .agent.md suffix — any .md in agents/ is an agent
+    const normalized = filePath.replace(/\\/g, '/');
+    if (/(?:^|[/])agents[/]/i.test(normalized) && filename.endsWith('.md')) {
       return 'agent';
     }
     return 'prompt';

--- a/src/adapters/awesome-copilot-adapter.ts
+++ b/src/adapters/awesome-copilot-adapter.ts
@@ -314,7 +314,7 @@ export class AwesomeCopilotAdapter extends RepositoryAdapter {
 
       // For other types, use prompts/ folder
       const filename = itemPath.split('/').pop() || 'unknown';
-      const id = filename.replace(/\.(prompt|instructions|chatmode|agent)\.md$/, '');
+      const id = filename.replace(/\.(prompt|instructions|chatmode|agent)\.md$/, '').replace(/\.md$/, '');
 
       return {
         id,

--- a/src/adapters/local-apm-adapter.ts
+++ b/src/adapters/local-apm-adapter.ts
@@ -325,14 +325,14 @@ export class LocalApmAdapter extends RepositoryAdapter {
 
     const prompts = promptFiles.map((file) => {
       const filename = path.basename(file);
-      const id = filename.replace(/\.(prompt|instructions|agent|chatmode)\.md$/, '');
+      const id = filename.replace(/\.(prompt|instructions|agent|chatmode)\.md$/, '').replace(/\.md$/, '');
 
       return {
         id,
         name: this.titleCase(id.replace(/-/g, ' ')),
         description: `From ${bundle.name}`,
         file: `prompts/${filename}`,
-        type: this.detectFileType(filename),
+        type: this.detectFileType(file),
         tags: apmManifest.tags || []
       };
     });
@@ -392,6 +392,9 @@ export class LocalApmAdapter extends RepositoryAdapter {
             }
           } else if (PROMPT_EXTENSIONS.some((ext) => entry.name.endsWith(ext))) {
             files.push(fullPath);
+          } else if (entry.name.endsWith('.md') && /(?:^|[/])agents[/]/i.test(fullPath.replace(/\\/g, '/'))) {
+            // VS Code no longer requires .agent.md suffix — any .md in agents/ is an agent
+            files.push(fullPath);
           }
         }
       } catch {
@@ -405,9 +408,10 @@ export class LocalApmAdapter extends RepositoryAdapter {
 
   /**
    * Detect file type from filename
-   * @param filename
+   * @param filePath
    */
-  private detectFileType(filename: string): 'prompt' | 'instructions' | 'chatmode' | 'agent' {
+  private detectFileType(filePath: string): 'prompt' | 'instructions' | 'chatmode' | 'agent' {
+    const filename = path.basename(filePath);
     if (filename.endsWith('.instructions.md')) {
       return 'instructions';
     }
@@ -415,6 +419,11 @@ export class LocalApmAdapter extends RepositoryAdapter {
       return 'chatmode';
     }
     if (filename.endsWith('.agent.md')) {
+      return 'agent';
+    }
+    // VS Code no longer requires .agent.md suffix — any .md in agents/ is an agent
+    const normalized = filePath.replace(/\\/g, '/');
+    if (/(?:^|[/])agents[/]/i.test(normalized) && filename.endsWith('.md')) {
       return 'agent';
     }
     return 'prompt';

--- a/src/adapters/local-awesome-copilot-adapter.ts
+++ b/src/adapters/local-awesome-copilot-adapter.ts
@@ -357,7 +357,7 @@ export class LocalAwesomeCopilotAdapter extends RepositoryAdapter {
 
       // For other types, use prompts/ folder
       const filename = path.basename(itemPath);
-      const id = filename.replace(/\.(prompt|instructions|chatmode|agent)\.md$/, '');
+      const id = filename.replace(/\.(prompt|instructions|chatmode|agent)\.md$/, '').replace(/\.md$/, '');
 
       return {
         id,

--- a/src/commands/validate-apm-command.ts
+++ b/src/commands/validate-apm-command.ts
@@ -74,6 +74,9 @@ export class ValidateApmCommand {
         } else {
           if (PROMPT_EXTENSIONS.some((ext) => name.endsWith(ext))) {
             fileList.push(entryUri.fsPath);
+          } else if (name.endsWith('.md') && /(?:^|[/])agents[/]/i.test(entryUri.fsPath.replace(/\\/g, '/'))) {
+            // VS Code no longer requires .agent.md suffix — any .md in agents/ is an agent
+            fileList.push(entryUri.fsPath);
           }
         }
       }

--- a/src/services/bundle-installer.ts
+++ b/src/services/bundle-installer.ts
@@ -38,6 +38,7 @@ import {
   isManifestIdMatch,
 } from '../utils/bundle-name-utils';
 import {
+  CopilotFileType,
   determineFileType,
   getRepositoryTargetDirectory,
   getTargetFileName,
@@ -224,7 +225,7 @@ export class BundleInstaller {
       // Collect files from .github/ directories based on manifest
       for (const promptDef of manifest.prompts) {
         const promptId = normalizePromptId(promptDef.id);
-        const fileType = determineFileType(promptDef.file, promptDef.tags);
+        const fileType = (promptDef.type as CopilotFileType) || determineFileType(promptDef.file, promptDef.tags);
         const targetDir = getRepositoryTargetDirectory(fileType);
 
         if (fileType === 'skill') {

--- a/src/utils/copilot-file-type-utils.ts
+++ b/src/utils/copilot-file-type-utils.ts
@@ -102,10 +102,11 @@ export function getSkillName(skillPath: string): string | null {
  *
  * Detection priority:
  * 1. File extension patterns (e.g., .prompt.md, .agent.md)
- * 2. Special file names (e.g., SKILL.md)
- * 3. Tags from manifest
- * 4. Filename patterns (e.g., contains "instructions")
- * 5. Default to 'prompt'
+ * 2. Directory-based detection (e.g., any .md file in an agents/ directory)
+ * 3. Special file names (e.g., SKILL.md)
+ * 4. Tags from manifest
+ * 5. Filename patterns (e.g., contains "instructions")
+ * 6. Default to 'prompt'
  * @param fileName - The file name or path to analyze
  * @param tags - Optional tags from the manifest
  * @returns The detected CopilotFileType
@@ -129,12 +130,19 @@ export function determineFileType(fileName: string, tags?: string[]): CopilotFil
     return 'agent';
   }
 
-  // 2. Check for special file names
+  // 2. Check if file is in an agents/ directory
+  // VS Code no longer requires .agent.md suffix — any .md in agents/ is an agent
+  const normalizedPath = fileName.replace(/\\/g, '/');
+  if (lowerBaseName.endsWith('.md') && /(?:^|[/])agents[/]/i.test(normalizedPath)) {
+    return 'agent';
+  }
+
+  // 3. Check for special file names
   if (lowerBaseName === 'skill.md') {
     return 'skill';
   }
 
-  // 3. Check tags if provided
+  // 4. Check tags if provided
   if (tags && tags.length > 0) {
     const lowerTags = tags.map((t) => t.toLowerCase());
 
@@ -152,12 +160,12 @@ export function determineFileType(fileName: string, tags?: string[]): CopilotFil
     }
   }
 
-  // 4. Check filename patterns
+  // 5. Check filename patterns
   if (lowerBaseName.includes('instructions')) {
     return 'instructions';
   }
 
-  // 5. Default to prompt
+  // 6. Default to prompt
   return 'prompt';
 }
 

--- a/test/adapters/local-apm-adapter.test.ts
+++ b/test/adapters/local-apm-adapter.test.ts
@@ -5,6 +5,8 @@
 
 import * as assert from 'node:assert';
 import * as path from 'node:path';
+import AdmZip from 'adm-zip';
+import * as yaml from 'js-yaml';
 import {
   LocalApmAdapter,
 } from '../../src/adapters/local-apm-adapter';
@@ -263,6 +265,28 @@ suite('LocalApmAdapter', () => {
 
       // Archive should be non-trivial size (manifest + files)
       assert.ok(buffer.length > 100);
+    });
+
+    test('should detect agent type for .md files in agents/ directory (no .agent.md suffix)', async () => {
+      const adapter = new LocalApmAdapter(mockSource);
+      const bundles = await adapter.fetchBundles();
+      const bundle = bundles[0];
+
+      assert.ok(bundle);
+      const buffer = await adapter.downloadBundle(bundle);
+
+      // Parse the zip to extract deployment-manifest.yml
+      const zip = new AdmZip(buffer);
+      const manifestEntry = zip.getEntry('deployment-manifest.yml');
+      assert.ok(manifestEntry, 'deployment-manifest.yml should be in archive');
+      const manifestContent = manifestEntry.getData().toString('utf8');
+      const manifest = yaml.load(manifestContent) as any;
+
+      // Find the agent prompt entry
+      const agentPrompt = manifest.prompts.find((p: any) => p.type === 'agent');
+      assert.ok(agentPrompt, 'Manifest should contain an agent type prompt');
+      assert.strictEqual(agentPrompt.id, 'code-reviewer');
+      assert.ok(agentPrompt.file.includes('code-reviewer.md'));
     });
   });
 

--- a/test/fixtures/apm/single-package/agents/code-reviewer.md
+++ b/test/fixtures/apm/single-package/agents/code-reviewer.md
@@ -1,0 +1,10 @@
+---
+name: Code Reviewer
+description: Reviews code for quality and best practices
+tools:
+  - changes
+  - github
+model: claude-sonnet-4
+---
+
+You are a code reviewer agent. Review code for quality, security, and best practices.

--- a/test/utils/copilot-file-type-utils.test.ts
+++ b/test/utils/copilot-file-type-utils.test.ts
@@ -77,6 +77,17 @@ suite('copilotFileTypeUtils', () => {
         assert.strictEqual(determineFileType('test.agent.md'), 'agent');
       });
 
+      test('should detect agent type from agents/ directory (no .agent.md suffix needed)', () => {
+        assert.strictEqual(determineFileType('agents/code-reviewer.md'), 'agent');
+        assert.strictEqual(determineFileType('agents/my-agent.md'), 'agent');
+        assert.strictEqual(determineFileType('path/to/agents/my-agent.md'), 'agent');
+      });
+
+      test('should not detect agent type for .md files outside agents/ directory', () => {
+        assert.strictEqual(determineFileType('prompts/my-agent.md'), 'prompt');
+        assert.strictEqual(determineFileType('instructions/my-agent.md'), 'prompt');
+      });
+
       test('should detect skill type from SKILL.md file', () => {
         assert.strictEqual(determineFileType('SKILL.md'), 'skill');
       });
@@ -121,6 +132,11 @@ suite('copilotFileTypeUtils', () => {
         assert.strictEqual(determineFileType('generic.md', ['agent']), 'agent');
         assert.strictEqual(determineFileType('generic.md', ['chatmode']), 'chatmode');
       });
+
+      test('should prioritize agents/ directory over tags for .md files', () => {
+        assert.strictEqual(determineFileType('agents/generic.md', ['instructions']), 'agent');
+        assert.strictEqual(determineFileType('agents/generic.md', ['chatmode']), 'agent');
+      });
     });
 
     suite('edge cases', () => {
@@ -140,6 +156,11 @@ suite('copilotFileTypeUtils', () => {
       test('should handle paths with directories', () => {
         assert.strictEqual(determineFileType('prompts/my-prompt.prompt.md'), 'prompt');
         assert.strictEqual(determineFileType('agents/code-reviewer.agent.md'), 'agent');
+      });
+
+      test('should handle Windows-style backslash paths in agents/ directory', () => {
+        assert.strictEqual(determineFileType('agents\\code-reviewer.md'), 'agent');
+        assert.strictEqual(determineFileType('path\\to\\agents\\my-agent.md'), 'agent');
       });
     });
   });


### PR DESCRIPTION
## Description

VS Code no longer requires the .agent.md suffix for custom agents. Any .md file in an agents/ directory is now recognized as an agent.

## Type of Change

<!-- Mark relevant items with an [x] -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 📝 Documentation update

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes #307

## Changes Made

- determineFileType: add directory-based detection for agents/ dir
- APM adapters (apm, local-apm): findPromptFiles picks up .md from agents/, detectFileType accepts full path and checks agents/ dir
- Awesome Copilot adapters: fix ID extraction for plain .md files
- bundle-installer: use promptDef.type from manifest when available
- validate-apm-command: scan .md files in agents/ directories
- Tests: add directory-based agent detection tests, fixture with plain .md agent file, adapter test verifying agent type detection
- Docs: update file type tables and naming conventions


## Testing

<!-- Describe the testing you've done -->

### Test Coverage

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

### Tested On

- [x] Linux

- [x] VS Code Insiders

## Checklist

<!-- Mark completed items with an [x] -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Documentation

<!-- Describe any documentation changes needed -->

- [x] README.md updated
- [x] JSDoc comments added/updated

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**
