### PR TITLE
fix: isolate McpServerManager tests from real VS Code mcp.json

### DIFF
--- a/test/services/mcp-server-manager.test.ts
+++ b/test/services/mcp-server-manager.test.ts
@@ -2,24 +2,41 @@ import * as assert from 'node:assert';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import * as fs from 'fs-extra';
+import * as sinon from 'sinon';
 import {
   McpServerManager,
 } from '../../src/services/mcp-server-manager';
 import {
   McpServersManifest,
 } from '../../src/types/mcp';
+import {
+  McpConfigLocator,
+} from '../../src/utils/mcp-config-locator';
 
 suite('McpServerManager Test Suite', () => {
   let manager: McpServerManager;
   let testDir: string;
+  let sandbox: sinon.SinonSandbox;
 
   setup(() => {
+    sandbox = sinon.createSandbox();
     manager = new McpServerManager();
     testDir = path.join(os.tmpdir(), 'mcp-test-' + Date.now());
     fs.ensureDirSync(testDir);
+
+    const mockConfigPath = path.join(testDir, 'mcp.json');
+    const mockTrackingPath = path.join(testDir, 'mcp-tracking.json');
+
+    sandbox.stub(McpConfigLocator, 'getMcpConfigLocation').returns({
+      configPath: mockConfigPath,
+      trackingPath: mockTrackingPath,
+      exists: false,
+    });
+    sandbox.stub(McpConfigLocator, 'ensureConfigDirectory').resolves();
   });
 
   teardown(async () => {
+    sandbox.restore();
     if (fs.existsSync(testDir)) {
       await fs.remove(testDir);
     }


### PR DESCRIPTION
## Description

Tests in `mcp-server-manager.test.ts` were leaking into the real VS Code user `mcp.json` because `McpConfigLocator.getUserConfigDirectory()` falls back to `os.homedir()` when no extension context is set. This caused test entries like `prompt-registry:test-bundle-...:test-server` to appear in the real VS Code MCP configuration.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🧪 Test coverage improvement

## Related Issues

Relates to #

## Changes Made

- Stub `McpConfigLocator.getMcpConfigLocation` and `McpConfigLocator.ensureConfigDirectory` in `mcp-server-manager.test.ts` setup to redirect all config reads/writes to a temporary directory
- Restore the sandbox in `teardown` to avoid cross-test pollution
- Add `sinon` and `McpConfigLocator` imports to the test file

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [x] All existing tests pass

### Manual Testing Steps

1. Run `npm run test:one -- test/services/mcp-server-manager.test.ts` — all 4 tests pass
2. Verify no new entries appear in `~/Library/Application Support/Code/User/mcp.json` after the test run

### Tested On

- [x] macOS

- [x] VS Code Stable

## Screenshots

Before the fix mcp.json
<img width="731" height="384" alt="image" src="https://github.com/user-attachments/assets/c5093b5c-8c40-4be1-a975-d6a52baff054" />


## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] No documentation changes needed

## Additional Notes

The root cause is `McpConfigLocator.getUserConfigDirectory()` falling back to `os.homedir()` when `this.context` is unset (which is always the case in unit tests). The fix stubs the locator at the static method level so all downstream code (including `McpConfigService`) is redirected to the temp dir.

## Reviewer Guidelines

Please pay special attention to:

- Whether the stub correctly covers all code paths in `installServers` and `uninstallServers` that call `McpConfigLocator`
- Whether restoring the sandbox in `teardown` is sufficient to prevent cross-test pollution

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**