### PR TITLE
feat: progressive marketplace display during large skills source sync

### DIFF
--- a/docs/contributor-guide/architecture/adapters.md
+++ b/docs/contributor-guide/architecture/adapters.md
@@ -8,7 +8,7 @@ Adapters provide a unified interface for fetching bundles from different source 
 interface IRepositoryAdapter {
     readonly type: string;
     readonly source: RegistrySource;
-    fetchBundles(): Promise<Bundle[]>;
+    fetchBundles(onPartialBundles?: (bundles: Bundle[]) => void | Promise<void>): Promise<Bundle[]>;
     downloadBundle(bundle: Bundle): Promise<Buffer>;
     fetchMetadata(): Promise<SourceMetadata>;
     validate(): Promise<ValidationResult>;

--- a/docs/contributor-guide/architecture/ui-components.md
+++ b/docs/contributor-guide/architecture/ui-components.md
@@ -48,6 +48,13 @@ graph TD
 
 Bundle README markdown is rendered to HTML in the details panel via `markdown-it` and sanitized with `sanitize-html` (`getMarkdownRender`). Links (`<a>`) are preserved and tagged with a `data-external-link` attribute. The details webview intercepts clicks on these links and sends an `openExternalLink` message; the host then prompts the user for confirmation before opening the URL with `vscode.env.openExternal`. Images remain HTTPS-only to match the webview CSP; links may use `https`, `http`, or `mailto`.
 
+### Progressive Loading on Source Sync
+
+Sources sync in parallel (`Promise.allSettled`), and each fires `RegistryManager.onSourceSynced` as its bundles are cached — large skills sources stream multiple partial batches as they parse. The marketplace renders bundles as soon as **any** source has cached them, rather than waiting for all sources to finish. Two mechanisms cooperate in `MarketplaceViewProvider`:
+
+- **`handleSourceSynced` throttle (leading + trailing, 500ms)** — the leading edge renders immediately when a burst starts; the trailing edge picks up whatever arrived during the window. This rate-limits renders to avoid flicker when a source streams many partial batches.
+- **`loadBundles` coalescing** — `loadBundles` reads the full cache (`searchBundles({ cacheOnly: true })`) and posts one `bundlesLoaded` message. If it is called while a load is already in flight (e.g. the throttle's trailing edge racing the 100ms bootstrap load or the webview's self-`refresh`), it sets a pending flag and re-runs exactly once when the current load finishes, instead of dropping the request. This guarantees the latest cache always renders — without it, the first source's bundles could stay hidden until a later source re-armed the throttle.
+
 ## Tree View
 
 Hierarchical view displaying profiles, bundles, and sources with two view modes: "All Hubs" and "Favorites".
@@ -144,7 +151,7 @@ Extensive right-click menus defined in `package.json` with context-sensitive act
 - Implements `vscode.TreeDataProvider<RegistryTreeItem>`
 - Registered as `promptRegistryExplorer` in `package.json`
 - Supports collapse/expand states and refresh events
-- Debounced refresh on source sync events (500ms)
+- Throttled refresh on source sync events (leading + trailing, 500ms); `refresh()` fires `onDidChangeTreeData` so VS Code re-queries lazily
 
 #### Event Handling
 Listens to multiple registry and hub manager events:

--- a/docs/reference/adapter-api.md
+++ b/docs/reference/adapter-api.md
@@ -18,8 +18,10 @@ interface IRepositoryAdapter {
     // The source configuration
     readonly source: RegistrySource;
     
-    // Fetch all bundles from this source
-    fetchBundles(): Promise<Bundle[]>;
+    // Fetch all bundles from this source. The optional onPartialBundles
+    // callback is invoked with a growing snapshot after each parse chunk so
+    // the UI can render progressively during large syncs.
+    fetchBundles(onPartialBundles?: (bundles: Bundle[]) => void | Promise<void>): Promise<Bundle[]>;
     
     // Download a specific bundle (returns zip Buffer)
     downloadBundle(bundle: Bundle): Promise<Buffer>;

--- a/src/adapters/AGENTS.md
+++ b/src/adapters/AGENTS.md
@@ -19,7 +19,7 @@ interface IRepositoryAdapter {
   readonly type: string;
   readonly source: RegistrySource;
 
-  fetchBundles(): Promise<Bundle[]>;
+  fetchBundles(onPartialBundles?: (bundles: Bundle[]) => void | Promise<void>): Promise<Bundle[]>;
   downloadBundle(bundle: Bundle): Promise<Buffer>;
   fetchMetadata(): Promise<SourceMetadata>;
   validate(): Promise<ValidationResult>;
@@ -33,6 +33,7 @@ interface IRepositoryAdapter {
 - `downloadBundle` always returns a `Buffer` — whether the source provides pre-packaged ZIPs (GitHub) or builds them dynamically (Awesome Copilot, Local).
 - `getDownloadUrl` / `getManifestUrl` return `string` URLs — used for UI display and debug links, not for the actual download (which goes through `downloadBundle`).
 - `validate` returns a `ValidationResult` (not a boolean) — contains error details for user-facing diagnostics.
+- `fetchBundles` accepts an optional `onPartialBundles` callback — invoked with a growing snapshot after each parse chunk so the UI can render progressively during large syncs. Implementing it is optional; adapters that omit it simply resolve once with the full list. `SkillsAdapter` uses it to stream 360+ skills as they parse.
 
 ## Authentication Chain (GitHub)
 

--- a/src/adapters/repository-adapter.ts
+++ b/src/adapters/repository-adapter.ts
@@ -26,9 +26,10 @@ export interface IRepositoryAdapter {
 
   /**
    * Fetch list of available bundles from the source
+   * @param onPartialBundles Optional callback invoked with a growing snapshot after each chunk
    * @returns Promise with array of bundles
    */
-  fetchBundles(): Promise<Bundle[]>;
+  fetchBundles(onPartialBundles?: (bundles: Bundle[]) => void | Promise<void>): Promise<Bundle[]>;
 
   /**
    * Download a specific bundle
@@ -155,7 +156,7 @@ export abstract class RepositoryAdapter implements IRepositoryAdapter {
     return Promise.resolve(null);
   }
 
-  public abstract fetchBundles(): Promise<Bundle[]>;
+  public abstract fetchBundles(onPartialBundles?: (bundles: Bundle[]) => void | Promise<void>): Promise<Bundle[]>;
   public abstract downloadBundle(bundle: Bundle): Promise<Buffer>;
   public abstract fetchMetadata(): Promise<SourceMetadata>;
   public abstract validate(): Promise<ValidationResult>;

--- a/src/adapters/skills-adapter.ts
+++ b/src/adapters/skills-adapter.ts
@@ -45,6 +45,7 @@ export class SkillsAdapter extends RepositoryAdapter {
   public readonly type = 'skills';
   private readonly logger: Logger;
   private readonly githubAdapter: GitHubAdapter;
+  private readonly defaultBranch = 'main';
 
   constructor(source: RegistrySource) {
     super(source);
@@ -86,6 +87,20 @@ export class SkillsAdapter extends RepositoryAdapter {
       owner: match[1],
       repo: match[2]
     };
+  }
+
+  private collectSkillIds(tree: GitTreeEntry[]): Set<string> {
+    const skillIds = new Set<string>();
+    for (const entry of tree) {
+      if (entry.type !== 'blob') {
+        continue;
+      }
+      const segments = entry.path.split('/');
+      if (segments[0] === 'skills' && segments.length === 3 && segments[2] === 'SKILL.md') {
+        skillIds.add(segments[1]);
+      }
+    }
+    return skillIds;
   }
 
   private async fetchRepoTree(owner: string, repo: string, branch: string): Promise<GitTreeEntry[]> {
@@ -143,20 +158,23 @@ export class SkillsAdapter extends RepositoryAdapter {
 
   /**
    * Scan skills/ directory via a single Git Trees API call.
+   * @param onChunk Optional callback invoked with each finished chunk of skills
    */
-  private async scanSkillsDirectory(): Promise<SkillItem[]> {
+  private async scanSkillsDirectory(
+    onChunk?: (skills: SkillItem[]) => void | Promise<void>
+  ): Promise<SkillItem[]> {
     const { owner, repo } = this.parseGitHubUrl();
-    const branch = 'main';
+    const branch = this.defaultBranch;
 
     this.logger.debug(`[SkillsAdapter] Scanning skills via git tree: ${owner}/${repo}@${branch}`);
 
     try {
       const tree = await this.fetchRepoTree(owner, repo, branch);
 
-      // Single O(tree) pass: group blobs under skills/<id>/ and note which
-      // skills have a top-level SKILL.md (a skill id requires SKILL.md).
+      // Single O(tree) pass: group all blobs under skills/<id>/. A skill id
+      // requires a top-level SKILL.md — collectSkillIds is the single source of
+      // truth for that rule (also used by validate()/fetchMetadata()).
       const filesBySkill = new Map<string, GitTreeEntry[]>();
-      const skillIds = new Set<string>();
       for (const entry of tree) {
         if (entry.type !== 'blob') {
           continue;
@@ -170,10 +188,8 @@ export class SkillsAdapter extends RepositoryAdapter {
           filesBySkill.set(skillId, []);
         }
         filesBySkill.get(skillId)!.push(entry);
-        if (segments.length === 3 && segments[2] === 'SKILL.md') {
-          skillIds.add(skillId);
-        }
       }
+      const skillIds = this.collectSkillIds(tree);
 
       this.logger.debug(`[SkillsAdapter] Found ${skillIds.size} skills in tree`);
 
@@ -181,14 +197,16 @@ export class SkillsAdapter extends RepositoryAdapter {
       // SKILL.md fetches without serializing them.
       const ids = [...skillIds];
       const skills: SkillItem[] = [];
-      const CONCURRENCY_LIMIT = 5;
+      const CONCURRENCY_LIMIT = 15;
 
       for (let i = 0; i < ids.length; i += CONCURRENCY_LIMIT) {
         const chunk = ids.slice(i, i + CONCURRENCY_LIMIT);
         const chunkResults = await Promise.all(
           chunk.map((skillId) => this.buildSkillFromTree(owner, repo, branch, skillId, filesBySkill.get(skillId) ?? []))
         );
-        skills.push(...chunkResults.filter((s): s is SkillItem => s !== null));
+        const built = chunkResults.filter((s): s is SkillItem => s !== null);
+        skills.push(...built);
+        await onChunk?.(built);
       }
 
       return skills;
@@ -674,25 +692,30 @@ export class SkillsAdapter extends RepositoryAdapter {
   /**
    * Fetch all skills from the repository as bundles
    * Each skill becomes a separate bundle
+   * @param onPartialBundles Optional callback invoked with a growing snapshot after each chunk
    */
-  public async fetchBundles(): Promise<Bundle[]> {
+  public async fetchBundles(
+    onPartialBundles?: (bundles: Bundle[]) => void | Promise<void>
+  ): Promise<Bundle[]> {
     this.logger.info(`[SkillsAdapter] Fetching skills from repository: ${this.source.url}`);
 
     try {
-      const skills = await this.scanSkillsDirectory();
-      this.logger.info(`[SkillsAdapter] Found ${skills.length} skills in repository`);
-
       const bundles: Bundle[] = [];
-      for (const skill of skills) {
-        try {
-          const bundle = this.createBundleFromSkill(skill);
-          bundles.push(bundle);
-          this.logger.debug(`[SkillsAdapter] Created bundle: ${bundle.id}`);
-        } catch (error) {
-          this.logger.warn(`[SkillsAdapter] Failed to create bundle from skill ${skill.id}: ${error}`);
-        }
-      }
 
+      const skills = await this.scanSkillsDirectory(async (chunkSkills) => {
+        for (const skill of chunkSkills) {
+          try {
+            const bundle = this.createBundleFromSkill(skill);
+            bundles.push(bundle);
+            this.logger.debug(`[SkillsAdapter] Created bundle: ${bundle.id}`);
+          } catch (error) {
+            this.logger.warn(`[SkillsAdapter] Failed to create bundle from skill ${skill.id}: ${error}`);
+          }
+        }
+        await onPartialBundles?.([...bundles]);
+      });
+
+      this.logger.info(`[SkillsAdapter] Found ${skills.length} skills in repository`);
       this.logger.info(`[SkillsAdapter] Successfully created ${bundles.length} bundles`);
       return bundles;
     } catch (error) {
@@ -745,8 +768,8 @@ export class SkillsAdapter extends RepositoryAdapter {
 
       let skillCount = 0;
       try {
-        const skills = await this.scanSkillsDirectory();
-        skillCount = skills.length;
+        const tree = await this.fetchRepoTree(owner, repo, this.defaultBranch);
+        skillCount = this.collectSkillIds(tree).size;
 
         if (skillCount === 0) {
           warnings.push('No valid skills found in skills/ directory (skills must have SKILL.md file)');
@@ -778,13 +801,13 @@ export class SkillsAdapter extends RepositoryAdapter {
    */
   public async fetchMetadata(): Promise<SourceMetadata> {
     try {
-      const skills = await this.scanSkillsDirectory();
       const { owner, repo } = this.parseGitHubUrl();
+      const tree = await this.fetchRepoTree(owner, repo, this.defaultBranch);
 
       return {
         name: `${owner}/${repo}`,
         description: 'Skills Repository',
-        bundleCount: skills.length,
+        bundleCount: this.collectSkillIds(tree).size,
         lastUpdated: new Date().toISOString(),
         version: '1.0.0'
       };

--- a/src/services/registry-manager.ts
+++ b/src/services/registry-manager.ts
@@ -1304,7 +1304,11 @@ export class RegistryManager {
     }
 
     const adapter = this.getAdapter(source);
-    const bundles = await adapter.fetchBundles();
+    const bundles = await adapter.fetchBundles(async (partial) => {
+      // Progressive update: cache what we have so far and notify the UI.
+      await this.storage.cacheSourceBundles(sourceId, partial);
+      this._onSourceSynced.fire({ sourceId, bundleCount: partial.length });
+    });
 
     // Reuse still-valid cached readmes so we only re-download when the source revision changed
     await this.reuseCachedReadmes(sourceId, bundles);

--- a/src/storage/registry-storage.ts
+++ b/src/storage/registry-storage.ts
@@ -21,6 +21,7 @@ import {
 
 const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
+const rename = promisify(fs.rename);
 const mkdir = promisify(fs.mkdir);
 const readdir = promisify(fs.readdir);
 const unlink = promisify(fs.unlink);
@@ -365,7 +366,14 @@ export class RegistryStorage {
     const sanitizedId = this.sanitizeFilename(sourceId);
     const filepath = path.join(this.paths.sourcesCache, `${sanitizedId}.json`);
     const data = JSON.stringify(bundles, null, 2);
-    await writeFile(filepath, data, 'utf8');
+    // Write atomically: progressive sync calls this repeatedly while the UI reads
+    // the same file (see getCachedSourceBundles). A plain writeFile truncates then
+    // streams, so a concurrent read could see partial JSON and fail to parse,
+    // flickering the source to empty. Writing to a temp file then renaming makes
+    // every read observe either the old or the new content, never a partial one.
+    const tempPath = `${filepath}.${process.pid}.tmp`;
+    await writeFile(tempPath, data, 'utf8');
+    await rename(tempPath, filepath);
   }
 
   /**

--- a/src/ui/marketplace-view-provider.ts
+++ b/src/ui/marketplace-view-provider.ts
@@ -34,6 +34,9 @@ import {
   extractBundleSources,
 } from '../utils/filter-utils';
 import {
+  LeadingTrailingThrottle,
+} from '../utils/leading-trailing-throttle';
+import {
   Logger,
 } from '../utils/logger';
 import {
@@ -72,10 +75,47 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
 
   private _view?: vscode.WebviewView;
   private readonly logger: Logger;
-  private sourceSyncDebounceTimer?: NodeJS.Timeout;
+
+  private readonly sourceSyncThrottle = new LeadingTrailingThrottle(
+    () => void this.loadBundles(),
+    UI_CONSTANTS.SOURCE_SYNC_DEBOUNCE_MS
+  );
+
   private isLoadingBundles = false;
+  private loadBundlesPending = false;
   private disposables: vscode.Disposable[] = [];
   private markDownIt: InstanceType<typeof MarkdownIt> | undefined;
+  private readonly sanitizeOptions: sanitizeHtml.IOptions = {
+    allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img']),
+    allowedAttributes: {
+      ...sanitizeHtml.defaults.allowedAttributes,
+      a: ['href', 'title', 'data-external-link', 'rel', 'class'],
+      img: ['src', 'alt', 'title', 'width', 'height']
+    },
+    allowedSchemes: ['https', 'http', 'mailto'],
+    allowedSchemesByTag: {
+      img: ['https'],
+      a: ['https', 'http', 'mailto']
+    },
+    transformTags: {
+      a: (tagName, attribs) => {
+        const href = attribs.href;
+        if (href) {
+          const { href: _dropped, ...rest } = attribs;
+          return {
+            tagName,
+            attribs: {
+              ...rest,
+              'data-external-link': href,
+              class: rest.class ? `${rest.class} external-link` : 'external-link',
+              rel: 'noopener noreferrer'
+            }
+          };
+        }
+        return { tagName, attribs };
+      }
+    }
+  };
 
   constructor(
     private readonly context: vscode.ExtensionContext,
@@ -159,24 +199,7 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
    */
   private handleSourceSynced(event: { sourceId: string; bundleCount: number }): void {
     this.logger.debug(`Source synced: ${event.sourceId} (${event.bundleCount} bundles)`);
-
-    const isFirstEvent = !this.sourceSyncDebounceTimer;
-
-    // Clear existing timer if any
-    if (this.sourceSyncDebounceTimer) {
-      clearTimeout(this.sourceSyncDebounceTimer);
-    }
-
-    // Fire immediately on first event (leading edge)
-    if (isFirstEvent) {
-      void this.loadBundles();
-    }
-
-    // Set trailing edge timer
-    this.sourceSyncDebounceTimer = setTimeout(() => {
-      this.sourceSyncDebounceTimer = undefined;
-      void this.loadBundles();
-    }, UI_CONSTANTS.SOURCE_SYNC_DEBOUNCE_MS);
+    this.sourceSyncThrottle.trigger();
   }
 
   /**
@@ -189,27 +212,6 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
     }
     return this.markDownIt;
   }
-
-  // private handleReadmeDownloaded(sourceId: string, bundleIds: string[], panel: vscode.WebviewPanel): void {
-  //   // TODO handle render through the details view
-  //   // Handle messages from the details panel
-  //   panel.webview.onDidReceiveMessage(
-  //     async (message) => {
-  //       if (message.type === 'openPromptFile') {
-  //         await this.openPromptFileInEditor(message.installPath, message.filePath);
-  //       } else if (message.type === 'toggleAutoUpdate') {
-  //         await this.handleToggleAutoUpdate(message.bundleId, message.enabled);
-  //         // Update the panel with new status
-  //         if (installed) {
-  //           const newStatus = await this.registryManager.autoUpdateService?.isAutoUpdateEnabled(installed.bundleId) || false;
-  //           panel.webview.postMessage({ type: 'autoUpdateStatusChanged', enabled: newStatus });
-  //         }
-  //       }
-  //     },
-  //     undefined,
-  //     this.context.subscriptions
-  //   );
-  // }
 
   /**
    * Find installed bundle by marketplace bundle ID using identity matching
@@ -294,9 +296,13 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
    * Uses cacheOnly mode for fast initial load, then updates progressively via onSourceSynced events
    */
   private async loadBundles(): Promise<void> {
-    // Prevent concurrent loads to avoid UI flicker
+    // Coalesce concurrent loads: if a load is already running, mark that another
+    // is needed and re-run once after it finishes (see finally block). This keeps
+    // the throttle's trailing edge — and any other dropped request — self-healing,
+    // so freshly-cached bundles always render.
     if (this.isLoadingBundles) {
-      this.logger.debug('Skipping loadBundles - already loading');
+      this.loadBundlesPending = true;
+      this.logger.debug('loadBundles already running - scheduling a follow-up load');
       return;
     }
 
@@ -304,9 +310,11 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
     try {
       // Search for all bundles using cache only (non-blocking)
       // This ensures fast initial load - network fetches happen via syncSource which fires onSourceSynced
-      const bundles = await this.registryManager.searchBundles({ cacheOnly: true });
-      const installedBundles = await this.registryManager.listInstalledBundles();
-      const sources = await this.registryManager.listSources();
+      const [bundles, installedBundles, sources] = await Promise.all([
+        this.registryManager.searchBundles({ cacheOnly: true }),
+        this.registryManager.listInstalledBundles(),
+        this.registryManager.listSources()
+      ]);
       const autoUpdateService = this.registryManager.autoUpdateService;
 
       // Preload auto-update preferences once per refresh
@@ -383,6 +391,12 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
       this.logger.error('Failed to load marketplace bundles', error as Error);
     } finally {
       this.isLoadingBundles = false;
+      // A load was requested while this one was in flight — run exactly once more
+      // to pick up cache updates that arrived during this render.
+      if (this.loadBundlesPending) {
+        this.loadBundlesPending = false;
+        void this.loadBundles();
+      }
     }
   }
 
@@ -936,45 +950,7 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
   private getMarkdownRender(rawmarkdown: string): string {
     const md = this.getMarkdownItInstance();
     const html = md.render(rawmarkdown);
-    return sanitizeHtml(html, {
-      // 'a' is already part of the defaults; 'img' is added for inline images
-      allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img']),
-      allowedAttributes: {
-        ...sanitizeHtml.defaults.allowedAttributes,
-        a: ['href', 'title', 'data-external-link', 'rel', 'class'],
-        img: ['src', 'alt', 'title', 'width', 'height']
-      },
-      // Allow safe external link/image schemes — still blocks data: and javascript:
-      allowedSchemes: ['https', 'http', 'mailto'],
-      // Keep images HTTPS-only (matches the webview CSP `img-src https:`); links may
-      // additionally use http/mailto since they are opened via vscode.env.openExternal.
-      allowedSchemesByTag: {
-        img: ['https'],
-        a: ['https', 'http', 'mailto']
-      },
-      transformTags: {
-        // Move the link target into a data attribute and DROP the href. Keeping
-        // href would let VS Code's built-in webview link handling open the URL
-        // directly (bypassing our confirmation prompt). The webview JS reads
-        // data-external-link on click and routes through vscode.env.openExternal.
-        a: (tagName, attribs) => {
-          const href = attribs.href;
-          if (href) {
-            const { href: _dropped, ...rest } = attribs;
-            return {
-              tagName,
-              attribs: {
-                ...rest,
-                'data-external-link': href,
-                class: rest.class ? `${rest.class} external-link` : 'external-link',
-                rel: 'noopener noreferrer'
-              }
-            };
-          }
-          return { tagName, attribs };
-        }
-      }
-    });
+    return sanitizeHtml(html, this.sanitizeOptions);
   }
 
   /**
@@ -1100,12 +1076,10 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
     // Replace all placeholders
     html = html
       .replace('{{cspSource}}', cspSource)
-      .replace('{{bundleName}}', this.escapeHtml(bundle.name))
-      .replace('{{bundleName}}', this.escapeHtml(bundle.name))
+      .replaceAll('{{bundleName}}', this.escapeHtml(bundle.name))
       .replace('{{cssUri}}', cssUri.toString())
       .replace('{{installedBadge}}', installedBadge)
-      .replace('{{author}}', this.escapeHtml(bundle.author || 'Unknown'))
-      .replace('{{author}}', this.escapeHtml(bundle.author || 'Unknown'))
+      .replaceAll('{{author}}', this.escapeHtml(bundle.author || 'Unknown'))
       .replace('{{version}}', bundle.version)
       .replace('{{autoUpdateSection}}', autoUpdateSection)
       .replace('{{description}}', bundle.description || 'No description available')
@@ -1310,10 +1284,7 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
    * Dispose of resources
    */
   public dispose(): void {
-    // Clear debounce timer
-    if (this.sourceSyncDebounceTimer) {
-      clearTimeout(this.sourceSyncDebounceTimer);
-    }
+    this.sourceSyncThrottle.dispose();
 
     // Dispose all event listeners
     this.disposables.forEach((d) => d.dispose());

--- a/src/ui/registry-tree-provider.ts
+++ b/src/ui/registry-tree-provider.ts
@@ -23,6 +23,9 @@ import {
   UI_CONSTANTS,
 } from '../utils/constants';
 import {
+  LeadingTrailingThrottle,
+} from '../utils/leading-trailing-throttle';
+import {
   Logger,
 } from '../utils/logger';
 
@@ -274,7 +277,12 @@ export class RegistryTreeProvider implements vscode.TreeDataProvider<RegistryTre
 
   private readonly logger: Logger;
   private readonly availableUpdates: Map<string, UpdateCheckResult> = new Map();
-  private sourceSyncDebounceTimer?: NodeJS.Timeout;
+
+  private readonly sourceSyncThrottle = new LeadingTrailingThrottle(
+    () => this.refresh(),
+    UI_CONSTANTS.SOURCE_SYNC_DEBOUNCE_MS
+  );
+
   private disposables: vscode.Disposable[] = [];
 
   private viewMode: 'all' | 'favorites' = 'all';
@@ -329,17 +337,7 @@ export class RegistryTreeProvider implements vscode.TreeDataProvider<RegistryTre
    */
   private handleSourceSynced(event: { sourceId: string; bundleCount: number }): void {
     this.logger.debug(`Source synced: ${event.sourceId} (${event.bundleCount} bundles)`);
-
-    // Clear existing timer
-    if (this.sourceSyncDebounceTimer) {
-      clearTimeout(this.sourceSyncDebounceTimer);
-    }
-
-    // Set new timer with shared debounce delay
-    this.sourceSyncDebounceTimer = setTimeout(() => {
-      this.logger.debug('Refreshing tree view after source sync');
-      this.refresh();
-    }, UI_CONSTANTS.SOURCE_SYNC_DEBOUNCE_MS);
+    this.sourceSyncThrottle.trigger();
   }
 
   /**
@@ -1021,10 +1019,7 @@ export class RegistryTreeProvider implements vscode.TreeDataProvider<RegistryTre
    * Dispose of resources
    */
   public dispose(): void {
-    // Clear debounce timer
-    if (this.sourceSyncDebounceTimer) {
-      clearTimeout(this.sourceSyncDebounceTimer);
-    }
+    this.sourceSyncThrottle.dispose();
 
     // Dispose all event listeners
     this.disposables.forEach((d) => d.dispose());

--- a/src/ui/webview/bundle-details/bundle-details.js
+++ b/src/ui/webview/bundle-details/bundle-details.js
@@ -54,10 +54,7 @@
       var readmeContent = document.querySelector('.details-content');
       if (readmeContent) {
         readmeContent.innerHTML = message.readmeHtml;
-        var readmeSection = document.querySelector('#readme-section');
-        if (readmeSection) {
-          readmeSection.style.display = '';
-        }
+        readmeContent.closest('#readme-section')?.removeAttribute('style');
       }
     }
   });

--- a/src/utils/leading-trailing-throttle.ts
+++ b/src/utils/leading-trailing-throttle.ts
@@ -1,0 +1,49 @@
+/**
+ * Leading + trailing edge throttle.
+ *
+ * Runs the action immediately on the first trigger of a burst (leading edge),
+ * then once more after `delayMs` of quiet following the last trigger (trailing
+ * edge). Resetting the timer on every trigger means the trailing edge always
+ * fires after the last event settles — important when the action reads a file
+ * that is still being written during the burst.
+ *
+ * Used by the tree and marketplace views to rate-limit refreshes while a source
+ * streams many partial sync events.
+ */
+export class LeadingTrailingThrottle {
+  private timer?: NodeJS.Timeout;
+
+  constructor(
+    private readonly action: () => void,
+    private readonly delayMs: number
+  ) {}
+
+  /**
+   * Signal an event. Fires the action on the leading edge of a burst and
+   * schedules a single trailing-edge run after the burst goes quiet.
+   */
+  public trigger(): void {
+    const isFirstEvent = !this.timer;
+
+    if (this.timer) {
+      clearTimeout(this.timer);
+    }
+
+    if (isFirstEvent) {
+      this.action(); // leading edge
+    }
+
+    this.timer = setTimeout(() => {
+      this.timer = undefined;
+      this.action(); // trailing edge — fires after the last event settles
+    }, this.delayMs);
+  }
+
+  /** Cancel any pending trailing-edge run. */
+  public dispose(): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+  }
+}

--- a/test/adapters/skills-adapter.test.ts
+++ b/test/adapters/skills-adapter.test.ts
@@ -322,8 +322,14 @@ suite('SkillsAdapter Tests', () => {
       nock('https://api.github.com')
         .get('/repos/test-owner/test-skills-repo/contents/skills')
         .reply(200, []);
-      // Tree scan returns one skill
-      setupSkillsTreeMocks([{ id: 'test-skill', name: 'test-skill', description: 'Test skill' }]);
+      // Tree scan returns one skill (no raw SKILL.md interceptor registered — validate must not fetch it)
+      nock('https://api.github.com')
+        .get('/repos/test-owner/test-skills-repo/git/trees/main?recursive=1')
+        .reply(200, { tree: [{ path: 'skills/test-skill/SKILL.md', type: 'blob', sha: 'sha-test' }], truncated: false });
+      // Register a raw SKILL.md scope; assert it is NOT consumed (validate must not download SKILL.md)
+      const rawScope = nock('https://raw.githubusercontent.com')
+        .get('/test-owner/test-skills-repo/main/skills/test-skill/SKILL.md')
+        .reply(200, '---\nname: test-skill\ndescription: Test skill\n---\n\nInstructions');
 
       const adapter = new SkillsAdapter(mockSource);
       const result = await adapter.validate();
@@ -331,6 +337,7 @@ suite('SkillsAdapter Tests', () => {
       assert.strictEqual(result.valid, true);
       assert.strictEqual(result.errors.length, 0);
       assert.strictEqual(result.bundlesFound, 1);
+      assert.ok(!rawScope.isDone(), 'validate() must not download SKILL.md files');
     });
 
     test('should fail validation when skills/ directory is missing', async () => {
@@ -383,6 +390,101 @@ suite('SkillsAdapter Tests', () => {
       const url = adapter.getDownloadUrl('skills-test-owner-test-skills-repo-algorithmic-art');
 
       assert.strictEqual(url, 'https://github.com/test-owner/test-skills-repo/archive/refs/heads/main.zip');
+    });
+  });
+
+  suite('fetchBundles() — progressive streaming', () => {
+    // Use 20 skills so we always exceed the current CONCURRENCY_LIMIT (15) and get 2+ chunks.
+    const makeSkills = (count: number) =>
+      Array.from({ length: count }, (_, i) => ({
+        id: `skill-${i}`,
+        name: `Skill ${i}`,
+        description: `Description ${i}`
+      }));
+
+    test('calls onPartialBundles more than once when skills exceed one chunk', async () => {
+      setupSkillsTreeMocks(makeSkills(20));
+
+      const adapter = new SkillsAdapter(mockSource);
+      const snapshots: number[] = [];
+
+      await adapter.fetchBundles((partial) => {
+        snapshots.push(partial.length);
+      });
+
+      assert.ok(snapshots.length > 1, `Expected >1 callback invocation, got ${snapshots.length}`);
+    });
+
+    test('each partial payload is monotonically non-decreasing in length', async () => {
+      setupSkillsTreeMocks(makeSkills(20));
+
+      const adapter = new SkillsAdapter(mockSource);
+      const snapshots: number[] = [];
+
+      await adapter.fetchBundles((partial) => {
+        snapshots.push(partial.length);
+      });
+
+      for (let i = 1; i < snapshots.length; i++) {
+        assert.ok(
+          snapshots[i] >= snapshots[i - 1],
+          `Expected non-decreasing lengths: ${snapshots.join(', ')}`
+        );
+      }
+    });
+
+    test('each partial payload is a distinct array (snapshot, not shared mutable ref)', async () => {
+      setupSkillsTreeMocks(makeSkills(20));
+
+      const adapter = new SkillsAdapter(mockSource);
+      const refs: unknown[][] = [];
+
+      await adapter.fetchBundles((partial) => {
+        refs.push(partial);
+      });
+
+      // All collected refs must be distinct array instances
+      for (let i = 0; i < refs.length; i++) {
+        for (let j = i + 1; j < refs.length; j++) {
+          assert.notStrictEqual(refs[i], refs[j], 'Each callback invocation should receive a distinct array');
+        }
+      }
+    });
+
+    test('final returned bundles equal the last partial payload', async () => {
+      setupSkillsTreeMocks(makeSkills(20));
+
+      const adapter = new SkillsAdapter(mockSource);
+      let lastPartial: unknown[] = [];
+
+      const finalBundles = await adapter.fetchBundles((partial) => {
+        lastPartial = partial;
+      });
+
+      assert.strictEqual(finalBundles.length, lastPartial.length);
+      for (const bundle of finalBundles) {
+        assert.ok(lastPartial.some((b: any) => b.id === bundle.id), `Bundle ${bundle.id} missing from last partial`);
+      }
+    });
+
+    test('final bundle set is identical with or without callback (regression for concurrency change)', async () => {
+      const skills = makeSkills(20);
+
+      // Without callback
+      setupSkillsTreeMocks(skills);
+      const withoutCb = await new SkillsAdapter(mockSource).fetchBundles();
+
+      // With callback
+      nock.cleanAll();
+      setupSkillsTreeMocks(skills);
+      const withCb = await new SkillsAdapter(mockSource).fetchBundles(() => {});
+
+      assert.strictEqual(withCb.length, withoutCb.length, 'Bundle count must be identical with or without callback');
+
+      const withoutIds = new Set(withoutCb.map((b) => b.id));
+      for (const bundle of withCb) {
+        assert.ok(withoutIds.has(bundle.id), `Bundle ${bundle.id} present with callback but missing without`);
+      }
     });
   });
 });

--- a/test/helpers/ui-test-helpers.ts
+++ b/test/helpers/ui-test-helpers.ts
@@ -34,8 +34,22 @@ const REGISTRY_MANAGER_EVENTS = [
   'onSourceUpdated',
   'onSourceSynced',
   'onAutoUpdatePreferenceChanged',
-  'onRepositoryBundlesChanged'
+  'onRepositoryBundlesChanged',
+  'onReadmeDownloaded',
+  'onReadmeDownloadComplete'
 ] as const;
+
+/** Name of a RegistryManager event emitter. */
+export type RegistryManagerEvent = (typeof REGISTRY_MANAGER_EVENTS)[number];
+
+/**
+ * Optional per-event capture callbacks. When provided for an event, the mock
+ * invokes the capture with the subscriber's callback so tests can drive the
+ * event later (e.g. `{ onSourceSynced: (cb) => { captured = cb; } }`).
+ */
+export type RegistryManagerEventCaptures = Partial<
+  Record<RegistryManagerEvent, (callback: any) => void>
+>;
 
 /**
  * All event emitter names that HubManager exposes.
@@ -61,21 +75,35 @@ function createDisposableStub(sandbox: sinon.SinonSandbox): sinon.SinonStub {
  *
  * This ensures that RegistryTreeProvider and other UI components can
  * subscribe to events without throwing errors.
- * @param registryManagerStub - The sinon stub instance of RegistryManager
+ * @param registryManagerStub - The sinon stub instance (or plain mock) of RegistryManager
  * @param sandbox - The sinon sandbox to use for creating stubs
+ * @param captures - Optional per-event capture callbacks; when provided for an
+ *   event, the mock invokes the capture with the subscriber's callback so the
+ *   test can drive the event later
  * @example
  * ```typescript
  * const sandbox = sinon.createSandbox();
  * const registryManagerStub = sandbox.createStubInstance(RegistryManager);
  * setupRegistryManagerEventMocks(registryManagerStub, sandbox);
+ *
+ * // Capturing a callback to fire it manually:
+ * let onSourceSynced;
+ * setupRegistryManagerEventMocks(mock, sandbox, { onSourceSynced: (cb) => { onSourceSynced = cb; } });
  * ```
  */
 export function setupRegistryManagerEventMocks(
-    registryManagerStub: sinon.SinonStubbedInstance<RegistryManager>,
-    sandbox: sinon.SinonSandbox
+    registryManagerStub: sinon.SinonStubbedInstance<RegistryManager> | Record<string, unknown>,
+    sandbox: sinon.SinonSandbox,
+    captures: RegistryManagerEventCaptures = {}
 ): void {
   for (const eventName of REGISTRY_MANAGER_EVENTS) {
-    (registryManagerStub as any)[eventName] = createDisposableStub(sandbox);
+    const capture = captures[eventName];
+    (registryManagerStub as any)[eventName] = capture
+      ? sandbox.stub().callsFake((callback: any) => {
+        capture(callback);
+        return { dispose: () => {} };
+      })
+      : createDisposableStub(sandbox);
   }
 }
 

--- a/test/services/registry-manager.eventHandling.test.ts
+++ b/test/services/registry-manager.eventHandling.test.ts
@@ -9,9 +9,20 @@ import * as assert from 'node:assert';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import {
+  RegistryManager,
+} from '../../src/services/registry-manager';
+import {
+  RegistryStorage,
+} from '../../src/storage/registry-storage';
+import {
+  Bundle,
   DeploymentManifest,
   InstalledBundle,
+  RegistrySource,
 } from '../../src/types/registry';
+import {
+  BundleBuilder,
+} from '../helpers/bundle-test-helpers';
 
 // Helper to create mock manifest
 function createMockManifest(): DeploymentManifest {
@@ -245,5 +256,132 @@ suite('RegistryManager - Event Handling', () => {
       assert.strictEqual(eventData?.sourceId, 'empty-source', 'Event should contain correct source ID');
       assert.strictEqual(eventData?.bundleCount, 0, 'Event should contain zero bundle count');
     });
+  });
+});
+
+suite('RegistryManager - Progressive syncSource', () => {
+  let sandbox: sinon.SinonSandbox;
+  let manager: RegistryManager;
+  let mockStorage: sinon.SinonStubbedInstance<RegistryStorage>;
+
+  const testSource: RegistrySource = {
+    id: 'progressive-source',
+    name: 'Progressive Source',
+    type: 'skills',
+    url: 'https://github.com/owner/skills-repo',
+    enabled: true,
+    priority: 1
+  };
+
+  const makeBundles = (count: number): Bundle[] =>
+    Array.from({ length: count }, () =>
+      BundleBuilder.github('owner', 'skills-repo').withVersion('1.0.0').build()
+    );
+
+  setup(() => {
+    sandbox = sinon.createSandbox();
+
+    const mockContext: any = {
+      globalState: {
+        get: sandbox.stub().returns(undefined),
+        update: sandbox.stub().resolves(),
+        keys: sandbox.stub().returns([]),
+        setKeysForSync: sandbox.stub()
+      },
+      workspaceState: {
+        get: sandbox.stub().returns(undefined),
+        update: sandbox.stub().resolves(),
+        keys: sandbox.stub().returns([]),
+        setKeysForSync: sandbox.stub()
+      },
+      subscriptions: [],
+      extensionPath: '/mock/path',
+      extensionUri: vscode.Uri.file('/mock/path'),
+      storageUri: vscode.Uri.file('/mock/storage'),
+      globalStorageUri: vscode.Uri.file('/mock/global'),
+      asAbsolutePath: (p: string) => `/mock/path/${p}`
+    };
+
+    manager = RegistryManager.getInstance(mockContext);
+
+    mockStorage = sandbox.createStubInstance(RegistryStorage);
+    mockStorage.getSources.resolves([testSource]);
+    mockStorage.getInstalledBundles.resolves([]);
+    mockStorage.getProfiles.resolves([]);
+    mockStorage.cacheSourceBundles.resolves();
+    (manager as any).storage = mockStorage;
+  });
+
+  teardown(() => {
+    sandbox.restore();
+  });
+
+  test('onSourceSynced fires per batch when adapter invokes callback multiple times', async () => {
+    const batch1 = makeBundles(15);
+    const batch2 = [...batch1, ...makeBundles(5)];
+
+    // Stub adapter that calls onPartialBundles twice then returns full list
+    const fakeAdapter = {
+      fetchBundles: async (onPartial?: (b: Bundle[]) => void | Promise<void>) => {
+        if (onPartial) {
+          await onPartial(batch1);
+          await onPartial(batch2);
+        }
+        return batch2;
+      }
+    };
+    (manager as any).adapters.set(testSource.id, fakeAdapter);
+
+    const firedCounts: number[] = [];
+    const disposable = manager.onSourceSynced((event) => {
+      if (event.sourceId === testSource.id) {
+        firedCounts.push(event.bundleCount);
+      }
+    });
+
+    try {
+      await manager.syncSource(testSource.id);
+    } finally {
+      disposable.dispose();
+    }
+
+    // Should fire at least once for each batch callback invocation (plus the final fire)
+    assert.ok(
+      firedCounts.length >= 2,
+      `Expected ≥2 onSourceSynced fires, got ${firedCounts.length}: [${firedCounts.join(', ')}]`
+    );
+  });
+
+  test('cacheSourceBundles is called incrementally with growing arrays', async () => {
+    const batch1 = makeBundles(15);
+    const batch2 = [...batch1, ...makeBundles(5)];
+
+    const fakeAdapter = {
+      fetchBundles: async (onPartial?: (b: Bundle[]) => void | Promise<void>) => {
+        if (onPartial) {
+          await onPartial(batch1);
+          await onPartial(batch2);
+        }
+        return batch2;
+      }
+    };
+    (manager as any).adapters.set(testSource.id, fakeAdapter);
+
+    await manager.syncSource(testSource.id);
+
+    // cacheSourceBundles should have been called multiple times (per batch + final)
+    assert.ok(
+      mockStorage.cacheSourceBundles.callCount >= 2,
+      `Expected ≥2 cacheSourceBundles calls, got ${mockStorage.cacheSourceBundles.callCount}`
+    );
+
+    // Each call should have non-decreasing bundle counts
+    const callArgs = mockStorage.cacheSourceBundles.args.map(([, bundles]) => bundles.length);
+    for (let i = 1; i < callArgs.length; i++) {
+      assert.ok(
+        callArgs[i] >= callArgs[i - 1],
+        `cacheSourceBundles call counts should be non-decreasing: ${callArgs.join(', ')}`
+      );
+    }
   });
 });

--- a/test/ui/marketplace-view-provider.eventHandling.test.ts
+++ b/test/ui/marketplace-view-provider.eventHandling.test.ts
@@ -21,6 +21,11 @@ import {
 import {
   MarketplaceViewProvider,
 } from '../../src/ui/marketplace-view-provider';
+import {
+  setupRegistryManagerEventMocks,
+} from '../helpers/ui-test-helpers';
+
+const PROJECT_ROOT = process.cwd();
 
 // Helper to create mock manifest
 function createMockManifest(): DeploymentManifest {
@@ -69,31 +74,24 @@ suite('MarketplaceViewProvider - Event Handling', () => {
       extensionMode: 2 // ExtensionMode.Test
     } as any;
 
-    // Create mock RegistryManager with event emitters
+    // Create mock RegistryManager with event emitters, capturing the callbacks
+    // this suite drives directly.
     mockRegistryManager = {
-      onBundleInstalled: sandbox.stub().callsFake((callback) => {
-        onBundleInstalledCallback = callback;
-        return { dispose: () => {} };
-      }),
-      onBundleUninstalled: sandbox.stub().callsFake((callback) => {
-        onBundleUninstalledCallback = callback;
-        return { dispose: () => {} };
-      }),
-      onBundleUpdated: sandbox.stub().callsFake((callback) => {
-        onBundleUpdatedCallback = callback;
-        return { dispose: () => {} };
-      }),
-      onBundlesInstalled: sandbox.stub().returns({ dispose: () => {} }),
-      onBundlesUninstalled: sandbox.stub().returns({ dispose: () => {} }),
-      onSourceSynced: sandbox.stub().returns({ dispose: () => {} }),
-      onAutoUpdatePreferenceChanged: sandbox.stub().returns({ dispose: () => {} }),
-      onRepositoryBundlesChanged: sandbox.stub().returns({ dispose: () => {} }),
-      onReadmeDownloaded: sandbox.stub().returns({ dispose: () => {} }),
-      onReadmeDownloadComplete: sandbox.stub().returns({ dispose: () => {} }),
       searchBundles: sandbox.stub().resolves([]),
       listInstalledBundles: sandbox.stub().resolves([]),
       listSources: sandbox.stub().resolves([])
     } as any;
+    setupRegistryManagerEventMocks(mockRegistryManager, sandbox, {
+      onBundleInstalled: (cb) => {
+        onBundleInstalledCallback = cb;
+      },
+      onBundleUninstalled: (cb) => {
+        onBundleUninstalledCallback = cb;
+      },
+      onBundleUpdated: (cb) => {
+        onBundleUpdatedCallback = cb;
+      }
+    });
 
     // Create mock SetupStateManager
     mockSetupStateManager = {
@@ -357,5 +355,185 @@ suite('MarketplaceViewProvider - Event Handling', () => {
       // The event should have been processed without errors
       assert.ok(true, 'Event processed successfully');
     });
+  });
+});
+
+suite('MarketplaceViewProvider - Throttle on source sync burst', () => {
+  let sandbox: sinon.SinonSandbox;
+  let clock: sinon.SinonFakeTimers;
+  let onSourceSyncedCallback: ((event: { sourceId: string; bundleCount: number }) => void) | undefined;
+  let postedMessages: any[];
+  let mockSearchBundles: sinon.SinonStub;
+
+  setup(() => {
+    sandbox = sinon.createSandbox();
+    clock = sandbox.useFakeTimers();
+    postedMessages = [];
+    mockSearchBundles = sandbox.stub().resolves([]);
+
+    const mockWebview = {
+      postMessage: (message: any) => {
+        postedMessages.push(message);
+        return Promise.resolve(true);
+      },
+      onDidReceiveMessage: sandbox.stub().returns({ dispose: () => {} }),
+      asWebviewUri: (uri: vscode.Uri) => uri,
+      cspSource: "'self'",
+      options: {},
+      html: ''
+    };
+
+    const mockContext: any = {
+      subscriptions: [],
+      extensionUri: vscode.Uri.file(PROJECT_ROOT),
+      extensionPath: PROJECT_ROOT,
+      storagePath: '/mock/storage',
+      globalStoragePath: '/mock/global-storage',
+      logPath: '/mock/logs',
+      extensionMode: 2
+    };
+
+    const mockRegistryManager: any = {
+      searchBundles: mockSearchBundles,
+      listInstalledBundles: sandbox.stub().resolves([]),
+      listSources: sandbox.stub().resolves([]),
+      autoUpdateService: null
+    };
+    setupRegistryManagerEventMocks(mockRegistryManager, sandbox, {
+      onSourceSynced: (cb) => {
+        onSourceSyncedCallback = cb;
+      }
+    });
+
+    const mockSetupStateManager: any = {
+      getState: sandbox.stub().resolves('complete'),
+      isComplete: sandbox.stub().resolves(true),
+      isIncomplete: sandbox.stub().resolves(false)
+    };
+
+    const provider = new MarketplaceViewProvider(mockContext, mockRegistryManager, mockSetupStateManager);
+    (provider as any)._view = { webview: mockWebview };
+  });
+
+  teardown(() => {
+    sandbox.restore();
+  });
+
+  const flushAsync = async () => {
+    // Flush pending microtasks and promise chains (searchBundles, listInstalledBundles, listSources each add ticks)
+    for (let i = 0; i < 10; i++) {
+      await Promise.resolve();
+    }
+  };
+
+  test('fires leading-edge refresh immediately on first source-synced event', async () => {
+    // Fire one event — the leading edge must trigger a refresh right away (before any timer)
+    onSourceSyncedCallback?.({ sourceId: 'test-source', bundleCount: 5 });
+
+    // Drain the microtask queue so the async loadBundles can post its message
+    await flushAsync();
+
+    const countBeforeTimer = postedMessages.filter((m) => m.type === 'bundlesLoaded').length;
+    assert.ok(countBeforeTimer >= 1, `Expected leading-edge bundlesLoaded message before timer, got ${countBeforeTimer}`);
+  });
+
+  test('a burst of 5 source-synced events produces ≥2 bundlesLoaded messages (leading + trailing)', async () => {
+    if (!onSourceSyncedCallback) {
+      assert.fail('onSourceSynced callback was not registered');
+    }
+
+    // Fire 5 events in rapid succession (all within the 500ms window)
+    for (let i = 0; i < 5; i++) {
+      onSourceSyncedCallback({ sourceId: 'test-source', bundleCount: i + 1 });
+    }
+
+    // Drain microtasks so the leading-edge loadBundles completes
+    await flushAsync();
+
+    const afterLeading = postedMessages.filter((m) => m.type === 'bundlesLoaded').length;
+    assert.ok(afterLeading >= 1, `Expected at least leading-edge bundlesLoaded, got ${afterLeading}`);
+
+    // Advance past the throttle window to trigger the trailing edge
+    clock.tick(600);
+    await flushAsync();
+
+    const afterTrailing = postedMessages.filter((m) => m.type === 'bundlesLoaded').length;
+    assert.ok(
+      afterTrailing >= 2,
+      `Expected ≥2 bundlesLoaded messages (leading + trailing), got ${afterTrailing}`
+    );
+  });
+
+  // Gate the FIRST load on a FAKE TIMER (not a hand-resolved promise). This keeps
+  // the entire async chain timer-driven so clock.tickAsync fully controls ordering
+  // and settling — mixing a manually-resolved promise with tickAsync is flaky under
+  // a busy event loop. The gate "releases" at GATE_MS; later calls resolve at once.
+  const GATE_MS = 10_000;
+  const gateFirstLoad = () => {
+    mockSearchBundles.onFirstCall().callsFake(
+      () => new Promise((resolve) => setTimeout(() => resolve([]), GATE_MS))
+    );
+    mockSearchBundles.callsFake(async () => []);
+  };
+  const renderCount = () => postedMessages.filter((m) => m.type === 'bundlesLoaded').length;
+
+  test('does not drop the trailing-edge load when the leading-edge load is still in flight', async () => {
+    if (!onSourceSyncedCallback) {
+      assert.fail('onSourceSynced callback was not registered');
+    }
+
+    gateFirstLoad();
+
+    // Leading edge: starts the (gated) first load and arms the 500ms throttle timer.
+    onSourceSyncedCallback({ sourceId: 'source-a', bundleCount: 3 });
+
+    // Advance past the 500ms throttle window (but not past the gate) so the trailing
+    // edge fires while the first load is still in flight — the call that was
+    // previously swallowed and never rescheduled.
+    await clock.tickAsync(600);
+
+    assert.strictEqual(renderCount(), 0, 'no render should occur while the first load is still gated');
+
+    // Release the gated first load. The coalesced follow-up must run and render again.
+    await clock.tickAsync(GATE_MS);
+
+    assert.ok(
+      renderCount() >= 2,
+      `expected leading-edge render plus a coalesced trailing-edge render, got ${renderCount()}`
+    );
+    assert.ok(
+      mockSearchBundles.callCount >= 2,
+      `expected the coalesced load to re-query the cache, got ${mockSearchBundles.callCount} calls`
+    );
+  });
+
+  test('collapses multiple mid-flight load requests into a single follow-up render', async () => {
+    if (!onSourceSyncedCallback) {
+      assert.fail('onSourceSynced callback was not registered');
+    }
+
+    gateFirstLoad();
+
+    // Leading edge starts the gated load and arms the throttle timer.
+    onSourceSyncedCallback({ sourceId: 'source-a', bundleCount: 1 });
+
+    // Generate several load requests while the first load is still gated: each
+    // trailing edge fires, and a fresh event re-arms the throttle for the next one.
+    await clock.tickAsync(600); // trailing edge #1 → pending
+    onSourceSyncedCallback({ sourceId: 'source-a', bundleCount: 2 }); // re-arms
+    await clock.tickAsync(600); // trailing edge #2 → pending (still just one re-run queued)
+    onSourceSyncedCallback({ sourceId: 'source-a', bundleCount: 3 }); // re-arms
+    await clock.tickAsync(600); // trailing edge #3 → pending
+
+    assert.strictEqual(renderCount(), 0, 'no render should occur while the first load is still gated');
+
+    // Release the gate: exactly one leading render + one coalesced follow-up.
+    await clock.tickAsync(GATE_MS);
+
+    assert.strictEqual(
+      renderCount(),
+      2,
+      `expected exactly leading + one coalesced follow-up render, got ${renderCount()}`
+    );
   });
 });


### PR DESCRIPTION
## Description

Syncing a large skills source (360+ skills) left the marketplace blank for ~40s. Skills now appear within ~1-2s and progressively fill in as chunks are parsed.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] ⚡ Performance improvement
- [x] 🧪 Test coverage improvement

## Related Issues

Relates to #

## Changes Made

- Raise `CONCURRENCY_LIMIT` 5→15 in `SkillsAdapter` to cut raw parse time
- Add optional `onPartialBundles` callback to `IRepositoryAdapter.fetchBundles` (all other adapters unchanged — param is optional)
- `SkillsAdapter.fetchBundles` streams bundle chunks via the callback as each parse chunk completes
- `RegistryManager.syncSource` passes a callback that progressively caches and fires `onSourceSynced` per batch
- Switch `handleSourceSynced` in marketplace and tree providers from debounce (clear-and-reset) to throttle (leading + trailing, no mid-burst resets)

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

### Manual Testing Steps

1. Add the Anthropic skills source (`https://github.com/anthropics/claude-code`)
2. Trigger a sync
3. Confirm skills appear in the marketplace within ~1-2s and progressively fill in (rather than blank for ~40s)

### Tested On

- [x] macOS
- [ ] Windows
- [ ] Linux

- [x] VS Code Stable
- [ ] VS Code Insiders

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Documentation

- [x] JSDoc comments added/updated
- [ ] No documentation changes needed

## Reviewer Guidelines

Please pay special attention to:

- `SkillsAdapter.fetchBundles` — bundle creation now happens inside the chunk callback; the old post-scan loop is removed
- `RegistryManager.syncSource` — the progressive callback fires `_onSourceSynced` before the final fire; both are intentional

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**