### PR TITLE
fix(publish): npmjs configuration for ai-primitives-hub

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -5,17 +5,17 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
-    "validate-collections": "./bin/validate-collections.js",
-    "validate-skills": "./bin/validate-skills.js",
-    "build-collection-bundle": "./bin/build-collection-bundle.js",
-    "compute-collection-version": "./bin/compute-collection-version.js",
-    "detect-affected-collections": "./bin/detect-affected-collections.js",
-    "generate-manifest": "./bin/generate-manifest.js",
-    "publish-collections": "./bin/publish-collections.js",
-    "list-collections": "./bin/list-collections.js",
-    "create-skill": "./bin/create-skill.js",
-    "hub-release-analyzer": "./bin/hub-release-analyzer.js",
-    "hub-ownership-analyzer": "./bin/hub-ownership-analyzer.js"
+    "validate-collections": "bin/validate-collections.js",
+    "validate-skills": "bin/validate-skills.js",
+    "build-collection-bundle": "bin/build-collection-bundle.js",
+    "compute-collection-version": "bin/compute-collection-version.js",
+    "detect-affected-collections": "bin/detect-affected-collections.js",
+    "generate-manifest": "bin/generate-manifest.js",
+    "publish-collections": "bin/publish-collections.js",
+    "list-collections": "bin/list-collections.js",
+    "create-skill": "bin/create-skill.js",
+    "hub-release-analyzer": "bin/hub-release-analyzer.js",
+    "hub-ownership-analyzer": "bin/hub-ownership-analyzer.js"
   },
   "scripts": {
     "build": "tsc",
@@ -28,7 +28,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/AmadeusITGroup/prompt-registry.git",
+    "url": "git+https://github.com/AmadeusITGroup/ai-primitives-hub.git",
     "directory": "lib"
   },
   "keywords": [
@@ -41,9 +41,9 @@
   "author": "Prompt Registry Contributors",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/AmadeusITGroup/prompt-registry/issues"
+    "url": "https://github.com/AmadeusITGroup/ai-primitives-hub/issues"
   },
-  "homepage": "https://github.com/AmadeusITGroup/prompt-registry/tree/main/lib#readme",
+  "homepage": "https://github.com/AmadeusITGroup/ai-primitives-hub/tree/main/lib#readme",
   "engines": {
     "node": ">=18.0.0"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,7 @@
     },
     "lib": {
       "name": "@prompt-registry/collection-scripts",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
         "archiver": "^7.0.1",

--- a/test/services/mcp-server-manager.test.ts
+++ b/test/services/mcp-server-manager.test.ts
@@ -30,7 +30,7 @@ suite('McpServerManager Test Suite', () => {
     sandbox.stub(McpConfigLocator, 'getMcpConfigLocation').returns({
       configPath: mockConfigPath,
       trackingPath: mockTrackingPath,
-      exists: false,
+      exists: false
     });
     sandbox.stub(McpConfigLocator, 'ensureConfigDirectory').resolves();
   });


### PR DESCRIPTION
## Description

Fixes npmjs publication issues following the repository rename to ai-primitives-hub.

## Type of Change

- [x] 🔧 Configuration/build changes
- [x] ⚡ Performance improvement

## Changes Made

- Fix npmjs publication configuration after renaming to ai-primitives-hub
- Bump version of the lib manually to take into account README publication
- Ensure collection-scripts uses correct publishing credentials

## Testing

- [x] All existing tests pass
- [x] Manual testing completed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

This addresses the OIDC token issue that broke publication after the repository was renamed from `prompt-registry` to `ai-primitives-hub` at the npm registry level.

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**