### PR TITLE
chore: bump version of the lib manually to take into account README publication

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prompt-registry/collection-scripts",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Shared scripts for building, validating, and publishing Copilot prompt collections",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Description

Manually bump the version of the library to account for the recent README publication changes.

## Type of Change

- [x] 🔧 Configuration/build changes

## Related Issues

Relates to the library versioning after README updates

## Changes Made

- Updated library version in package.json to reflect README publication

## Testing

- [x] All existing tests pass
- [x] No new warnings or errors

## Checklist

- [x] My code follows the project's style guidelines
- [x] My changes generate no new warnings or errors
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

This is a manual version bump to ensure the published version correctly reflects the README documentation changes.

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**