### PR TITLE
fix: resolve skill source dir from manifest path instead of hardcoded skills/ prefix

### DIFF
--- a/src/adapters/local-skills-adapter.ts
+++ b/src/adapters/local-skills-adapter.ts
@@ -470,7 +470,7 @@ export class LocalSkillsAdapter extends RepositoryAdapter {
           id: skill.id,
           name: skill.name,
           description: skill.description,
-          file: `SKILL.md`,
+          file: `skills/${skill.id}/SKILL.md`,
           type: 'skill',
           tags: ['skill', 'anthropic', 'local']
         }

--- a/src/services/bundle-installer.ts
+++ b/src/services/bundle-installer.ts
@@ -508,29 +508,6 @@ export class BundleInstaller {
   }
 
   /**
-   * Extract skill name from a skills bundle
-   * Looks for the first directory under skills/ in the extracted bundle
-   * @param extractDir
-   */
-  private async extractSkillNameFromBundle(extractDir: string): Promise<string> {
-    const skillsDir = path.join(extractDir, 'skills');
-
-    if (!fs.existsSync(skillsDir)) {
-      throw new Error('Skills directory not found in bundle');
-    }
-
-    const entries = await readdir(skillsDir, { withFileTypes: true });
-    const skillDirs = entries.filter((e) => e.isDirectory());
-
-    if (skillDirs.length === 0) {
-      throw new Error('No skill directories found in bundle');
-    }
-
-    // Return the first skill directory name
-    return skillDirs[0].name;
-  }
-
-  /**
    * Copy directory recursively
    * @param sourceDir
    * @param targetDir
@@ -775,9 +752,16 @@ export class BundleInstaller {
       let installDir: string;
 
       if (installSkillsToCopilotDir) {
-        // Skills bundles install directly to Copilot skills directory for user/workspace scopes
-        // Extract skill name from the bundle - look in skills/ directory
-        const skillName = await this.extractSkillNameFromBundle(extractDir);
+        // Skills bundles install directly to Copilot skills directory for user/workspace scopes.
+        // Derive the skill's source directory from the manifest file path so skills packaged
+        // under a non-standard directory (e.g. .github/skills/) are resolved correctly.
+        const skillEntry = (manifest.prompts || []).find((p) => p.type === 'skill');
+        const skillFile = skillEntry?.file;
+        if (!skillFile) {
+          throw new Error('No skill entry found in bundle manifest');
+        }
+        const skillDir = path.dirname(skillFile);
+        const skillName = path.basename(skillDir);
         const copilotScope = options.scope === 'workspace' ? 'workspace' : 'user';
         installDir = this.copilotSync.getCopilotSkillsDirectory(copilotScope);
         await ensureDirectory(installDir);
@@ -786,7 +770,7 @@ export class BundleInstaller {
         this.logger.debug(`[BundleInstaller] Skills bundle detected, installing to: ${installDir}`);
 
         // Copy skill files directly to ~/.copilot/skills/{skill-name}
-        const skillSourceDir = path.join(extractDir, 'skills', skillName);
+        const skillSourceDir = path.join(extractDir, skillDir);
         if (fs.existsSync(skillSourceDir)) {
           // Check for existing skill using checkPathExists to detect broken symlinks
           const existingEntry = await checkPathExists(installDir);
@@ -807,7 +791,7 @@ export class BundleInstaller {
           }
           await this.copyDirectory(skillSourceDir, installDir);
         } else {
-          throw new Error(`Skill directory not found in bundle: skills/${skillName}`);
+          throw new Error(`Skill directory not found in bundle: ${skillDir}`);
         }
       } else {
         // Step 5: Get installation directory (standard bundles)

--- a/src/services/repository-scope-service.ts
+++ b/src/services/repository-scope-service.ts
@@ -310,16 +310,7 @@ export class RepositoryScopeService implements IScopeService {
     skillFile: string,
     skillId: string
   ): Promise<string[]> {
-    // skillFile may be a file path (e.g., "skills/my-skill/SKILL.md")
-    // Extract the skill directory similar to UserScopeService
-    const skillMatch = skillFile.match(/skills\/([^/]+)/);
-    if (!skillMatch) {
-      this.logger.warn(`[RepositoryScopeService] Invalid skill path format: ${skillFile}`);
-      return [];
-    }
-
-    const skillName = skillMatch[1];
-    const sourcePath = path.join(bundlePath, 'skills', skillName);
+    const sourcePath = path.join(bundlePath, path.dirname(skillFile));
 
     if (!fs.existsSync(sourcePath)) {
       this.logger.warn(`[RepositoryScopeService] Skill directory not found: ${sourcePath}`);

--- a/src/services/user-scope-service.ts
+++ b/src/services/user-scope-service.ts
@@ -362,17 +362,9 @@ export class UserScopeService implements IScopeService {
    */
   private async syncSkillFromBundle(bundleId: string, bundlePath: string, promptDef: any): Promise<void> {
     try {
-      // Extract skill name from the path (e.g., skills/my-skill/SKILL.md -> my-skill)
       const skillPath = promptDef.file;
-      const skillMatch = skillPath.match(/skills\/([^/]+)\/SKILL\.md/);
-
-      if (!skillMatch) {
-        this.logger.warn(`Invalid skill path: ${skillPath}`);
-        return;
-      }
-
-      const skillName = skillMatch[1];
-      const skillSourceDir = path.join(bundlePath, 'skills', skillName);
+      const skillName = path.basename(path.dirname(skillPath));
+      const skillSourceDir = path.join(bundlePath, path.dirname(skillPath));
 
       if (!fs.existsSync(skillSourceDir)) {
         this.logger.warn(`Skill directory not found: ${skillSourceDir}`);

--- a/test/adapters/local-skills-adapter.test.ts
+++ b/test/adapters/local-skills-adapter.test.ts
@@ -7,6 +7,8 @@ import * as assert from 'node:assert';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import AdmZip from 'adm-zip';
+import * as yaml from 'js-yaml';
 import * as sinon from 'sinon';
 import {
   LocalSkillsAdapter,
@@ -400,6 +402,47 @@ Instructions for ${name}
       // Verify it's a valid ZIP (starts with PK signature)
       assert.strictEqual(zipBuffer[0], 0x50); // 'P'
       assert.strictEqual(zipBuffer[1], 0x4B); // 'K'
+    });
+
+    test('manifest file field should match the skill SKILL.md path inside the ZIP', async () => {
+      // Regression: the generated manifest declared file: "SKILL.md" while the ZIP stores
+      // the skill under skills/<id>/SKILL.md, so downstream sync (which resolves the source
+      // from the manifest file path) silently skipped local skills.
+      createSkill('my-local-skill', {
+        description: 'Local skill for manifest check',
+        additionalFiles: ['helper.md']
+      });
+
+      const source: RegistrySource = {
+        id: 'test-local-skills',
+        name: 'Test Local Skills',
+        type: 'local-skills',
+        url: tempDir,
+        enabled: true,
+        priority: 1
+      };
+
+      const adapter = new LocalSkillsAdapter(source);
+      const bundles = await adapter.fetchBundles();
+      const zipBuffer = await adapter.downloadBundle(bundles[0]);
+
+      const zip = new AdmZip(zipBuffer);
+      const manifestEntry = zip.getEntry('deployment-manifest.yml');
+      assert.ok(manifestEntry, 'ZIP should contain deployment-manifest.yml');
+
+      const manifest = yaml.load(manifestEntry.getData().toString('utf8')) as any;
+      const skillFile = manifest.prompts[0].file;
+
+      // The declared file path must point at a real entry inside the ZIP.
+      assert.ok(
+        zip.getEntry(skillFile),
+        `manifest file path "${skillFile}" should exist inside the ZIP`
+      );
+      assert.strictEqual(
+        skillFile,
+        'skills/my-local-skill/SKILL.md',
+        'manifest file should point at skills/<id>/SKILL.md matching the ZIP layout'
+      );
     });
 
     test('should throw error for non-existent skill', async () => {

--- a/test/services/bundle-installer.test.ts
+++ b/test/services/bundle-installer.test.ts
@@ -5,9 +5,14 @@
 import * as assert from 'node:assert';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import AdmZip from 'adm-zip';
+import * as sinon from 'sinon';
 import {
   BundleInstaller,
 } from '../../src/services/bundle-installer';
+import {
+  UserScopeService,
+} from '../../src/services/user-scope-service';
 import {
   Bundle,
   InstallOptions,
@@ -59,6 +64,7 @@ suite('BundleInstaller', () => {
   });
 
   teardown(() => {
+    sinon.restore();
     // Cleanup temp directories
     if (fs.existsSync(tempDir)) {
       fs.rmSync(tempDir, { recursive: true, force: true });
@@ -315,6 +321,58 @@ suite('BundleInstaller', () => {
 
       // Should not throw even if path doesn't exist
       await installer.uninstallSkillSymlink(mockInstalled);
+    });
+  });
+
+  suite('installFromBuffer - skills bundle with non-standard source directory', () => {
+    /**
+     * Build a skills bundle ZIP where the skill lives under a non-standard directory
+     * and the manifest file field points at its real location.
+     * @param skillId
+     * @param skillDirPrefix directory inside the bundle that holds the skill (e.g. .github/skills)
+     */
+    const buildSkillsZip = (skillId: string, skillDirPrefix: string): Buffer => {
+      const zip = new AdmZip();
+      const skillFile = `${skillDirPrefix}/${skillId}/SKILL.md`;
+      const manifest = {
+        id: 'nonstandard-skill-bundle',
+        version: '1.0.0',
+        name: 'Non-standard Skill Bundle',
+        prompts: [
+          {
+            id: skillId,
+            name: skillId,
+            description: 'Skill under a non-standard directory',
+            file: skillFile,
+            type: 'skill'
+          }
+        ]
+      };
+      zip.addFile('deployment-manifest.yml', Buffer.from(JSON.stringify(manifest), 'utf8'));
+      zip.addFile(skillFile, Buffer.from('# Skill\n', 'utf8'));
+      zip.addFile(`${skillDirPrefix}/${skillId}/helper.sh`, Buffer.from('echo hi\n', 'utf8'));
+      return zip.toBuffer();
+    };
+
+    test('installs skill from the manifest path, not a hardcoded skills/ directory', async () => {
+      const skillId = 'nevio-deployment-automation';
+      const copilotSkillsDir = path.join(tempDir, 'copilot-skills');
+      fs.mkdirSync(copilotSkillsDir, { recursive: true });
+
+      // Redirect the copilot skills directory into the temp dir so we don't touch ~/.copilot
+      sinon.stub(UserScopeService.prototype, 'getCopilotSkillsDirectory').returns(copilotSkillsDir);
+
+      const bundle: Bundle = { ...mockBundle, id: 'nonstandard-skill-bundle' };
+      const zipBuffer = buildSkillsZip(skillId, '.github/skills');
+      const options: InstallOptions = { scope: 'user', force: false };
+
+      const installed = await installer.installFromBuffer(bundle, zipBuffer, options, 'skills');
+
+      const installedSkillDir = path.join(copilotSkillsDir, skillId);
+      assert.ok(fs.existsSync(installedSkillDir), 'Skill directory should be installed');
+      assert.ok(fs.existsSync(path.join(installedSkillDir, 'SKILL.md')), 'SKILL.md should be copied');
+      assert.ok(fs.existsSync(path.join(installedSkillDir, 'helper.sh')), 'helper.sh should be copied');
+      assert.strictEqual(installed.installPath, installedSkillDir);
     });
   });
 });

--- a/test/services/repository-scope-service.property.test.ts
+++ b/test/services/repository-scope-service.property.test.ts
@@ -544,7 +544,7 @@ version: "1.0.0"
 prompts:
   - id: ${skillName}
     name: ${skillName}
-    file: skills/${skillName}
+    file: skills/${skillName}/SKILL.md
     type: skill`;
 
       fs.writeFileSync(path.join(bundlePath, 'deployment-manifest.yml'), manifest);

--- a/test/services/repository-scope-service.test.ts
+++ b/test/services/repository-scope-service.test.ts
@@ -742,13 +742,14 @@ suite('RepositoryScopeService', () => {
         fs.writeFileSync(filePath, file.content);
       }
 
-      // Create deployment manifest with skill entry
+      // Create deployment manifest with skill entry. The file field points at the
+      // skill's SKILL.md, matching what real adapters emit (skills/<name>/SKILL.md).
       const manifest = `id: ${bundleId}
 version: "1.0.0"
 prompts:
   - id: ${skillName}
     name: ${skillName}
-    file: skills/${skillName}
+    file: skills/${skillName}/SKILL.md
     type: skill`;
 
       fs.writeFileSync(path.join(bundlePath, 'deployment-manifest.yml'), manifest);
@@ -904,7 +905,7 @@ prompts:
     type: prompt
   - id: my-skill
     name: My Skill
-    file: skills/my-skill
+    file: skills/my-skill/SKILL.md
     type: skill`;
 
       fs.writeFileSync(path.join(bundlePath, 'deployment-manifest.yml'), manifest);
@@ -962,6 +963,40 @@ prompts:
       assert.ok(fs.existsSync(path.join(targetSkillDir, 'SKILL.md')), 'SKILL.md should be copied');
       assert.ok(fs.existsSync(path.join(targetSkillDir, 'resources', 'helper.md')), 'resources/helper.md should be copied');
     });
+
+    test('should sync skill packaged under a non-standard directory (.github/skills)', async () => {
+      // Regression for the PR 313 bug class at repository scope: the source directory
+      // must be derived from the manifest file path, not a hardcoded skills/ prefix.
+      const bundleId = 'skill-bundle-github-prefix';
+      const skillName = 'nevio-deployment-automation';
+      const bundlePath = path.join(tempDir, 'bundles', bundleId);
+      fs.mkdirSync(bundlePath, { recursive: true });
+
+      // Skill lives under .github/skills/ instead of the standard skills/ root path
+      const skillDir = path.join(bundlePath, '.github', 'skills', skillName);
+      fs.mkdirSync(skillDir, { recursive: true });
+      fs.writeFileSync(path.join(skillDir, 'SKILL.md'), '# Deployment Automation');
+      fs.writeFileSync(path.join(skillDir, 'helper.sh'), '#!/bin/bash\necho hello');
+
+      const manifest = `id: ${bundleId}
+version: "1.0.0"
+prompts:
+  - id: ${skillName}
+    name: ${skillName}
+    file: .github/skills/${skillName}/SKILL.md
+    type: skill`;
+
+      fs.writeFileSync(path.join(bundlePath, 'deployment-manifest.yml'), manifest);
+
+      mockStorage.getInstalledBundle.resolves(createMockInstalledBundle(bundleId, 'commit'));
+
+      await service.syncBundle(bundleId, bundlePath);
+
+      const targetSkillDir = path.join(workspaceRoot, '.github', 'skills', skillName);
+      assert.ok(fs.existsSync(targetSkillDir), 'Skill directory should be created');
+      assert.ok(fs.existsSync(path.join(targetSkillDir, 'SKILL.md')), 'SKILL.md should be copied');
+      assert.ok(fs.existsSync(path.join(targetSkillDir, 'helper.sh')), 'helper.sh should be copied');
+    });
   });
 
   suite('unsyncBundle - Skills Directory Removal', () => {
@@ -995,7 +1030,7 @@ version: "1.0.0"
 prompts:
   - id: ${skillName}
     name: ${skillName}
-    file: skills/${skillName}
+    file: skills/${skillName}/SKILL.md
     type: skill`;
 
       fs.writeFileSync(path.join(bundlePath, 'deployment-manifest.yml'), manifest);
@@ -1130,7 +1165,7 @@ version: "1.0.0"
 prompts:
   - id: ${skillName}
     name: ${skillName}
-    file: skills/${skillName}
+    file: skills/${skillName}/SKILL.md
     type: skill`;
 
       fs.writeFileSync(path.join(bundlePath, 'deployment-manifest.yml'), manifest);

--- a/test/services/user-scope-service.test.ts
+++ b/test/services/user-scope-service.test.ts
@@ -10,7 +10,9 @@
 
 import * as assert from 'node:assert';
 import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
+import * as sinon from 'sinon';
 import {
   UserScopeService,
 } from '../../src/services/user-scope-service';
@@ -155,6 +157,101 @@ prompts: []
       } catch (error: any) {
         assert.ok(error.message, 'Should provide error message');
         assert.ok(error.message.length > 0, 'Error message should not be empty');
+      }
+    });
+  });
+
+  suite('syncBundle - skill with non-standard path', () => {
+    let sandbox: sinon.SinonSandbox;
+    let skillBundlePath: string;
+    let syncSkillSpy: sinon.SinonSpy;
+
+    setup(() => {
+      sandbox = sinon.createSandbox();
+
+      // Create a bundle that mimics a GitHub release where the skill lives
+      // under .github/skills/ instead of the standard skills/ root path.
+      skillBundlePath = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-bundle-'));
+      const skillDir = path.join(skillBundlePath, '.github', 'skills', 'nevio-deployment-automation');
+      fs.mkdirSync(skillDir, { recursive: true });
+      fs.writeFileSync(path.join(skillDir, 'SKILL.md'), '---\nname: Deployment Automation\ndescription: Test\n---\n# Skill');
+      fs.writeFileSync(path.join(skillDir, 'helper.sh'), '#!/bin/bash\necho hello');
+
+      const manifest = {
+        id: 'test-skills-bundle',
+        version: '1.0.0',
+        name: 'Test Skills Bundle',
+        prompts: [
+          {
+            id: 'nevio-deployment-automation',
+            name: 'Deployment Automation',
+            file: '.github/skills/nevio-deployment-automation/SKILL.md',
+            type: 'skill'
+          }
+        ]
+      };
+      fs.writeFileSync(
+        path.join(skillBundlePath, 'deployment-manifest.yml'),
+        JSON.stringify(manifest)
+      );
+
+      // Spy on the public syncSkill so we can assert its arguments without writing to ~/.copilot/skills
+      syncSkillSpy = sandbox.stub(service, 'syncSkill').resolves();
+    });
+
+    teardown(() => {
+      sandbox.restore();
+      fs.rmSync(skillBundlePath, { recursive: true, force: true });
+    });
+
+    test('should sync skill when file path has .github/skills prefix', async () => {
+      await service.syncBundle('test-skills-bundle', skillBundlePath);
+
+      assert.ok(syncSkillSpy.calledOnce, 'syncSkill should have been called once');
+
+      const [skillName, sourceDir] = syncSkillSpy.firstCall.args;
+      assert.strictEqual(skillName, 'nevio-deployment-automation',
+        'skill name should be extracted correctly from the path');
+      assert.strictEqual(sourceDir, path.join(skillBundlePath, '.github', 'skills', 'nevio-deployment-automation'),
+        'sourceDir should point to the actual skill location in the bundle, not a hardcoded skills/ prefix');
+    });
+
+    test('should still sync skill when file path has standard skills/ prefix', async () => {
+      // Create a second bundle with the standard path layout
+      const standardBundlePath = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-bundle-standard-'));
+      const skillDir = path.join(standardBundlePath, 'skills', 'pr-review');
+      fs.mkdirSync(skillDir, { recursive: true });
+      fs.writeFileSync(path.join(skillDir, 'SKILL.md'), '---\nname: PR Review\ndescription: Test\n---\n# Skill');
+
+      const manifest = {
+        id: 'test-standard-bundle',
+        version: '1.0.0',
+        name: 'Test Standard Bundle',
+        prompts: [
+          {
+            id: 'pr-review',
+            name: 'PR Review',
+            file: 'skills/pr-review/SKILL.md',
+            type: 'skill'
+          }
+        ]
+      };
+      fs.writeFileSync(
+        path.join(standardBundlePath, 'deployment-manifest.yml'),
+        JSON.stringify(manifest)
+      );
+
+      try {
+        await service.syncBundle('test-standard-bundle', standardBundlePath);
+
+        assert.ok(syncSkillSpy.calledOnce, 'syncSkill should have been called once');
+
+        const [skillName, sourceDir] = syncSkillSpy.firstCall.args;
+        assert.strictEqual(skillName, 'pr-review', 'skill name should be correct');
+        assert.strictEqual(sourceDir, path.join(standardBundlePath, 'skills', 'pr-review'),
+          'sourceDir should point to skills/pr-review in the bundle');
+      } finally {
+        fs.rmSync(standardBundlePath, { recursive: true, force: true });
       }
     });
   });


### PR DESCRIPTION
## Description

Skills that package their content under a **non-standard directory** (e.g. `.github/skills/` instead of the standard `skills/` root) were silently skipped and never installed. Root cause: the skill's **source** directory inside a bundle was resolved from a hardcoded `skills/` prefix instead of the path declared in the deployment manifest's `file` field.

This PR started as a one-line user-scope fix and was extended to cover the **same bug class everywhere it exists** across scopes and adapters.

Example source with the issue: 
[Release with unusual path when building the assets] (https://github.com/amadeus-airlines-solutions/nevio.sre-ai-toolkit/releases/tag/nevio-deployment-automation-v1.0.1)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🧪 Test coverage improvement

## Root Cause

To locate a resource inside a bundle, the code should trust the manifest `file` field: `path.join(bundlePath, promptDef.file)` (or `path.dirname` for directory-based skills). Several skill code paths instead reconstructed the source from a hardcoded `skills/` folder + the skill name, so any skill packaged elsewhere (e.g. `.github/skills/foo/SKILL.md`) resolved to a non-existent path, logged "Skill directory not found", and was skipped silently.

Non-skill resources (prompts, instructions, agents) already resolved their source via `promptDef.file` and were **not** affected. TARGET directory conventions (`.github/skills/`, `~/.copilot/skills/`) are intentional and unchanged.

## Changes Made

Four sites of the same bug class, each with a regression test:

- **`src/services/user-scope-service.ts`** (`syncSkillFromBundle`) — derive the skill source dir from `path.dirname(promptDef.file)` instead of hardcoding `skills/{skillName}`. *(original fix)*
- **`src/services/repository-scope-service.ts`** (`installSkillDirectory`) — was hardcoding `path.join(bundlePath, 'skills', skillName)`; now uses `path.join(bundlePath, path.dirname(skillFile))` so repository-scope installs handle non-standard layouts. Removed the now-unused `skillName` local.
- **`src/services/bundle-installer.ts`** (`installFromBuffer`) — for user/workspace skills bundles, replaced the hardcoded `skills/` scan (`extractSkillNameFromBundle`) with derivation from the manifest skill entry's `file` path. Removed the now-unused `extractSkillNameFromBundle` helper.
- **`src/adapters/local-skills-adapter.ts`** (`generateDeploymentManifest`) — emitted `file: 'SKILL.md'` while the ZIP stored the skill at `skills/<id>/SKILL.md`, so the bare path failed downstream matching. Now emits `skills/${skill.id}/SKILL.md`, matching the ZIP layout and the remote `skills-adapter` convention. *(root cause for local skills)*

```typescript
// Before (bug) — hardcoded prefix, ignores where the skill actually lives
const skillSourceDir = path.join(bundlePath, 'skills', skillName);

// After (fix) — trust the manifest file path
const skillSourceDir = path.join(bundlePath, path.dirname(skillPath));
```

### Verified safe (not changed)

- Non-skill resource source resolution (already uses `promptDef.file`).
- TARGET directory conventions (`.github/prompts`, `~/.copilot/skills`, etc.).
- `awesome-copilot` / remote `skills-adapter` manifest generation (already correct — full path preserved in both manifest and ZIP).
- `local-skills-adapter` local-filesystem `skills/` paths (the adapter's own repo-structure contract, not a bundle read).
- The skill-name regex — it already handles `.github/skills/` correctly (verified), so it was left unchanged.

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

New regression tests:

- `test/services/user-scope-service.test.ts` — `.github/skills/` path and standard `skills/` path.
- `test/services/repository-scope-service.test.ts` — skill packaged under `.github/skills/` at repository scope.
- `test/adapters/local-skills-adapter.test.ts` — manifest `file` field matches the real `skills/<id>/SKILL.md` entry inside the generated ZIP.
- `test/services/bundle-installer.test.ts` — skills bundle with a non-standard source directory installs from the manifest path.

Existing skill test fixtures were aligned from the unrealistic `file: skills/<name>` (bare directory) form to the realistic `skills/<id>/SKILL.md` form that adapters actually emit (`repository-scope-service.test.ts`, `repository-scope-service.property.test.ts`).

Full unit suite: **2308 passing, 0 failing**. Lint: **0 errors**.

### Manual Testing Steps

1. Add a skills source pointing to a GitHub release where skills are under `.github/skills/`.
2. Install the skill at user level and at repository level.
3. Verify the skill directory is created (`~/.copilot/skills/<name>/` for user, `.github/skills/<name>/` for repository) with the expected files.

### Tested On

- [x] macOS
- [x] VS Code Stable

## Documentation

- [x] No documentation changes needed — `docs/author-guide/creating-skills.md` already documents the `skills/<id>/SKILL.md` path format the fix aligns to.

## Reviewer Guidelines

Please pay special attention to:

- Whether `path.dirname` behaves correctly for both `skills/foo/SKILL.md` and `.github/skills/foo/SKILL.md` at each of the four fixed sites.
- The `local-skills-adapter` manifest change: confirm the emitted `file` now matches the ZIP entry path.
- The test-fixture alignment — the old `file: skills/<name>` form is not produced by any real adapter.

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**
