### PR TITLE
fix: consolidate GitHub-backed adapters + progressive marketplace refresh

### DIFF
--- a/docs/contributor-guide/architecture/adapters.md
+++ b/docs/contributor-guide/architecture/adapters.md
@@ -8,7 +8,7 @@ Adapters provide a unified interface for fetching bundles from different source 
 interface IRepositoryAdapter {
     readonly type: string;
     readonly source: RegistrySource;
-    fetchBundles(): Promise<Bundle[]>;
+    fetchBundles(onPartialBundles?: (bundles: Bundle[]) => void | Promise<void>): Promise<Bundle[]>;
     downloadBundle(bundle: Bundle): Promise<Buffer>;
     fetchMetadata(): Promise<SourceMetadata>;
     validate(): Promise<ValidationResult>;

--- a/docs/contributor-guide/architecture/adapters.md
+++ b/docs/contributor-guide/architecture/adapters.md
@@ -19,21 +19,55 @@ interface IRepositoryAdapter {
 }
 ```
 
+## Class Hierarchy
+
+The three GitHub-backed adapters share an intermediate abstract base, `GitHubBackedAdapter`, that
+centralizes GitHub URL parsing, the authentication chain, the HTTP transport, and the progressive
+chunked-fetch helper. Local (filesystem) adapters extend `RepositoryAdapter` directly.
+
+```mermaid
+classDiagram
+    RepositoryAdapter <|-- GitHubBackedAdapter
+    RepositoryAdapter <|-- LocalAdapter
+    RepositoryAdapter <|-- LocalAwesomeCopilotAdapter
+    RepositoryAdapter <|-- ApmAdapter
+    RepositoryAdapter <|-- LocalApmAdapter
+    GitHubBackedAdapter <|-- GitHubAdapter
+    GitHubBackedAdapter <|-- AwesomeCopilotAdapter
+    GitHubBackedAdapter <|-- SkillsAdapter
+    class GitHubBackedAdapter {
+        +apiBase
+        #parseGitHubUrl()
+        #getAuthenticationToken()
+        #httpGet() / getJson() / getText() / getBuffer()
+        #buildContentsUrl() / buildRawUrl()
+        #processInChunks()
+        #validateGitHubRepository()
+    }
+```
+
+`processInChunks(items, chunkSize, processItem, onPartial?)` runs each chunk with `Promise.allSettled`
+(one failure drops only that item) and invokes `onPartial` with a growing snapshot after each chunk.
+This is what drives the marketplace/tree views to fill in progressively during large source syncs,
+rather than appearing frozen until every source finishes.
+
 ## Adapter Types
 
-| Adapter | Source Type | Installation Method | Status |
-|---------|-------------|---------------------|--------|
-| **GitHubAdapter** | `github` | URL-based (getDownloadUrl) | Active |
-| **LocalAdapter** | `local` | Buffer-based (downloadBundle) | Active |
-| **AwesomeCopilotAdapter** | `awesome-copilot` | Buffer-based (builds zip on-the-fly) | Active |
-| **LocalAwesomeCopilotAdapter** | `local-awesome-copilot` | Buffer-based | Active |
-| **ApmAdapter** | `apm` | URL-based | Active |
-| **LocalApmAdapter** | `local-apm` | Buffer-based | Active |
+| Adapter | Source Type | Base Class | Installation Method | Status |
+|---------|-------------|------------|---------------------|--------|
+| **GitHubAdapter** | `github` | GitHubBackedAdapter | URL-based (getDownloadUrl) | Active |
+| **AwesomeCopilotAdapter** | `awesome-copilot` | GitHubBackedAdapter | Buffer-based (builds zip on-the-fly) | Active |
+| **SkillsAdapter** | `skills` | GitHubBackedAdapter | Buffer-based (builds zip on-the-fly) | Active |
+| **LocalAdapter** | `local` | RepositoryAdapter | Buffer-based (downloadBundle) | Active |
+| **LocalAwesomeCopilotAdapter** | `local-awesome-copilot` | RepositoryAdapter | Buffer-based | Active |
+| **LocalSkillsAdapter** | `local-skills` | RepositoryAdapter | Buffer-based | Active |
+| **ApmAdapter** | `apm` | RepositoryAdapter | URL-based | Active |
+| **LocalApmAdapter** | `local-apm` | RepositoryAdapter | Buffer-based | Active |
 
 Source types are defined in `src/types/registry.ts`:
 ```typescript
-export type SourceType = 'github' | 'local' | 
-    'awesome-copilot' | 'local-awesome-copilot' | 'apm' | 'local-apm';
+export type SourceType = 'github' | 'local' |
+    'awesome-copilot' | 'local-awesome-copilot' | 'apm' | 'local-apm' | 'skills' | 'local-skills';
 ```
 
 > **Freshness note:** `LocalAwesomeCopilotAdapter` does not cache its bundle list. `fetchBundles()` re-reads collection files from disk on every call so local edits (including readmes) are reflected immediately during development.
@@ -57,11 +91,16 @@ export type SourceType = 'github' | 'local' |
 ## Adding a New Adapter
 
 ```typescript
-// 1. Extend RepositoryAdapter base class
-export class MyAdapter extends RepositoryAdapter {
+// 1. Extend GitHubBackedAdapter for GitHub sources (inherits auth/HTTP/URL/chunking),
+//    or RepositoryAdapter for non-GitHub sources (implement auth/HTTP yourself).
+export class MyAdapter extends GitHubBackedAdapter {
     readonly type = 'my-type';
-    
-    async fetchBundles(): Promise<Bundle[]> { /* ... */ }
+
+    // Stream partial results so the UI renders progressively during large syncs.
+    async fetchBundles(onPartialBundles?: (b: Bundle[]) => void | Promise<void>): Promise<Bundle[]> {
+        const items = await this.getJson<Item[]>(/* ... */);
+        return this.processInChunks(items, 10, (item) => this.toBundle(item), onPartialBundles);
+    }
     async downloadBundle(bundle: Bundle): Promise<Buffer> { /* ... */ }
     async fetchMetadata(): Promise<SourceMetadata> { /* ... */ }
     async validate(): Promise<ValidationResult> { /* ... */ }
@@ -73,8 +112,9 @@ export class MyAdapter extends RepositoryAdapter {
 RepositoryAdapterFactory.register('my-type', MyAdapter);
 
 // 3. Add to SourceType union in src/types/registry.ts
-export type SourceType = 'github' | 'local' | 
-    'awesome-copilot' | 'local-awesome-copilot' | 'apm' | 'local-apm' | 'my-type';
+export type SourceType = 'github' | 'local' |
+    'awesome-copilot' | 'local-awesome-copilot' | 'apm' | 'local-apm' |
+    'skills' | 'local-skills' | 'my-type';
 ```
 
 ## See Also

--- a/docs/contributor-guide/architecture/ui-components.md
+++ b/docs/contributor-guide/architecture/ui-components.md
@@ -48,6 +48,13 @@ graph TD
 
 Bundle README markdown is rendered to HTML in the details panel via `markdown-it` and sanitized with `sanitize-html` (`getMarkdownRender`). Links (`<a>`) are preserved and tagged with a `data-external-link` attribute. The details webview intercepts clicks on these links and sends an `openExternalLink` message; the host then prompts the user for confirmation before opening the URL with `vscode.env.openExternal`. Images remain HTTPS-only to match the webview CSP; links may use `https`, `http`, or `mailto`.
 
+### Progressive Loading on Source Sync
+
+Sources sync in parallel (`Promise.allSettled`), and each fires `RegistryManager.onSourceSynced` as its bundles are cached — large skills sources stream multiple partial batches as they parse. The marketplace renders bundles as soon as **any** source has cached them, rather than waiting for all sources to finish. Two mechanisms cooperate in `MarketplaceViewProvider`:
+
+- **`handleSourceSynced` throttle (leading + trailing, 500ms)** — the leading edge renders immediately when a burst starts; the trailing edge picks up whatever arrived during the window. This rate-limits renders to avoid flicker when a source streams many partial batches.
+- **`loadBundles` coalescing** — `loadBundles` reads the full cache (`searchBundles({ cacheOnly: true })`) and posts one `bundlesLoaded` message. If it is called while a load is already in flight (e.g. the throttle's trailing edge racing the 100ms bootstrap load or the webview's self-`refresh`), it sets a pending flag and re-runs exactly once when the current load finishes, instead of dropping the request. This guarantees the latest cache always renders — without it, the first source's bundles could stay hidden until a later source re-armed the throttle.
+
 ## Tree View
 
 Hierarchical view displaying profiles, bundles, and sources with two view modes: "All Hubs" and "Favorites".
@@ -144,7 +151,7 @@ Extensive right-click menus defined in `package.json` with context-sensitive act
 - Implements `vscode.TreeDataProvider<RegistryTreeItem>`
 - Registered as `promptRegistryExplorer` in `package.json`
 - Supports collapse/expand states and refresh events
-- Debounced refresh on source sync events (500ms)
+- Throttled refresh on source sync events (leading + trailing, 500ms); `refresh()` fires `onDidChangeTreeData` so VS Code re-queries lazily
 
 #### Event Handling
 Listens to multiple registry and hub manager events:

--- a/docs/reference/adapter-api.md
+++ b/docs/reference/adapter-api.md
@@ -18,8 +18,10 @@ interface IRepositoryAdapter {
     // The source configuration
     readonly source: RegistrySource;
     
-    // Fetch all bundles from this source
-    fetchBundles(): Promise<Bundle[]>;
+    // Fetch all bundles from this source. The optional onPartialBundles
+    // callback is invoked with a growing snapshot after each parse chunk so
+    // the UI can render progressively during large syncs.
+    fetchBundles(onPartialBundles?: (bundles: Bundle[]) => void | Promise<void>): Promise<Bundle[]>;
     
     // Download a specific bundle (returns zip Buffer)
     downloadBundle(bundle: Bundle): Promise<Buffer>;

--- a/src/adapters/AGENTS.md
+++ b/src/adapters/AGENTS.md
@@ -19,7 +19,7 @@ interface IRepositoryAdapter {
   readonly type: string;
   readonly source: RegistrySource;
 
-  fetchBundles(): Promise<Bundle[]>;
+  fetchBundles(onPartialBundles?: (bundles: Bundle[]) => void | Promise<void>): Promise<Bundle[]>;
   downloadBundle(bundle: Bundle): Promise<Buffer>;
   fetchMetadata(): Promise<SourceMetadata>;
   validate(): Promise<ValidationResult>;
@@ -33,6 +33,7 @@ interface IRepositoryAdapter {
 - `downloadBundle` always returns a `Buffer` — whether the source provides pre-packaged ZIPs (GitHub) or builds them dynamically (Awesome Copilot, Local).
 - `getDownloadUrl` / `getManifestUrl` return `string` URLs — used for UI display and debug links, not for the actual download (which goes through `downloadBundle`).
 - `validate` returns a `ValidationResult` (not a boolean) — contains error details for user-facing diagnostics.
+- `fetchBundles` accepts an optional `onPartialBundles` callback — invoked with a growing snapshot after each parse chunk so the UI can render progressively during large syncs. Implementing it is optional; adapters that omit it simply resolve once with the full list. `SkillsAdapter` uses it to stream 360+ skills as they parse.
 
 ## Authentication Chain (GitHub)
 

--- a/src/adapters/AGENTS.md
+++ b/src/adapters/AGENTS.md
@@ -4,11 +4,40 @@
 
 Adapters provide a unified interface for prompt bundle sources (GitHub, Local, Awesome Copilot, APM, Skills, and their local variants).
 
+## Adapter Class Hierarchy
+
+```
+RepositoryAdapter (abstract, repository-adapter.ts)
+  └─ GitHubBackedAdapter (abstract, github-backed-adapter.ts)   ← shared GitHub logic
+       ├─ GitHubAdapter            (github-adapter.ts)
+       ├─ AwesomeCopilotAdapter    (awesome-copilot-adapter.ts)
+       └─ SkillsAdapter            (skills-adapter.ts)
+```
+
+`GitHubBackedAdapter` hoists everything the three GitHub-backed adapters share, so they no
+longer re-implement it:
+
+- **URL parsing / validation** — `parseGitHubUrl()`, `isValidGitHubUrl()` (validated in the constructor)
+- **URL builders** — `apiBase`, `buildContentsUrl(owner, repo, path, ref?)`, `buildRawUrl(owner, repo, branch, path)`
+- **Auth chain** — `getAuthenticationToken()` (explicit token → VS Code session → gh CLI), with
+  memoization, retry accounting, and `invalidateAuthCache()`
+- **HTTP transport** — `httpGet()` (redirects, sanitized header logging) plus the `getJson<T>()` /
+  `getText()` / `getBuffer()` wrappers; `getJson` invalidates auth and retries once on 401/403
+- **Progressive fetch** — `processInChunks(items, chunkSize, processItem, onPartial?)` runs each chunk
+  with `Promise.allSettled` (one failure drops only that item) and streams a growing snapshot to
+  `onPartial` after each chunk — this is what drives incremental marketplace refresh during large syncs
+- **Validation** — `validateGitHubRepository()` and a default `validate()` (subclasses override for
+  collection/skill-specific structure)
+
+Local adapters (`local-*`) are filesystem-backed and extend `RepositoryAdapter` directly, not this class.
+
 ## Adding a New Adapter
 
-1. Copy an existing adapter (e.g., `github-adapter.ts`)
-2. Extend `RepositoryAdapter` (see `repository-adapter.ts`) — it implements shared auth/header logic
-3. Register in `RegistryManager` via `RepositoryAdapterFactory.register('type', AdapterClass)`
+1. Copy the closest existing adapter (`github-adapter.ts` for GitHub-backed, `local-adapter.ts` otherwise)
+2. Extend `GitHubBackedAdapter` for GitHub sources (inherits auth/HTTP/URL/chunking) or
+   `RepositoryAdapter` for non-GitHub sources (implement auth/HTTP yourself)
+3. Route `fetchBundles(onPartialBundles?)` through `processInChunks` so the UI renders progressively
+4. Register in `RegistryManager` via `RepositoryAdapterFactory.register('type', AdapterClass)`
 
 ## Interface
 
@@ -58,8 +87,9 @@ Resolved in order:
 
 ## Checklist
 
-- [ ] Extends `RepositoryAdapter`
+- [ ] Extends `GitHubBackedAdapter` (GitHub sources) or `RepositoryAdapter` (non-GitHub sources)
 - [ ] Implements all required `IRepositoryAdapter` methods
+- [ ] `fetchBundles` streams partial results via `processInChunks` (GitHub-backed adapters)
 - [ ] Returns `Buffer` from `downloadBundle`
 - [ ] Returns `ValidationResult` from `validate` with actionable error messages
 - [ ] Handles authentication via inherited helpers where possible

--- a/src/adapters/awesome-copilot-adapter.ts
+++ b/src/adapters/awesome-copilot-adapter.ts
@@ -20,13 +20,6 @@
  * ```
  */
 
-import {
-  exec,
-} from 'node:child_process';
-import * as https from 'node:https';
-import {
-  promisify,
-} from 'node:util';
 import archiver from 'archiver';
 import * as yaml from 'js-yaml';
 import * as vscode from 'vscode';
@@ -37,13 +30,8 @@ import {
   ValidationResult,
 } from '../types/registry';
 import {
-  Logger,
-} from '../utils/logger';
-import {
-  RepositoryAdapter,
-} from './repository-adapter';
-
-const execAsync = promisify(exec);
+  GitHubBackedAdapter,
+} from './github-backed-adapter';
 
 /**
  * Awesome Copilot Collection Schema
@@ -106,7 +94,7 @@ export interface AwesomeCopilotConfig {
  * - Automatic collection discovery
  * - Content type mapping (prompt/instruction/chatmode/agent)
  * - Cache for performance
- * - GitHub API integration
+ * - GitHub API integration (via GitHubBackedAdapter)
  *
  * Usage:
  * ```typescript
@@ -118,21 +106,17 @@ export interface AwesomeCopilotConfig {
  *   config: { branch: 'main', collectionsPath: 'collections' }
  * };
  * const adapter = new AwesomeCopilotAdapter(source);
- * const bundles = await adapter.listBundles();
+ * const bundles = await adapter.fetchBundles();
  * ```
  */
-export class AwesomeCopilotAdapter extends RepositoryAdapter {
+export class AwesomeCopilotAdapter extends GitHubBackedAdapter {
   public readonly type = 'awesome-copilot';
   private readonly config: Required<AwesomeCopilotConfig>;
   private readonly collectionsCache: Map<string, { bundles: Bundle[]; timestamp: number }> = new Map();
   private readonly CACHE_TTL = 5 * 60 * 1000; // 5 minutes
-  protected logger: Logger;
-  private authToken: string | undefined;
-  private authMethod: 'vscode' | 'gh-cli' | 'explicit' | 'none' = 'none';
 
   constructor(source: RegistrySource) {
     super(source);
-    this.logger = Logger.getInstance();
 
     // Parse config
     const userConfig = source.config || {};
@@ -148,10 +132,7 @@ export class AwesomeCopilotAdapter extends RepositoryAdapter {
    * List all .collection.yml files in collections directory
    */
   private async listCollectionFiles(): Promise<string[]> {
-    const apiUrl = this.buildApiUrl(`${this.config.collectionsPath}`);
-    const content = await this.fetchUrl(apiUrl);
-
-    const files = JSON.parse(content) as GitHubContent[];
+    const files = await this.getJson<GitHubContent[]>(this.buildCollectionsApiUrl());
     return files
       .filter((f) => f.type === 'file' && f.name.endsWith('.collection.yml'))
       .map((f) => f.name);
@@ -163,8 +144,8 @@ export class AwesomeCopilotAdapter extends RepositoryAdapter {
    */
   private async parseCollection(collectionFile: string): Promise<Bundle | null> {
     try {
-      const collectionUrl = this.buildRawUrl(`${this.config.collectionsPath}/${collectionFile}`);
-      const yamlContent = await this.fetchUrl(collectionUrl);
+      const collectionUrl = this.buildRepoRawUrl(`${this.config.collectionsPath}/${collectionFile}`);
+      const yamlContent = await this.getText(collectionUrl);
       const collection = yaml.load(yamlContent) as CollectionManifest;
 
       this.logger.debug(`[AwesomeCopilot]: Here is the parsed collection ${collection.readme?.path}`);
@@ -175,7 +156,7 @@ export class AwesomeCopilotAdapter extends RepositoryAdapter {
       // Count items by kind (including MCP servers)
       const breakdown = this.calculateBreakdown(collection.items, mcpServers);
 
-      const readmeUrl = collection.readme?.path ? this.buildRawUrl(collection.readme.path) : undefined;
+      const readmeUrl = collection.readme?.path ? this.buildRepoRawUrl(collection.readme.path) : undefined;
 
       const bundle: Bundle = {
         id: collection.id,
@@ -187,8 +168,8 @@ export class AwesomeCopilotAdapter extends RepositoryAdapter {
         tags: collection.tags || [],
         environments: this.inferEnvironments(collection.tags || []),
         sourceId: this.source.id,
-        manifestUrl: this.buildRawUrl(`${this.config.collectionsPath}/${collectionFile}`),
-        downloadUrl: this.buildRawUrl(`${this.config.collectionsPath}/${collectionFile}`),
+        manifestUrl: this.buildRepoRawUrl(`${this.config.collectionsPath}/${collectionFile}`),
+        downloadUrl: this.buildRepoRawUrl(`${this.config.collectionsPath}/${collectionFile}`),
         lastUpdated: new Date().toISOString(),
         size: `${collection.items.length} items`,
         dependencies: [],
@@ -269,15 +250,15 @@ export class AwesomeCopilotAdapter extends RepositoryAdapter {
             this.logger.debug(`Found ${skillFiles.length} files in skill directory: ${skillFiles.join(', ')}`);
 
             for (const filePath of skillFiles) {
-              const fileUrl = this.buildRawUrl(filePath);
-              const content = await this.fetchUrl(fileUrl);
+              const fileUrl = this.buildRepoRawUrl(filePath);
+              const content = await this.getText(fileUrl);
               archive.append(content, { name: filePath });
               this.logger.debug(`Added ${filePath} (${content.length} bytes)`);
             }
           } else {
             // For other types, fetch single file and put in prompts/ folder
-            const itemUrl = this.buildRawUrl(item.path);
-            const content = await this.fetchUrl(itemUrl);
+            const itemUrl = this.buildRepoRawUrl(item.path);
+            const content = await this.getText(itemUrl);
             const filename = item.path.split('/').pop() || 'unknown';
             archive.append(content, { name: `prompts/${filename}` });
             this.logger.debug(`Added ${filename} (${content.length} bytes)`);
@@ -436,12 +417,20 @@ export class AwesomeCopilotAdapter extends RepositoryAdapter {
   }
 
   /**
-   * Build GitHub API URL
+   * Build GitHub Contents API URL for the collections directory (pinned to branch).
+   */
+  private buildCollectionsApiUrl(): string {
+    const { owner, repo } = this.parseGitHubUrl();
+    return this.buildContentsUrl(owner, repo, this.config.collectionsPath, this.config.branch);
+  }
+
+  /**
+   * Build a raw githubusercontent URL for a repo-relative path at the configured branch.
    * @param path
    */
-  private buildApiUrl(path: string): string {
+  private buildRepoRawUrl(path: string): string {
     const { owner, repo } = this.parseGitHubUrl();
-    return `https://api.github.com/repos/${owner}/${repo}/contents/${path}?ref=${this.config.branch}`;
+    return this.buildRawUrl(owner, repo, this.config.branch, path);
   }
 
   /**
@@ -452,9 +441,8 @@ export class AwesomeCopilotAdapter extends RepositoryAdapter {
   private async fetchBranchSha(): Promise<string | undefined> {
     try {
       const { owner, repo } = this.parseGitHubUrl();
-      const apiUrl = `https://api.github.com/repos/${owner}/${repo}/commits/${this.config.branch}`;
-      const content = await this.fetchUrl(apiUrl);
-      const commit = JSON.parse(content) as { sha?: string };
+      const apiUrl = `${this.apiBase}/repos/${owner}/${repo}/commits/${this.config.branch}`;
+      const commit = await this.getJson<{ sha?: string }>(apiUrl);
       return commit.sha;
     } catch (error) {
       this.logger.warn(`Failed to resolve branch sha for readme revision: ${(error as Error).message}`);
@@ -471,9 +459,9 @@ export class AwesomeCopilotAdapter extends RepositoryAdapter {
     const filePaths: string[] = [];
 
     try {
-      const apiUrl = this.buildApiUrl(dirPath);
-      const response = await this.fetchUrl(apiUrl);
-      const contents = JSON.parse(response) as GitHubContent[];
+      const { owner, repo } = this.parseGitHubUrl();
+      const apiUrl = this.buildContentsUrl(owner, repo, dirPath, this.config.branch);
+      const contents = await this.getJson<GitHubContent[]>(apiUrl);
 
       for (const item of contents) {
         if (item.type === 'file') {
@@ -492,187 +480,11 @@ export class AwesomeCopilotAdapter extends RepositoryAdapter {
   }
 
   /**
-   * Build raw GitHub content URL
-   * @param path
-   */
-  private buildRawUrl(path: string): string {
-    const { owner, repo } = this.parseGitHubUrl();
-    return `https://raw.githubusercontent.com/${owner}/${repo}/${this.config.branch}/${path}`;
-  }
-
-  /**
-   * Parse GitHub URL
-   */
-  private parseGitHubUrl(): { owner: string; repo: string } {
-    const url = this.source.url.replace(/\.git$/, '');
-    const match = url.match(/github\.com[/:]([^/]+)\/([^/]+)/);
-
-    if (!match) {
-      throw new Error(`Invalid GitHub URL: ${this.source.url}`);
-    }
-
-    return { owner: match[1], repo: match[2] };
-  }
-
-  /**
    * Extract repository owner
    */
   private extractRepoOwner(): string {
     const { owner } = this.parseGitHubUrl();
     return owner;
-  }
-
-  /**
-   * Get authentication token using fallback chain:
-   * 1. VSCode GitHub API (if user is logged in)
-   * 2. gh CLI (if installed and authenticated)
-   * 3. Explicit token from source configuration
-   */
-  private async getAuthenticationToken(): Promise<string | undefined> {
-    // Return cached token if already resolved
-    if (this.authToken !== undefined) {
-      this.logger.debug(`[AwesomeCopilotAdapter] Using cached token (method: ${this.authMethod})`);
-      return this.authToken;
-    }
-
-    this.logger.info('[AwesomeCopilotAdapter] Attempting authentication...');
-
-    // Try VSCode GitHub authentication first
-    try {
-      this.logger.debug('[AwesomeCopilotAdapter] Trying VSCode GitHub authentication...');
-      const session = await vscode.authentication.getSession('github', ['repo'], { createIfNone: true });
-      if (session) {
-        this.authToken = session.accessToken;
-        this.authMethod = 'vscode';
-        this.logger.info('[AwesomeCopilotAdapter] ✓ Using VSCode GitHub authentication');
-        this.logger.debug(`[AwesomeCopilotAdapter] Token preview: ${this.authToken.substring(0, 8)}...`);
-        return this.authToken;
-      }
-      this.logger.debug('[AwesomeCopilotAdapter] VSCode auth session not found');
-    } catch (error) {
-      this.logger.warn(`[AwesomeCopilotAdapter] VSCode auth failed: ${error}`);
-    }
-
-    // Try gh CLI authentication
-    try {
-      this.logger.debug('[AwesomeCopilotAdapter] Trying gh CLI authentication...');
-      const { stdout } = await execAsync('gh auth token');
-      const token = stdout.trim();
-      if (token && token.length > 0) {
-        this.authToken = token;
-        this.authMethod = 'gh-cli';
-        this.logger.info('[AwesomeCopilotAdapter] ✓ Using gh CLI authentication');
-        this.logger.debug(`[AwesomeCopilotAdapter] Token preview: ${this.authToken.substring(0, 8)}...`);
-        return this.authToken;
-      }
-      this.logger.debug('[AwesomeCopilotAdapter] gh CLI returned empty token');
-    } catch (error) {
-      this.logger.warn(`[AwesomeCopilotAdapter] gh CLI auth failed: ${error}`);
-    }
-
-    // Fall back to explicit token from source configuration
-    const explicitToken = this.getAuthToken();
-    if (explicitToken) {
-      this.authToken = explicitToken;
-      this.authMethod = 'explicit';
-      this.logger.info('[AwesomeCopilotAdapter] ✓ Using explicit token from configuration');
-      this.logger.debug(`[AwesomeCopilotAdapter] Token preview: ${this.authToken.substring(0, 8)}...`);
-      return this.authToken;
-    }
-
-    // No authentication available
-    this.authMethod = 'none';
-    this.logger.warn('[AwesomeCopilotAdapter] ✗ No authentication available - API rate limits will apply and private repos will be inaccessible');
-    return undefined;
-  }
-
-  /**
-   * Fetch URL content with authentication
-   * Handles redirects (301/302) by following the Location header
-   * @param url
-   * @param redirectDepth
-   */
-  private async fetchUrl(url: string, redirectDepth = 0): Promise<string> {
-    /**
-     * Maximum redirect depth to prevent infinite loops.
-     */
-    const MAX_REDIRECTS = 10;
-    if (redirectDepth >= MAX_REDIRECTS) {
-      this.logger.error(`[AwesomeCopilotAdapter] Maximum redirect depth (${MAX_REDIRECTS}) exceeded`);
-      throw new Error(`Maximum redirect depth (${MAX_REDIRECTS}) exceeded`);
-    }
-
-    const token = await this.getAuthenticationToken();
-    const headers: Record<string, string> = {
-      'User-Agent': 'VSCode-Prompt-Registry'
-    };
-
-    if (token) {
-      headers.Authorization = `token ${token}`;
-      this.logger.debug(`[AwesomeCopilotAdapter] Request to ${url} with auth (method: ${this.authMethod})`);
-    } else {
-      this.logger.debug(`[AwesomeCopilotAdapter] Request to ${url} WITHOUT auth`);
-    }
-
-    // Log headers (sanitized)
-    const sanitizedHeaders = { ...headers };
-    if (sanitizedHeaders.Authorization) {
-      sanitizedHeaders.Authorization = sanitizedHeaders.Authorization.substring(0, 15) + '...';
-    }
-    this.logger.debug(`[AwesomeCopilotAdapter] Request headers: ${JSON.stringify(sanitizedHeaders)}`);
-
-    return new Promise((resolve, reject) => {
-      https.get(url, { headers }, (res) => {
-        // Handle redirects (301/302)
-        if (res.statusCode === 301 || res.statusCode === 302) {
-          const redirectUrl = res.headers.location;
-          if (redirectUrl) {
-            this.logger.debug(`[AwesomeCopilotAdapter] Following redirect (depth ${redirectDepth + 1}) to: ${redirectUrl}`);
-            this.fetchUrl(redirectUrl, redirectDepth + 1).then(resolve).catch(reject);
-            return;
-          }
-        }
-
-        let data = '';
-        res.on('data', (chunk) => data += chunk);
-        res.on('end', () => {
-          if (res.statusCode === 200) {
-            this.logger.debug(`[AwesomeCopilotAdapter] Response OK (${res.statusCode}), ${data.length} bytes`);
-            resolve(data);
-          } else {
-            this.logger.error(`[AwesomeCopilotAdapter] HTTP ${res.statusCode}: ${res.statusMessage}`);
-            this.logger.error(`[AwesomeCopilotAdapter] URL: ${url}`);
-            this.logger.error(`[AwesomeCopilotAdapter] Auth method: ${this.authMethod}`);
-            this.logger.error(`[AwesomeCopilotAdapter] Response: ${data.substring(0, 500)}`);
-
-            // Provide helpful error messages
-            let errorMsg = `HTTP ${res.statusCode}: ${res.statusMessage}`;
-            switch (res.statusCode) {
-              case 404: {
-                errorMsg += ' - Repository not found or not accessible. Check authentication.';
-
-                break;
-              }
-              case 401: {
-                errorMsg += ' - Authentication failed. Token may be invalid or expired.';
-
-                break;
-              }
-              case 403: {
-                errorMsg += ' - Access forbidden. Token may lack required scopes (repo).';
-
-                break;
-              }
-                        // No default
-            }
-            reject(new Error(errorMsg));
-          }
-        });
-      }).on('error', (error) => {
-        this.logger.error(`[AwesomeCopilotAdapter] Network error: ${error.message}`);
-        reject(error);
-      });
-    });
   }
 
   /**
@@ -689,11 +501,15 @@ export class AwesomeCopilotAdapter extends RepositoryAdapter {
   /**
    * Fetch list of available bundles from the source
    * Scans the collections directory for .collection.yml files and creates Bundle objects.
-   * Results are cached for 5 minutes to reduce API calls.
+   * Results are cached for 5 minutes to reduce API calls. Each parse chunk streams a growing
+   * snapshot to the optional callback so the UI can render progressively during large syncs.
+   * @param onPartialBundles Optional callback invoked with a growing snapshot after each chunk
    * @returns Promise resolving to array of Bundle objects from collection files
    * @throws {Error} if GitHub API fails or collection parsing fails
    */
-  public async fetchBundles(): Promise<Bundle[]> {
+  public async fetchBundles(
+    onPartialBundles?: (bundles: Bundle[]) => void | Promise<void>
+  ): Promise<Bundle[]> {
     this.logger.debug('Listing bundles from awesome-copilot repository');
 
     // Check cache
@@ -709,29 +525,16 @@ export class AwesomeCopilotAdapter extends RepositoryAdapter {
       const collectionFiles = await this.listCollectionFiles();
       this.logger.debug(`Found ${collectionFiles.length} collection files`);
 
-      // Step 2: Parse each collection (with concurrency limit)
-      const bundles: Bundle[] = [];
-      const CONCURRENCY_LIMIT = 5;
-
-      for (let i = 0; i < collectionFiles.length; i += CONCURRENCY_LIMIT) {
-        const chunk = collectionFiles.slice(i, i + CONCURRENCY_LIMIT);
-        this.logger.debug(`Processing chunk ${i / CONCURRENCY_LIMIT + 1}/${Math.ceil(collectionFiles.length / CONCURRENCY_LIMIT)}`);
-
-        const chunkResults = await Promise.all(chunk.map(async (file) => {
-          try {
-            return await this.parseCollection(file);
-          } catch (error) {
-            this.logger.warn(`Failed to parse collection ${file}:`, error);
-            return null;
-          }
-        }));
-
-        for (const bundle of chunkResults) {
-          if (bundle) {
-            bundles.push(bundle);
-          }
-        }
-      }
+      // Step 2: Parse each collection in bounded-size chunks, streaming partial results
+      const bundles = await this.processInChunks(
+        collectionFiles,
+        5,
+        (file) => this.parseCollection(file).catch((error) => {
+          this.logger.warn(`Failed to parse collection ${file}:`, error);
+          return null;
+        }),
+        onPartialBundles
+      );
 
       // Stamp the branch head sha as the readme revision so cached readmes are refreshed
       // when the branch advances (the raw readme URL is stable across commits)
@@ -771,9 +574,9 @@ export class AwesomeCopilotAdapter extends RepositoryAdapter {
       this.logger.debug(`Collection file: ${collectionFile}`);
 
       // Parse collection
-      const collectionUrl = this.buildRawUrl(`${this.config.collectionsPath}/${collectionFile}`);
+      const collectionUrl = this.buildRepoRawUrl(`${this.config.collectionsPath}/${collectionFile}`);
       this.logger.debug(`Fetching collection from: ${collectionUrl}`);
-      const yamlContent = await this.fetchUrl(collectionUrl);
+      const yamlContent = await this.getText(collectionUrl);
       const collection = yaml.load(yamlContent) as CollectionManifest;
       this.logger.debug(`Collection loaded: ${collection.name}, items: ${collection.items.length}`);
 
@@ -792,7 +595,7 @@ export class AwesomeCopilotAdapter extends RepositoryAdapter {
       return null;
     }
     try {
-      return await this.fetchUrl(bundle.readmeUrl);
+      return await this.getText(bundle.readmeUrl);
     } catch (error) {
       this.logger.error('Failed to download readme', error as Error);
       return null;
@@ -831,7 +634,7 @@ export class AwesomeCopilotAdapter extends RepositoryAdapter {
    */
   public getManifestUrl(bundleId: string, _version?: string): string {
     const collectionFile = `${bundleId}.collection.yml`;
-    return this.buildRawUrl(`${this.config.collectionsPath}/${collectionFile}`);
+    return this.buildRepoRawUrl(`${this.config.collectionsPath}/${collectionFile}`);
   }
 
   /**
@@ -855,10 +658,7 @@ export class AwesomeCopilotAdapter extends RepositoryAdapter {
   public async validate(): Promise<ValidationResult> {
     try {
       // Check if collections directory exists
-      const apiUrl = this.buildApiUrl(`${this.config.collectionsPath}`);
-      const content = await this.fetchUrl(apiUrl);
-
-      const files = JSON.parse(content) as GitHubContent[];
+      const files = await this.getJson<GitHubContent[]>(this.buildCollectionsApiUrl());
       const collectionFiles = files.filter((f) => f.type === 'file' && f.name.endsWith('.collection.yml'));
 
       if (collectionFiles.length === 0) {
@@ -894,8 +694,7 @@ export class AwesomeCopilotAdapter extends RepositoryAdapter {
     this.logger.info('[AwesomeCopilotAdapter] Forcing re-authentication...');
 
     // Clear current state
-    this.authToken = undefined;
-    this.authMethod = 'none';
+    this.invalidateAuthCache('force re-authentication');
 
     // Force new session with VS Code
     try {

--- a/src/adapters/github-adapter.ts
+++ b/src/adapters/github-adapter.ts
@@ -4,18 +4,8 @@
  */
 
 import {
-  exec,
-} from 'node:child_process';
-import * as https from 'node:https';
-import {
-  promisify,
-} from 'node:util';
-import * as vscode from 'vscode';
-import {
   Bundle,
-  RegistrySource,
   SourceMetadata,
-  ValidationResult,
 } from '../types/registry';
 import {
   formatByteSize,
@@ -25,13 +15,8 @@ import {
   CONCURRENCY_CONSTANTS,
 } from '../utils/constants';
 import {
-  Logger,
-} from '../utils/logger';
-import {
-  RepositoryAdapter,
-} from './repository-adapter';
-
-const execAsync = promisify(exec);
+  GitHubBackedAdapter,
+} from './github-backed-adapter';
 
 /**
  * GitHub API response types
@@ -55,476 +40,14 @@ interface GitHubRelease {
 /**
  * GitHub repository adapter implementation
  */
-export class GitHubAdapter extends RepositoryAdapter {
+export class GitHubAdapter extends GitHubBackedAdapter {
   public readonly type = 'github';
-  private readonly apiBase = 'https://api.github.com';
-  private authToken: string | undefined;
-  private authMethod: 'vscode' | 'gh-cli' | 'explicit' | 'none' = 'none';
-  private readonly logger: Logger;
-  private readonly attemptedMethods: Set<string> = new Set();
-  /**
-   * Maximum authentication attempts to prevent infinite retry loops.
-   * Tries: explicit token → VS Code auth → gh CLI
-   */
-  private readonly maxAuthAttempts = 3;
-  /**
-   * Promise for ongoing authentication attempt to prevent race conditions.
-   * Multiple parallel requests will wait for the same authentication promise.
-   */
-  private authPromise?: Promise<string | undefined>;
 
   /**
    * Cache for downloaded manifest content to avoid duplicate downloads.
    * Key is the asset URL, value is the parsed manifest object.
    */
   private readonly manifestCache: Map<string, any> = new Map();
-
-  constructor(source: RegistrySource) {
-    super(source);
-    this.logger = Logger.getInstance();
-
-    if (!this.isValidGitHubUrl(source.url)) {
-      throw new Error(`Invalid GitHub URL: ${source.url}`);
-    }
-  }
-
-  /**
-   * Validate GitHub URL (supports both HTTPS and SSH formats)
-   * @param url
-   */
-  private isValidGitHubUrl(url: string): boolean {
-    // HTTPS format: https://github.com/owner/repo
-    if (url.startsWith('https://')) {
-      return url.includes('github.com');
-    }
-    // SSH format: git@github.com:owner/repo.git
-    if (url.startsWith('git@')) {
-      return url.includes('github.com:');
-    }
-    return false;
-  }
-
-  /**
-   * Parse GitHub URL to extract owner and repo
-   */
-  private parseGitHubUrl(): { owner: string; repo: string } {
-    const url = this.source.url.replace(/\.git$/, '');
-    const match = url.match(/github\.com[/:]([^/]+)\/([^/]+)/);
-
-    if (!match) {
-      throw new Error(`Invalid GitHub URL format: ${this.source.url}`);
-    }
-
-    return {
-      owner: match[1],
-      repo: match[2]
-    };
-  }
-
-  /**
-   * Get authentication token using fallback chain:
-   * 1. Explicit token from source configuration
-   * 2. VSCode GitHub API (if user is logged in)
-   * 3. gh CLI (if installed and authenticated)
-   * 4. No authentication
-   *
-   * Uses promise memoization to prevent race conditions when multiple
-   * parallel requests attempt authentication simultaneously.
-   */
-  private async getAuthenticationToken(): Promise<string | undefined> {
-    // Return cached token if already resolved
-    if (this.authToken !== undefined) {
-      this.logger.debug(`[GitHubAdapter] Using cached token (method: ${this.authMethod})`);
-      return this.authToken;
-    }
-
-    // If authentication is already in progress, wait for it
-    if (this.authPromise) {
-      this.logger.debug('[GitHubAdapter] Authentication in progress, waiting...');
-      return this.authPromise;
-    }
-
-    // Check if we've exceeded max attempts
-    if (this.attemptedMethods.size >= this.maxAuthAttempts) {
-      this.logger.error(`[GitHubAdapter] Maximum authentication attempts (${this.maxAuthAttempts}) exceeded`);
-      this.logger.error(`[GitHubAdapter] Attempted methods: ${Array.from(this.attemptedMethods).join(', ')}`);
-      return undefined;
-    }
-
-    // Start new authentication attempt and cache the promise
-    this.authPromise = this.performAuthentication();
-
-    try {
-      const token = await this.authPromise;
-      this.authToken = token;
-      return token;
-    } finally {
-      // Clear the promise once authentication completes (success or failure)
-      this.authPromise = undefined;
-    }
-  }
-
-  /**
-   * Perform the actual authentication attempt through the fallback chain.
-   * This is separated from getAuthenticationToken to enable promise memoization.
-   */
-  private async performAuthentication(): Promise<string | undefined> {
-    this.logger.info('[GitHubAdapter] Attempting authentication...');
-
-    // Try explicit token from source configuration first
-    if (this.attemptedMethods.has('explicit')) {
-      this.logger.debug('[GitHubAdapter] Skipping explicit token (already attempted)');
-    } else {
-      const explicitToken = this.getAuthToken();
-      if (explicitToken && explicitToken.trim().length > 0) {
-        this.authMethod = 'explicit';
-        this.logger.info('[GitHubAdapter] ✓ Using explicit token from configuration');
-        const token = explicitToken.trim();
-        this.logger.debug(`[GitHubAdapter] Token preview: ${token.substring(0, 8)}...`);
-        return token;
-      }
-      this.logger.debug('[GitHubAdapter] No explicit token configured');
-    }
-
-    // Try VSCode GitHub authentication second
-    if (this.attemptedMethods.has('vscode')) {
-      this.logger.debug('[GitHubAdapter] Skipping VSCode auth (already attempted)');
-    } else {
-      try {
-        this.logger.debug('[GitHubAdapter] Trying VSCode GitHub authentication...');
-        const session = await vscode.authentication.getSession('github', ['repo'], { createIfNone: true });
-        if (session) {
-          this.authMethod = 'vscode';
-          this.logger.info('[GitHubAdapter] ✓ Using VSCode GitHub authentication');
-          this.logger.debug(`[GitHubAdapter] Token preview: ${session.accessToken.substring(0, 8)}...`);
-          return session.accessToken;
-        }
-        this.logger.debug('[GitHubAdapter] VSCode auth session not found');
-      } catch (error) {
-        this.logger.warn(`[GitHubAdapter] VSCode auth failed: ${error}`);
-      }
-    }
-
-    // Try gh CLI authentication third
-    if (this.attemptedMethods.has('gh-cli')) {
-      this.logger.debug('[GitHubAdapter] Skipping gh CLI (already attempted)');
-    } else {
-      try {
-        this.logger.debug('[GitHubAdapter] Trying gh CLI authentication...');
-        const { stdout } = await execAsync('gh auth token');
-        const token = stdout.trim();
-        if (token && token.length > 0) {
-          this.authMethod = 'gh-cli';
-          this.logger.info('[GitHubAdapter] ✓ Using gh CLI authentication');
-          this.logger.debug(`[GitHubAdapter] Token preview: ${token.substring(0, 8)}...`);
-          return token;
-        }
-        this.logger.debug('[GitHubAdapter] gh CLI returned empty token');
-      } catch (error) {
-        this.logger.warn(`[GitHubAdapter] gh CLI auth failed: ${error}`);
-      }
-    }
-
-    // No authentication available
-    this.authMethod = 'none';
-    if (this.attemptedMethods.size > 0) {
-      this.logger.error('[GitHubAdapter] ✗ All authentication methods exhausted');
-      this.logger.error(`[GitHubAdapter] Attempted methods: ${Array.from(this.attemptedMethods).join(', ')}`);
-    } else {
-      this.logger.warn('[GitHubAdapter] ✗ No authentication available - API rate limits will apply and private repos will be inaccessible');
-    }
-    return undefined;
-  }
-
-  /**
-   * Validate response Content-Type and detect HTML error pages
-   * @param res
-   * @param data
-   */
-  private validateResponse(res: any, data: string): { isValid: boolean; error?: string } {
-    const contentType = res.headers['content-type'] || '';
-
-    // Check if response is HTML (common for authentication errors)
-    if (contentType.includes('text/html')) {
-      this.logger.warn(`[GitHubAdapter] Received HTML response instead of JSON (Content-Type: ${contentType})`);
-
-      // Try to extract error information from HTML
-      let htmlError = 'HTML error page received';
-
-      // Simple HTML parsing to extract text content
-      const bodyMatch = data.match(/<body[^>]*>([\s\S]*?)<\/body>/i);
-      if (bodyMatch) {
-        // Remove HTML tags and get text content
-        const bodyText = bodyMatch[1]
-          .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
-          .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
-          .replace(/<[^>]+>/g, ' ')
-          .replace(/\s+/g, ' ')
-          .trim();
-
-        if (bodyText.length > 0) {
-          htmlError = bodyText.substring(0, 200);
-        }
-      }
-
-      return {
-        isValid: false,
-        error: `Received HTML error page instead of JSON response. This typically indicates an authentication or access issue. Error: ${htmlError}`
-      };
-    }
-
-    // Check if response is JSON
-    if (!contentType.includes('application/json') && !contentType.includes('application/octet-stream')) {
-      this.logger.warn(`[GitHubAdapter] Unexpected Content-Type: ${contentType}`);
-      return {
-        isValid: false,
-        error: `Unexpected Content-Type: ${contentType}. Expected application/json.`
-      };
-    }
-
-    return { isValid: true };
-  }
-
-  /**
-   * Make HTTP request to GitHub API with authentication and automatic retry on auth failures
-   * Handles redirects (301/302) by following the Location header
-   * @param url
-   * @param retryCount
-   * @param redirectDepth
-   */
-  private async makeRequest(url: string, retryCount = 0, redirectDepth = 0): Promise<any> {
-    /**
-     * Maximum redirect depth to prevent infinite loops.
-     */
-    const MAX_REDIRECTS = 10;
-    if (redirectDepth >= MAX_REDIRECTS) {
-      this.logger.error(`[GitHubAdapter] Maximum redirect depth (${MAX_REDIRECTS}) exceeded`);
-      throw new Error(`Maximum redirect depth (${MAX_REDIRECTS}) exceeded`);
-    }
-
-    const headers = this.getHeaders();
-
-    // Get authentication token using fallback chain
-    const token = await this.getAuthenticationToken();
-    if (token) {
-      // Use token format for GitHub API
-      headers.Authorization = `token ${token}`;
-      this.logger.debug(`[GitHubAdapter] Request to ${url} with auth (method: ${this.authMethod})`);
-    } else {
-      this.logger.debug(`[GitHubAdapter] Request to ${url} WITHOUT auth`);
-    }
-
-    // Log headers (sanitized)
-    const sanitizedHeaders = { ...headers };
-    if (sanitizedHeaders.Authorization) {
-      sanitizedHeaders.Authorization = sanitizedHeaders.Authorization.substring(0, 15) + '...';
-    }
-    this.logger.debug(`[GitHubAdapter] Request headers: ${JSON.stringify(sanitizedHeaders)}`);
-
-    return new Promise((resolve, reject) => {
-      https.get(url, { headers }, (res) => {
-        // Handle redirects (301/302)
-        if (res.statusCode === 301 || res.statusCode === 302) {
-          const redirectUrl = res.headers.location;
-          if (redirectUrl) {
-            this.logger.debug(`[GitHubAdapter] Following redirect (depth ${redirectDepth + 1}) to: ${redirectUrl}`);
-            this.makeRequest(redirectUrl, retryCount, redirectDepth + 1).then(resolve).catch(reject);
-            return;
-          }
-        }
-
-        let data = '';
-
-        res.on('data', (chunk) => {
-          data += chunk;
-        });
-
-        res.on('end', async () => {
-          if (res.statusCode && res.statusCode >= 400) {
-            this.logger.error(`[GitHubAdapter] HTTP ${res.statusCode}: ${res.statusMessage}`);
-            this.logger.error(`[GitHubAdapter] URL: ${url}`);
-            this.logger.error(`[GitHubAdapter] Auth method: ${this.authMethod}`);
-            this.logger.error(`[GitHubAdapter] Response: ${data.substring(0, 500)}`);
-
-            // Validate response format before processing error
-
-            const { isValid, error } = this.validateResponse(res, data);
-            if (!isValid) {
-              this.logger.error(`[GitHubAdapter] ${error}`);
-            }
-
-            // Check if this is an authentication error that should trigger retry
-            const isAuthError = res.statusCode === 401 || res.statusCode === 403;
-            const canRetry = retryCount < this.maxAuthAttempts && this.attemptedMethods.size < this.maxAuthAttempts;
-
-            if (isAuthError && canRetry) {
-              // Invalidate cache and retry with next auth method
-              const reason = `${res.statusCode} ${res.statusMessage}`;
-              this.logger.warn(`[GitHubAdapter] Authentication error detected, invalidating cache and retrying...`);
-              this.invalidateAuthCache(reason);
-
-              try {
-                // Retry the request with next authentication method
-                const result = await this.makeRequest(url, retryCount + 1);
-                resolve(result);
-                return;
-              } catch (retryError) {
-                // If retry also fails, fall through to error handling below
-                this.logger.error(`[GitHubAdapter] Retry failed: ${retryError}`);
-              }
-            }
-
-            // Provide helpful error messages
-            let errorMsg = `GitHub API error: ${res.statusCode} ${res.statusMessage}`;
-
-            // Include HTML error information if present
-            if (!isValid && error) {
-              errorMsg = error;
-            } else {
-              switch (res.statusCode) {
-                case 404: {
-                  errorMsg += ' - Repository not found or not accessible. Check authentication.';
-
-                  break;
-                }
-                case 401: {
-                  errorMsg += ' - Authentication failed. Token may be invalid or expired.';
-                  if (this.attemptedMethods.size > 0) {
-                    errorMsg += ` Attempted methods: ${Array.from(this.attemptedMethods).join(', ')}`;
-                  }
-
-                  break;
-                }
-                case 403: {
-                  errorMsg += ' - Access forbidden. Token may lack required scopes (repo).';
-                  if (this.attemptedMethods.size > 0) {
-                    errorMsg += ` Attempted methods: ${Array.from(this.attemptedMethods).join(', ')}`;
-                  }
-
-                  break;
-                }
- // No default
-              }
-            }
-            reject(new Error(errorMsg));
-            return;
-          }
-
-          // Validate response format for successful responses
-          const validation = this.validateResponse(res, data);
-          if (!validation.isValid) {
-            this.logger.error(`[GitHubAdapter] ${validation.error}`);
-            reject(new Error(validation.error));
-            return;
-          }
-
-          this.logger.debug(`[GitHubAdapter] Response OK (${res.statusCode})`);
-          try {
-            resolve(JSON.parse(data));
-          } catch (error) {
-            this.logger.error(`[GitHubAdapter] Failed to parse response: ${error}`);
-            this.logger.error(`[GitHubAdapter] Response preview: ${data.substring(0, 200)}`);
-            reject(new Error(`Failed to parse GitHub response as JSON: ${error}`));
-          }
-        });
-      }).on('error', (error) => {
-        this.logger.error(`[GitHubAdapter] Network error: ${error.message}`);
-        reject(new Error(`GitHub API request failed: ${error.message}`));
-      });
-    });
-  }
-
-  /**
-   * Download file from URL with authentication
-   * Handles redirects recursively with depth tracking and selective auth preservation
-   * @param url
-   * @param redirectDepth
-   */
-  private async downloadFile(url: string, redirectDepth = 0): Promise<Buffer> {
-    /**
-     * Maximum redirect depth to prevent infinite loops.
-     * GitHub typically uses 1-2 redirects for asset downloads.
-     */
-    const MAX_REDIRECTS = 10;
-    if (redirectDepth >= MAX_REDIRECTS) {
-      this.logger.error(`[GitHubAdapter] Maximum redirect depth (${MAX_REDIRECTS}) exceeded`);
-      throw new Error(`Maximum redirect depth (${MAX_REDIRECTS}) exceeded`);
-    }
-
-    // Check if URL is a GitHub domain (github.com or githubusercontent.com)
-    const isGitHubDomain = (urlString: string): boolean => {
-      try {
-        const urlObj = new URL(urlString);
-        return urlObj.hostname.includes('github.com')
-          || urlObj.hostname.includes('githubusercontent.com');
-      } catch {
-        return false;
-      }
-    };
-
-    // Check if URL is a GitHub API endpoint
-    const isGitHubApiUrl = (urlString: string): boolean => {
-      return urlString.startsWith(this.apiBase);
-    };
-
-    // Include authentication for private repos, but only for GitHub domains
-    const token = await this.getAuthenticationToken();
-    const headers: any = {
-      'User-Agent': 'Prompt-Registry-VSCode-Extension'
-    };
-
-    // For GitHub API asset downloads, use Accept header to get binary content
-    if (isGitHubApiUrl(url)) {
-      headers.Accept = 'application/octet-stream';
-    }
-
-    // Only add auth headers for GitHub domains
-    if (token && isGitHubDomain(url)) {
-      headers.Authorization = `token ${token}`;
-      this.logger.debug(`[GitHubAdapter] Downloading ${url} with auth (method: ${this.authMethod})`);
-    } else if (token && !isGitHubDomain(url)) {
-      this.logger.debug(`[GitHubAdapter] Downloading ${url} WITHOUT auth (non-GitHub domain)`);
-    } else {
-      this.logger.debug(`[GitHubAdapter] Downloading ${url} WITHOUT auth`);
-    }
-
-    return new Promise((resolve, reject) => {
-      https.get(url, { headers }, (res) => {
-        // Handle redirects (GitHub may redirect downloads)
-        if (res.statusCode === 302 || res.statusCode === 301) {
-          const redirectUrl = res.headers.location;
-          if (redirectUrl) {
-            this.logger.debug(`[GitHubAdapter] Following redirect (depth ${redirectDepth + 1}) to: ${redirectUrl}`);
-            // Recursive call to follow redirect with incremented depth
-            this.downloadFile(redirectUrl, redirectDepth + 1).then(resolve).catch(reject);
-            return;
-          }
-        }
-
-        const chunks: Buffer[] = [];
-
-        res.on('data', (chunk: Buffer) => {
-          chunks.push(chunk);
-        });
-
-        res.on('end', () => {
-          if (res.statusCode && res.statusCode >= 400) {
-            this.logger.error(`[GitHubAdapter] Download failed: HTTP ${res.statusCode}`);
-            this.logger.error(`[GitHubAdapter] URL: ${url}`);
-            this.logger.error(`[GitHubAdapter] Auth method: ${this.authMethod}`);
-            reject(new Error(`Download failed: ${res.statusCode} ${res.statusMessage}`));
-            return;
-          }
-          const totalBytes = Buffer.concat(chunks).length;
-          this.logger.debug(`[GitHubAdapter] Download complete: ${chunks.length} chunks, ${totalBytes} bytes`);
-          resolve(Buffer.concat(chunks));
-        });
-      }).on('error', (error) => {
-        this.logger.error(`[GitHubAdapter] Download error: ${error.message}`);
-        reject(new Error(`Download failed: ${error.message}`));
-      });
-    });
-  }
 
   /**
    * Process a single release to create a Bundle object.
@@ -628,7 +151,7 @@ export class GitHubAdapter extends RepositoryAdapter {
     }
 
     // Download and parse manifest
-    const manifestContent = await this.downloadFile(url);
+    const manifestContent = await this.getBuffer(url);
     const manifestText = manifestContent.toString('utf8');
 
     let manifest: any;
@@ -707,36 +230,24 @@ export class GitHubAdapter extends RepositoryAdapter {
   }
 
   /**
-   * Invalidate the cached authentication token
-   * This forces the adapter to re-authenticate on the next request
-   * @param reason - Optional reason for invalidation (e.g., "401 Unauthorized")
-   */
-  private invalidateAuthCache(reason?: string): void {
-    const previousMethod = this.authMethod;
-    this.logger.info(`[GitHubAdapter] Invalidating authentication cache${reason ? `: ${reason}` : ''}`);
-    if (previousMethod !== 'none') {
-      this.logger.debug(`[GitHubAdapter] Previous auth method: ${previousMethod}`);
-      this.attemptedMethods.add(previousMethod);
-    }
-    this.authToken = undefined;
-    this.authMethod = 'none';
-  }
-
-  /**
    * Fetch bundles from GitHub releases
    * Scans all releases in the repository and creates Bundle objects for those
    * that contain both a deployment manifest and a bundle archive.
    *
-   * Uses parallel manifest downloads with caching for improved performance.
+   * Downloads manifests in parallel chunks (with caching); after each chunk the
+   * optional callback receives a growing snapshot so the UI can render progressively.
+   * @param onPartialBundles Optional callback invoked with a growing snapshot after each chunk
    * @returns Promise resolving to array of Bundle objects
    * @throws {Error} if GitHub API request fails or authentication issues occur
    */
-  public async fetchBundles(): Promise<Bundle[]> {
+  public async fetchBundles(
+    onPartialBundles?: (bundles: Bundle[]) => void | Promise<void>
+  ): Promise<Bundle[]> {
     const { owner, repo } = this.parseGitHubUrl();
     const url = `${this.apiBase}/repos/${owner}/${repo}/releases`;
 
     try {
-      const releases: GitHubRelease[] = await this.makeRequest(url);
+      const releases = await this.getJson<GitHubRelease[]>(url);
 
       // Filter releases that have both manifest and bundle assets
       const validReleases = releases.filter((release) => {
@@ -752,24 +263,12 @@ export class GitHubAdapter extends RepositoryAdapter {
         return hasManifest && hasBundle;
       });
 
-      // Download manifests in parallel with concurrency limit
-      const concurrency = CONCURRENCY_CONSTANTS.MANIFEST_DOWNLOAD_CONCURRENCY;
-      const bundles: Bundle[] = [];
-
-      for (let i = 0; i < validReleases.length; i += concurrency) {
-        const batch = validReleases.slice(i, i + concurrency);
-        const batchResults = await Promise.allSettled(
-          batch.map((release) => this.processSingleRelease(release, owner, repo))
-        );
-
-        for (const result of batchResults) {
-          if (result.status === 'fulfilled' && result.value) {
-            bundles.push(result.value);
-          }
-        }
-      }
-
-      return bundles;
+      return await this.processInChunks(
+        validReleases,
+        CONCURRENCY_CONSTANTS.MANIFEST_DOWNLOAD_CONCURRENCY,
+        (release) => this.processSingleRelease(release, owner, repo),
+        onPartialBundles
+      );
     } catch (error) {
       throw new Error(`Failed to fetch bundles from GitHub: ${error}`);
     }
@@ -792,7 +291,7 @@ export class GitHubAdapter extends RepositoryAdapter {
    */
   public async downloadBundle(bundle: Bundle): Promise<Buffer> {
     try {
-      return await this.downloadFile(bundle.downloadUrl);
+      return await this.getBuffer(bundle.downloadUrl);
     } catch (error) {
       throw new Error(`Failed to download bundle: ${error}`);
     }
@@ -809,7 +308,7 @@ export class GitHubAdapter extends RepositoryAdapter {
       return null;
     }
     try {
-      const data = await this.downloadFile(bundle.readmeUrl);
+      const data = await this.getBuffer(bundle.readmeUrl);
       return data.toString('utf8');
     } catch (error) {
       this.logger.warn(`Failed to download README for ${bundle.id}: ${error}`);
@@ -828,9 +327,9 @@ export class GitHubAdapter extends RepositoryAdapter {
     const url = `${this.apiBase}/repos/${owner}/${repo}`;
 
     try {
-      const repoData: any = await this.makeRequest(url);
+      const repoData = await this.getJson<any>(url);
       const releasesUrl = `${this.apiBase}/repos/${owner}/${repo}/releases`;
-      const releases: GitHubRelease[] = await this.makeRequest(releasesUrl);
+      const releases = await this.getJson<GitHubRelease[]>(releasesUrl);
 
       return {
         name: repoData.name,
@@ -841,38 +340,6 @@ export class GitHubAdapter extends RepositoryAdapter {
       };
     } catch (error) {
       throw new Error(`Failed to fetch GitHub metadata: ${error}`);
-    }
-  }
-
-  /**
-   * Validate GitHub repository accessibility
-   * Checks if the repository exists and is accessible with current authentication.
-   * @returns Promise resolving to ValidationResult with status and any errors/warnings
-   */
-  public async validate(): Promise<ValidationResult> {
-    try {
-      const { owner, repo } = this.parseGitHubUrl();
-      const url = `${this.apiBase}/repos/${owner}/${repo}`;
-
-      await this.makeRequest(url);
-
-      // Try to fetch releases
-      const releasesUrl = `${this.apiBase}/repos/${owner}/${repo}/releases`;
-      const releases: GitHubRelease[] = await this.makeRequest(releasesUrl);
-
-      return {
-        valid: true,
-        errors: [],
-        warnings: releases.length === 0 ? ['No releases found in repository'] : [],
-        bundlesFound: releases.length
-      };
-    } catch (error) {
-      return {
-        valid: false,
-        errors: [`GitHub validation failed: ${error}`],
-        warnings: [],
-        bundlesFound: 0
-      };
     }
   }
 

--- a/src/adapters/github-backed-adapter.ts
+++ b/src/adapters/github-backed-adapter.ts
@@ -1,0 +1,628 @@
+/**
+ * Intermediate base class for GitHub-backed repository adapters.
+ *
+ * `GitHubAdapter`, `AwesomeCopilotAdapter`, and `SkillsAdapter` are all backed by
+ * GitHub and independently re-implemented the same concerns: URL parsing, the
+ * GitHub authentication chain (explicit token → VS Code session → gh CLI), an
+ * `https.get` wrapper with redirect/error handling, GitHub API + raw URL builders,
+ * and a progressive chunked-fetch loop. This class hoists all of that so the three
+ * adapters share one implementation.
+ *
+ * Hierarchy:
+ *   RepositoryAdapter (abstract)
+ *     └─ GitHubBackedAdapter (abstract)   ← this file
+ *          ├─ GitHubAdapter
+ *          ├─ AwesomeCopilotAdapter
+ *          └─ SkillsAdapter
+ */
+
+import {
+  exec,
+} from 'node:child_process';
+import * as https from 'node:https';
+import {
+  promisify,
+} from 'node:util';
+import * as vscode from 'vscode';
+import {
+  RegistrySource,
+  ValidationResult,
+} from '../types/registry';
+import {
+  Logger,
+} from '../utils/logger';
+import {
+  RepositoryAdapter,
+} from './repository-adapter';
+
+const execAsync = promisify(exec);
+
+/**
+ * Response shape returned by the shared {@link GitHubBackedAdapter.httpGet} transport.
+ */
+interface HttpGetResult {
+  status: number;
+  statusMessage: string;
+  headers: Record<string, string | string[] | undefined>;
+  body: Buffer;
+}
+
+/**
+ * Minimal GitHub release shape shared by adapters that read releases.
+ */
+export interface GitHubReleaseSummary {
+  // eslint-disable-next-line @typescript-eslint/naming-convention -- matches external API response shape
+  tag_name?: string;
+}
+
+export abstract class GitHubBackedAdapter extends RepositoryAdapter {
+  protected readonly logger: Logger;
+  protected readonly apiBase = 'https://api.github.com';
+
+  protected authToken: string | undefined;
+  protected authMethod: 'vscode' | 'gh-cli' | 'explicit' | 'none' = 'none';
+  protected readonly attemptedMethods: Set<string> = new Set();
+  /**
+   * Maximum authentication attempts to prevent infinite retry loops.
+   * Tries: explicit token → VS Code auth → gh CLI
+   */
+  protected readonly maxAuthAttempts = 3;
+  /**
+   * Promise for an in-flight authentication attempt, so parallel requests wait
+   * on the same attempt rather than racing to authenticate independently.
+   */
+  protected authPromise?: Promise<string | undefined>;
+
+  /**
+   * Maximum redirect depth to prevent infinite redirect loops.
+   */
+  protected readonly maxRedirects = 10;
+
+  constructor(source: RegistrySource) {
+    super(source);
+    this.logger = Logger.getInstance();
+
+    if (!this.isValidGitHubUrl(source.url)) {
+      throw new Error(`Invalid GitHub URL: ${source.url}`);
+    }
+  }
+
+  /**
+   * Validate a GitHub URL (supports both HTTPS and SSH formats).
+   * @param url
+   */
+  protected isValidGitHubUrl(url: string): boolean {
+    // HTTPS format: https://github.com/owner/repo
+    if (url.startsWith('https://')) {
+      return url.includes('github.com');
+    }
+    // SSH format: git@github.com:owner/repo.git
+    if (url.startsWith('git@')) {
+      return url.includes('github.com:');
+    }
+    return false;
+  }
+
+  /**
+   * Parse the source URL to extract owner and repo.
+   */
+  protected parseGitHubUrl(): { owner: string; repo: string } {
+    const url = this.source.url.replace(/\.git$/, '');
+    const match = url.match(/github\.com[/:]([^/]+)\/([^/]+)/);
+
+    if (!match) {
+      throw new Error(`Invalid GitHub URL format: ${this.source.url}`);
+    }
+
+    return {
+      owner: match[1],
+      repo: match[2]
+    };
+  }
+
+  /**
+   * Build a GitHub Contents API URL, optionally pinned to a ref/branch.
+   * @param owner
+   * @param repo
+   * @param path
+   * @param ref Optional branch/ref appended as ?ref=
+   */
+  protected buildContentsUrl(owner: string, repo: string, path: string, ref?: string): string {
+    const base = `${this.apiBase}/repos/${owner}/${repo}/contents/${path}`;
+    return ref ? `${base}?ref=${ref}` : base;
+  }
+
+  /**
+   * Build a raw githubusercontent URL for a file at a branch.
+   * @param owner
+   * @param repo
+   * @param branch
+   * @param path
+   */
+  protected buildRawUrl(owner: string, repo: string, branch: string, path: string): string {
+    return `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/${path}`;
+  }
+
+  // ===== Authentication =====
+
+  /**
+   * Get an authentication token using the canonical fallback chain:
+   * 1. Explicit token from source configuration
+   * 2. VS Code GitHub authentication session
+   * 3. gh CLI (`gh auth token`)
+   * 4. No authentication
+   *
+   * Uses promise memoization so parallel requests share one authentication attempt.
+   */
+  protected async getAuthenticationToken(): Promise<string | undefined> {
+    if (this.authToken !== undefined) {
+      this.logger.debug(`[${this.type}] Using cached token (method: ${this.authMethod})`);
+      return this.authToken;
+    }
+
+    if (this.authPromise) {
+      this.logger.debug(`[${this.type}] Authentication in progress, waiting...`);
+      return this.authPromise;
+    }
+
+    if (this.attemptedMethods.size >= this.maxAuthAttempts) {
+      this.logger.error(`[${this.type}] Maximum authentication attempts (${this.maxAuthAttempts}) exceeded`);
+      this.logger.error(`[${this.type}] Attempted methods: ${Array.from(this.attemptedMethods).join(', ')}`);
+      return undefined;
+    }
+
+    this.authPromise = this.performAuthentication();
+
+    try {
+      const token = await this.authPromise;
+      this.authToken = token;
+      return token;
+    } finally {
+      this.authPromise = undefined;
+    }
+  }
+
+  /**
+   * Perform the actual authentication attempt through the fallback chain.
+   * Separated from {@link getAuthenticationToken} to enable promise memoization.
+   */
+  protected async performAuthentication(): Promise<string | undefined> {
+    this.logger.info(`[${this.type}] Attempting authentication...`);
+
+    // 1. Explicit token from source configuration
+    if (this.attemptedMethods.has('explicit')) {
+      this.logger.debug(`[${this.type}] Skipping explicit token (already attempted)`);
+    } else {
+      const explicitToken = this.getAuthToken();
+      if (explicitToken && explicitToken.trim().length > 0) {
+        this.authMethod = 'explicit';
+        this.logger.info(`[${this.type}] ✓ Using explicit token from configuration`);
+        const token = explicitToken.trim();
+        this.logger.debug(`[${this.type}] Token preview: ${token.substring(0, 8)}...`);
+        return token;
+      }
+      this.logger.debug(`[${this.type}] No explicit token configured`);
+    }
+
+    // 2. VS Code GitHub authentication
+    if (this.attemptedMethods.has('vscode')) {
+      this.logger.debug(`[${this.type}] Skipping VSCode auth (already attempted)`);
+    } else {
+      const vscodeToken = await this.getVscodeSessionToken(true);
+      if (vscodeToken) {
+        this.authMethod = 'vscode';
+        this.logger.info(`[${this.type}] ✓ Using VSCode GitHub authentication`);
+        this.logger.debug(`[${this.type}] Token preview: ${vscodeToken.substring(0, 8)}...`);
+        return vscodeToken;
+      }
+    }
+
+    // 3. gh CLI authentication
+    if (this.attemptedMethods.has('gh-cli')) {
+      this.logger.debug(`[${this.type}] Skipping gh CLI (already attempted)`);
+    } else {
+      const cliToken = await this.getGhCliToken();
+      if (cliToken) {
+        this.authMethod = 'gh-cli';
+        this.logger.info(`[${this.type}] ✓ Using gh CLI authentication`);
+        this.logger.debug(`[${this.type}] Token preview: ${cliToken.substring(0, 8)}...`);
+        return cliToken;
+      }
+    }
+
+    // 4. No authentication available
+    this.authMethod = 'none';
+    if (this.attemptedMethods.size > 0) {
+      this.logger.error(`[${this.type}] ✗ All authentication methods exhausted`);
+      this.logger.error(`[${this.type}] Attempted methods: ${Array.from(this.attemptedMethods).join(', ')}`);
+    } else {
+      this.logger.warn(`[${this.type}] ✗ No authentication available - API rate limits will apply and private repos will be inaccessible`);
+    }
+    return undefined;
+  }
+
+  /**
+   * Resolve a token from a VS Code GitHub authentication session.
+   * @param createIfNone Whether to prompt the user to sign in when no session exists
+   */
+  protected async getVscodeSessionToken(createIfNone: boolean): Promise<string | undefined> {
+    try {
+      this.logger.debug(`[${this.type}] Trying VSCode GitHub authentication...`);
+      const session = await vscode.authentication.getSession('github', ['repo'], { createIfNone });
+      if (session) {
+        return session.accessToken;
+      }
+      this.logger.debug(`[${this.type}] VSCode auth session not found`);
+    } catch (error) {
+      this.logger.warn(`[${this.type}] VSCode auth failed: ${error}`);
+    }
+    return undefined;
+  }
+
+  /**
+   * Resolve a token from the gh CLI (`gh auth token`).
+   */
+  protected async getGhCliToken(): Promise<string | undefined> {
+    try {
+      this.logger.debug(`[${this.type}] Trying gh CLI authentication...`);
+      const { stdout } = await execAsync('gh auth token');
+      const token = stdout.trim();
+      if (token.length > 0) {
+        return token;
+      }
+      this.logger.debug(`[${this.type}] gh CLI returned empty token`);
+    } catch (error) {
+      this.logger.warn(`[${this.type}] gh CLI auth failed: ${error}`);
+    }
+    return undefined;
+  }
+
+  /**
+   * Invalidate the cached authentication token, forcing re-authentication with the
+   * next method in the chain on the following request.
+   * @param reason Optional reason for invalidation (e.g., "401 Unauthorized")
+   */
+  protected invalidateAuthCache(reason?: string): void {
+    const previousMethod = this.authMethod;
+    this.logger.info(`[${this.type}] Invalidating authentication cache${reason ? `: ${reason}` : ''}`);
+    if (previousMethod !== 'none') {
+      this.logger.debug(`[${this.type}] Previous auth method: ${previousMethod}`);
+      this.attemptedMethods.add(previousMethod);
+    }
+    this.authToken = undefined;
+    this.authMethod = 'none';
+  }
+
+  // ===== HTTP transport =====
+
+  /**
+   * Determine whether a URL points at a GitHub domain (auth is only attached to these).
+   * @param urlString
+   */
+  protected isGitHubDomain(urlString: string): boolean {
+    try {
+      const urlObj = new URL(urlString);
+      return urlObj.hostname.includes('github.com')
+        || urlObj.hostname.includes('githubusercontent.com');
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Single `https.get` wrapper: resolves auth, attaches headers, follows 301/302
+   * redirects (up to {@link maxRedirects}), and resolves with the raw status + body.
+   * Does NOT throw on 4xx/5xx — callers interpret the status.
+   * @param url
+   * @param opts Optional extra request headers
+   * @param opts.headers Additional headers merged over the defaults
+   * @param redirectDepth
+   */
+  protected async httpGet(
+    url: string,
+    opts: { headers?: Record<string, string> } = {},
+    redirectDepth = 0
+  ): Promise<HttpGetResult> {
+    if (redirectDepth >= this.maxRedirects) {
+      this.logger.error(`[${this.type}] Maximum redirect depth (${this.maxRedirects}) exceeded`);
+      throw new Error(`Maximum redirect depth (${this.maxRedirects}) exceeded`);
+    }
+
+    const headers: Record<string, string> = {
+      'User-Agent': 'Prompt-Registry-VSCode-Extension',
+      Accept: 'application/json',
+      ...opts.headers
+    };
+
+    // Only attach auth for GitHub domains (redirects can point at third parties, e.g. S3).
+    const token = await this.getAuthenticationToken();
+    if (token && this.isGitHubDomain(url)) {
+      headers.Authorization = `token ${token}`;
+      this.logger.debug(`[${this.type}] Request to ${url} with auth (method: ${this.authMethod})`);
+    } else {
+      this.logger.debug(`[${this.type}] Request to ${url} WITHOUT auth`);
+    }
+
+    const sanitizedHeaders = { ...headers };
+    if (sanitizedHeaders.Authorization) {
+      sanitizedHeaders.Authorization = sanitizedHeaders.Authorization.substring(0, 15) + '...';
+    }
+    this.logger.debug(`[${this.type}] Request headers: ${JSON.stringify(sanitizedHeaders)}`);
+
+    return new Promise<HttpGetResult>((resolve, reject) => {
+      https.get(url, { headers }, (res) => {
+        if (res.statusCode === 301 || res.statusCode === 302) {
+          const redirectUrl = res.headers.location;
+          if (redirectUrl) {
+            this.logger.debug(`[${this.type}] Following redirect (depth ${redirectDepth + 1}) to: ${redirectUrl}`);
+            this.httpGet(redirectUrl, opts, redirectDepth + 1).then(resolve).catch(reject);
+            return;
+          }
+        }
+
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk: Buffer) => {
+          chunks.push(Buffer.from(chunk));
+        });
+        res.on('end', () => {
+          resolve({
+            status: res.statusCode ?? 0,
+            statusMessage: res.statusMessage ?? '',
+            headers: res.headers,
+            body: Buffer.concat(chunks)
+          });
+        });
+      }).on('error', (error) => {
+        this.logger.error(`[${this.type}] Network error: ${error.message}`);
+        reject(new Error(`GitHub request failed: ${error.message}`));
+      });
+    });
+  }
+
+  /**
+   * Validate response Content-Type and detect HTML error pages returned for auth failures.
+   * @param headers
+   * @param body
+   */
+  protected validateResponse(
+    headers: Record<string, string | string[] | undefined>,
+    body: string
+  ): { isValid: boolean; error?: string } {
+    const contentType = (headers['content-type'] as string) || '';
+
+    if (contentType.includes('text/html')) {
+      this.logger.warn(`[${this.type}] Received HTML response instead of JSON (Content-Type: ${contentType})`);
+
+      let htmlError = 'HTML error page received';
+      const bodyMatch = body.match(/<body[^>]*>([\s\S]*?)<\/body>/i);
+      if (bodyMatch) {
+        const bodyText = bodyMatch[1]
+          .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
+          .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
+          .replace(/<[^>]+>/g, ' ')
+          .replace(/\s+/g, ' ')
+          .trim();
+        if (bodyText.length > 0) {
+          htmlError = bodyText.substring(0, 200);
+        }
+      }
+
+      return {
+        isValid: false,
+        error: `Received HTML error page instead of JSON response. This typically indicates an authentication or access issue. Error: ${htmlError}`
+      };
+    }
+
+    if (!contentType.includes('application/json') && !contentType.includes('application/octet-stream')) {
+      this.logger.warn(`[${this.type}] Unexpected Content-Type: ${contentType}`);
+      return {
+        isValid: false,
+        error: `Unexpected Content-Type: ${contentType}. Expected application/json.`
+      };
+    }
+
+    return { isValid: true };
+  }
+
+  /**
+   * Build a helpful error message for a failed GitHub API response.
+   * @param status
+   * @param statusMessage
+   */
+  protected buildApiErrorMessage(status: number, statusMessage: string): string {
+    let errorMsg = `GitHub API error: ${status} ${statusMessage}`;
+    switch (status) {
+      case 404: {
+        errorMsg += ' - Repository not found or not accessible. Check authentication.';
+        break;
+      }
+      case 401: {
+        errorMsg += ' - Authentication failed. Token may be invalid or expired.';
+        if (this.attemptedMethods.size > 0) {
+          errorMsg += ` Attempted methods: ${Array.from(this.attemptedMethods).join(', ')}`;
+        }
+        break;
+      }
+      case 403: {
+        errorMsg += ' - Access forbidden. Token may lack required scopes (repo).';
+        if (this.attemptedMethods.size > 0) {
+          errorMsg += ` Attempted methods: ${Array.from(this.attemptedMethods).join(', ')}`;
+        }
+        break;
+      }
+      // No default
+    }
+    return errorMsg;
+  }
+
+  /**
+   * GET a GitHub API endpoint and parse the JSON response.
+   * On 401/403 it invalidates the auth cache and retries once with the next auth method;
+   * on final failure it throws a helpful, status-specific error.
+   * @param url
+   * @param retryCount
+   */
+  protected async getJson<T>(url: string, retryCount = 0): Promise<T> {
+    const res = await this.httpGet(url);
+    const data = res.body.toString('utf8');
+
+    if (res.status >= 400) {
+      this.logger.error(`[${this.type}] HTTP ${res.status}: ${res.statusMessage}`);
+      this.logger.error(`[${this.type}] URL: ${url}`);
+      this.logger.error(`[${this.type}] Auth method: ${this.authMethod}`);
+      this.logger.error(`[${this.type}] Response: ${data.substring(0, 500)}`);
+
+      const { isValid, error } = this.validateResponse(res.headers, data);
+      if (!isValid) {
+        this.logger.error(`[${this.type}] ${error}`);
+      }
+
+      const isAuthError = res.status === 401 || res.status === 403;
+      const canRetry = retryCount < this.maxAuthAttempts && this.attemptedMethods.size < this.maxAuthAttempts;
+      if (isAuthError && canRetry) {
+        this.logger.warn(`[${this.type}] Authentication error detected, invalidating cache and retrying...`);
+        this.invalidateAuthCache(`${res.status} ${res.statusMessage}`);
+        try {
+          return await this.getJson<T>(url, retryCount + 1);
+        } catch (retryError) {
+          this.logger.error(`[${this.type}] Retry failed: ${retryError}`);
+          // Fall through to the original response's error message below.
+        }
+      }
+
+      // HTML error pages surface their own message; otherwise use the status switch.
+      throw new Error(!isValid && error ? error : this.buildApiErrorMessage(res.status, res.statusMessage));
+    }
+
+    const validation = this.validateResponse(res.headers, data);
+    if (!validation.isValid) {
+      this.logger.error(`[${this.type}] ${validation.error}`);
+      throw new Error(validation.error);
+    }
+
+    this.logger.debug(`[${this.type}] Response OK (${res.status})`);
+    try {
+      return JSON.parse(data) as T;
+    } catch (error) {
+      this.logger.error(`[${this.type}] Failed to parse response: ${error}`);
+      throw new Error(`Failed to parse GitHub response as JSON: ${error}`);
+    }
+  }
+
+  /**
+   * GET a URL and return the response body as text. Throws on any non-2xx status.
+   * @param url
+   */
+  protected async getText(url: string): Promise<string> {
+    const res = await this.httpGet(url);
+    if (res.status >= 400) {
+      this.logger.error(`[${this.type}] HTTP ${res.status}: ${res.statusMessage}`);
+      this.logger.error(`[${this.type}] URL: ${url}`);
+      throw new Error(this.buildApiErrorMessage(res.status, res.statusMessage));
+    }
+    this.logger.debug(`[${this.type}] Response OK (${res.status}), ${res.body.length} bytes`);
+    return res.body.toString('utf8');
+  }
+
+  /**
+   * GET a URL and return the response body as a Buffer. For GitHub API asset URLs it
+   * requests octet-stream so the raw file content is returned rather than JSON metadata.
+   * @param url
+   */
+  protected async getBuffer(url: string): Promise<Buffer> {
+    const headers: Record<string, string> = {};
+    if (url.startsWith(this.apiBase)) {
+      headers.Accept = 'application/octet-stream';
+    }
+    this.logger.debug(`[${this.type}] Downloading ${url} (auth method: ${this.authMethod})`);
+    const res = await this.httpGet(url, { headers });
+    if (res.status >= 400) {
+      this.logger.error(`[${this.type}] Download failed: HTTP ${res.status}`);
+      this.logger.error(`[${this.type}] URL: ${url}`);
+      this.logger.error(`[${this.type}] Auth method: ${this.authMethod}`);
+      throw new Error(`Download failed: ${res.status} ${res.statusMessage}`);
+    }
+    this.logger.debug(`[${this.type}] Download complete: ${res.body.length} bytes`);
+    return res.body;
+  }
+
+  // ===== Progressive chunked fetch =====
+
+  /**
+   * Process `items` in bounded-size chunks, invoking `processItem` concurrently within
+   * each chunk (`Promise.allSettled`, so one failure drops only that item). After each
+   * chunk, `onPartial` receives a fresh snapshot array of everything accumulated so far,
+   * letting the UI render progressively during large syncs.
+   *
+   * An empty input list never runs the loop, so `onPartial` is not invoked and the
+   * result is `[]`.
+   * @param items
+   * @param chunkSize
+   * @param processItem Maps an item to a result, or null/undefined to drop it
+   * @param onPartial Optional callback invoked with a growing snapshot after each chunk
+   */
+  protected async processInChunks<TItem, TResult>(
+    items: TItem[],
+    chunkSize: number,
+    processItem: (item: TItem) => Promise<TResult | null | undefined>,
+    onPartial?: (accumulated: TResult[]) => void | Promise<void>
+  ): Promise<TResult[]> {
+    const size = Math.max(1, chunkSize);
+    const accumulated: TResult[] = [];
+
+    for (let i = 0; i < items.length; i += size) {
+      const chunk = items.slice(i, i + size);
+      const settled = await Promise.allSettled(chunk.map((item) => processItem(item)));
+
+      for (const result of settled) {
+        if (result.status === 'fulfilled' && result.value !== null && result.value !== undefined) {
+          accumulated.push(result.value);
+        }
+      }
+
+      await onPartial?.([...accumulated]);
+    }
+
+    return accumulated;
+  }
+
+  // ===== Shared validation =====
+
+  /**
+   * GitHub-style repository validation: confirms the repo is accessible and reports the
+   * release count. Subclasses either use this directly (default {@link validate}) or call
+   * it as a base check before adding source-type-specific validation.
+   */
+  protected async validateGitHubRepository(): Promise<ValidationResult> {
+    try {
+      const { owner, repo } = this.parseGitHubUrl();
+      await this.getJson(`${this.apiBase}/repos/${owner}/${repo}`);
+
+      const releases = await this.getJson<GitHubReleaseSummary[]>(
+        `${this.apiBase}/repos/${owner}/${repo}/releases`
+      );
+
+      return {
+        valid: true,
+        errors: [],
+        warnings: releases.length === 0 ? ['No releases found in repository'] : [],
+        bundlesFound: releases.length
+      };
+    } catch (error) {
+      return {
+        valid: false,
+        errors: [`GitHub validation failed: ${error}`],
+        warnings: [],
+        bundlesFound: 0
+      };
+    }
+  }
+
+  /**
+   * Default validation delegates to {@link validateGitHubRepository}. Subclasses with
+   * source-type-specific structure (collections, skills) override this.
+   */
+  public async validate(): Promise<ValidationResult> {
+    return this.validateGitHubRepository();
+  }
+}

--- a/src/adapters/repository-adapter.ts
+++ b/src/adapters/repository-adapter.ts
@@ -26,9 +26,10 @@ export interface IRepositoryAdapter {
 
   /**
    * Fetch list of available bundles from the source
+   * @param onPartialBundles Optional callback invoked with a growing snapshot after each chunk
    * @returns Promise with array of bundles
    */
-  fetchBundles(): Promise<Bundle[]>;
+  fetchBundles(onPartialBundles?: (bundles: Bundle[]) => void | Promise<void>): Promise<Bundle[]>;
 
   /**
    * Download a specific bundle
@@ -155,7 +156,7 @@ export abstract class RepositoryAdapter implements IRepositoryAdapter {
     return Promise.resolve(null);
   }
 
-  public abstract fetchBundles(): Promise<Bundle[]>;
+  public abstract fetchBundles(onPartialBundles?: (bundles: Bundle[]) => void | Promise<void>): Promise<Bundle[]>;
   public abstract downloadBundle(bundle: Bundle): Promise<Buffer>;
   public abstract fetchMetadata(): Promise<SourceMetadata>;
   public abstract validate(): Promise<ValidationResult>;

--- a/src/adapters/skills-adapter.ts
+++ b/src/adapters/skills-adapter.ts
@@ -45,6 +45,7 @@ export class SkillsAdapter extends RepositoryAdapter {
   public readonly type = 'skills';
   private readonly logger: Logger;
   private readonly githubAdapter: GitHubAdapter;
+  private readonly defaultBranch = 'main';
 
   constructor(source: RegistrySource) {
     super(source);
@@ -86,6 +87,20 @@ export class SkillsAdapter extends RepositoryAdapter {
       owner: match[1],
       repo: match[2]
     };
+  }
+
+  private collectSkillIds(tree: GitTreeEntry[]): Set<string> {
+    const skillIds = new Set<string>();
+    for (const entry of tree) {
+      if (entry.type !== 'blob') {
+        continue;
+      }
+      const segments = entry.path.split('/');
+      if (segments[0] === 'skills' && segments.length === 3 && segments[2] === 'SKILL.md') {
+        skillIds.add(segments[1]);
+      }
+    }
+    return skillIds;
   }
 
   private async fetchRepoTree(owner: string, repo: string, branch: string): Promise<GitTreeEntry[]> {
@@ -143,20 +158,23 @@ export class SkillsAdapter extends RepositoryAdapter {
 
   /**
    * Scan skills/ directory via a single Git Trees API call.
+   * @param onChunk Optional callback invoked with each finished chunk of skills
    */
-  private async scanSkillsDirectory(): Promise<SkillItem[]> {
+  private async scanSkillsDirectory(
+    onChunk?: (skills: SkillItem[]) => void | Promise<void>
+  ): Promise<SkillItem[]> {
     const { owner, repo } = this.parseGitHubUrl();
-    const branch = 'main';
+    const branch = this.defaultBranch;
 
     this.logger.debug(`[SkillsAdapter] Scanning skills via git tree: ${owner}/${repo}@${branch}`);
 
     try {
       const tree = await this.fetchRepoTree(owner, repo, branch);
 
-      // Single O(tree) pass: group blobs under skills/<id>/ and note which
-      // skills have a top-level SKILL.md (a skill id requires SKILL.md).
+      // Single O(tree) pass: group all blobs under skills/<id>/. A skill id
+      // requires a top-level SKILL.md — collectSkillIds is the single source of
+      // truth for that rule (also used by validate()/fetchMetadata()).
       const filesBySkill = new Map<string, GitTreeEntry[]>();
-      const skillIds = new Set<string>();
       for (const entry of tree) {
         if (entry.type !== 'blob') {
           continue;
@@ -170,10 +188,8 @@ export class SkillsAdapter extends RepositoryAdapter {
           filesBySkill.set(skillId, []);
         }
         filesBySkill.get(skillId)!.push(entry);
-        if (segments.length === 3 && segments[2] === 'SKILL.md') {
-          skillIds.add(skillId);
-        }
       }
+      const skillIds = this.collectSkillIds(tree);
 
       this.logger.debug(`[SkillsAdapter] Found ${skillIds.size} skills in tree`);
 
@@ -181,14 +197,16 @@ export class SkillsAdapter extends RepositoryAdapter {
       // SKILL.md fetches without serializing them.
       const ids = [...skillIds];
       const skills: SkillItem[] = [];
-      const CONCURRENCY_LIMIT = 5;
+      const CONCURRENCY_LIMIT = 15;
 
       for (let i = 0; i < ids.length; i += CONCURRENCY_LIMIT) {
         const chunk = ids.slice(i, i + CONCURRENCY_LIMIT);
         const chunkResults = await Promise.all(
           chunk.map((skillId) => this.buildSkillFromTree(owner, repo, branch, skillId, filesBySkill.get(skillId) ?? []))
         );
-        skills.push(...chunkResults.filter((s): s is SkillItem => s !== null));
+        const built = chunkResults.filter((s): s is SkillItem => s !== null);
+        skills.push(...built);
+        await onChunk?.(built);
       }
 
       return skills;
@@ -674,25 +692,30 @@ export class SkillsAdapter extends RepositoryAdapter {
   /**
    * Fetch all skills from the repository as bundles
    * Each skill becomes a separate bundle
+   * @param onPartialBundles Optional callback invoked with a growing snapshot after each chunk
    */
-  public async fetchBundles(): Promise<Bundle[]> {
+  public async fetchBundles(
+    onPartialBundles?: (bundles: Bundle[]) => void | Promise<void>
+  ): Promise<Bundle[]> {
     this.logger.info(`[SkillsAdapter] Fetching skills from repository: ${this.source.url}`);
 
     try {
-      const skills = await this.scanSkillsDirectory();
-      this.logger.info(`[SkillsAdapter] Found ${skills.length} skills in repository`);
-
       const bundles: Bundle[] = [];
-      for (const skill of skills) {
-        try {
-          const bundle = this.createBundleFromSkill(skill);
-          bundles.push(bundle);
-          this.logger.debug(`[SkillsAdapter] Created bundle: ${bundle.id}`);
-        } catch (error) {
-          this.logger.warn(`[SkillsAdapter] Failed to create bundle from skill ${skill.id}: ${error}`);
-        }
-      }
 
+      const skills = await this.scanSkillsDirectory(async (chunkSkills) => {
+        for (const skill of chunkSkills) {
+          try {
+            const bundle = this.createBundleFromSkill(skill);
+            bundles.push(bundle);
+            this.logger.debug(`[SkillsAdapter] Created bundle: ${bundle.id}`);
+          } catch (error) {
+            this.logger.warn(`[SkillsAdapter] Failed to create bundle from skill ${skill.id}: ${error}`);
+          }
+        }
+        await onPartialBundles?.([...bundles]);
+      });
+
+      this.logger.info(`[SkillsAdapter] Found ${skills.length} skills in repository`);
       this.logger.info(`[SkillsAdapter] Successfully created ${bundles.length} bundles`);
       return bundles;
     } catch (error) {
@@ -745,8 +768,8 @@ export class SkillsAdapter extends RepositoryAdapter {
 
       let skillCount = 0;
       try {
-        const skills = await this.scanSkillsDirectory();
-        skillCount = skills.length;
+        const tree = await this.fetchRepoTree(owner, repo, this.defaultBranch);
+        skillCount = this.collectSkillIds(tree).size;
 
         if (skillCount === 0) {
           warnings.push('No valid skills found in skills/ directory (skills must have SKILL.md file)');
@@ -778,13 +801,13 @@ export class SkillsAdapter extends RepositoryAdapter {
    */
   public async fetchMetadata(): Promise<SourceMetadata> {
     try {
-      const skills = await this.scanSkillsDirectory();
       const { owner, repo } = this.parseGitHubUrl();
+      const tree = await this.fetchRepoTree(owner, repo, this.defaultBranch);
 
       return {
         name: `${owner}/${repo}`,
         description: 'Skills Repository',
-        bundleCount: skills.length,
+        bundleCount: this.collectSkillIds(tree).size,
         lastUpdated: new Date().toISOString(),
         version: '1.0.0'
       };

--- a/src/adapters/skills-adapter.ts
+++ b/src/adapters/skills-adapter.ts
@@ -12,7 +12,6 @@ import * as crypto from 'node:crypto';
 import * as yaml from 'js-yaml';
 import {
   Bundle,
-  RegistrySource,
   SourceMetadata,
   ValidationResult,
 } from '../types/registry';
@@ -23,14 +22,8 @@ import {
   SkillItem,
 } from '../types/skills';
 import {
-  Logger,
-} from '../utils/logger';
-import {
-  GitHubAdapter,
-} from './github-adapter';
-import {
-  RepositoryAdapter,
-} from './repository-adapter';
+  GitHubBackedAdapter,
+} from './github-backed-adapter';
 
 /**
  * A single entry from the GitHub Git Trees API (recursive listing).
@@ -38,56 +31,24 @@ import {
 type GitTreeEntry = { path: string; type: string; sha: string };
 
 /**
+ * A pre-computed work list for building skills: the resolved repo coordinates plus the
+ * discovered skill ids and their tree blobs, ready to fan out through `processInChunks`.
+ */
+interface SkillWorkList {
+  owner: string;
+  repo: string;
+  branch: string;
+  ids: string[];
+  filesBySkill: Map<string, GitTreeEntry[]>;
+}
+
+/**
  * Skills adapter implementation for GitHub repositories
  * Discovers skills from skills/ directory with SKILL.md files
  */
-export class SkillsAdapter extends RepositoryAdapter {
+export class SkillsAdapter extends GitHubBackedAdapter {
   public readonly type = 'skills';
-  private readonly logger: Logger;
-  private readonly githubAdapter: GitHubAdapter;
   private readonly defaultBranch = 'main';
-
-  constructor(source: RegistrySource) {
-    super(source);
-    this.logger = Logger.getInstance();
-
-    if (!this.isValidGitHubUrl(source.url)) {
-      throw new Error(`Invalid GitHub URL for skills source: ${source.url}`);
-    }
-
-    this.githubAdapter = new GitHubAdapter(source);
-  }
-
-  /**
-   * Validate GitHub URL format
-   * @param url
-   */
-  private isValidGitHubUrl(url: string): boolean {
-    if (url.startsWith('https://')) {
-      return url.includes('github.com');
-    }
-    if (url.startsWith('git@')) {
-      return url.includes('github.com:');
-    }
-    return false;
-  }
-
-  /**
-   * Parse GitHub URL to extract owner and repo
-   */
-  private parseGitHubUrl(): { owner: string; repo: string } {
-    const url = this.source.url.replace(/\.git$/, '');
-    const match = url.match(/github\.com[/:]([^/]+)\/([^/]+)/);
-
-    if (!match) {
-      throw new Error(`Invalid GitHub URL format: ${this.source.url}`);
-    }
-
-    return {
-      owner: match[1],
-      repo: match[2]
-    };
-  }
 
   private collectSkillIds(tree: GitTreeEntry[]): Set<string> {
     const skillIds = new Set<string>();
@@ -104,9 +65,9 @@ export class SkillsAdapter extends RepositoryAdapter {
   }
 
   private async fetchRepoTree(owner: string, repo: string, branch: string): Promise<GitTreeEntry[]> {
-    const url = `https://api.github.com/repos/${owner}/${repo}/git/trees/${branch}?recursive=1`;
+    const url = `${this.apiBase}/repos/${owner}/${repo}/git/trees/${branch}?recursive=1`;
     this.logger.debug(`[SkillsAdapter] Fetching repo tree: ${url}`);
-    const result = await this.makeGitHubRequest(url);
+    const result = await this.getJson<{ tree?: GitTreeEntry[]; truncated?: boolean }>(url);
     if (!Array.isArray(result.tree)) {
       throw new Error(`Unexpected response from Git Trees API for ${owner}/${repo}: missing tree array`);
     }
@@ -132,7 +93,7 @@ export class SkillsAdapter extends RepositoryAdapter {
     entries: GitTreeEntry[]
   ): Promise<SkillItem | null> {
     const skillPath = `skills/${skillId}`;
-    const rawSkillMdUrl = `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/${skillPath}/SKILL.md`;
+    const rawSkillMdUrl = this.buildRawUrl(owner, repo, branch, `${skillPath}/SKILL.md`);
 
     try {
       const parsedSkillMd = await this.parseSkillMd(rawSkillMdUrl);
@@ -157,63 +118,41 @@ export class SkillsAdapter extends RepositoryAdapter {
   }
 
   /**
-   * Scan skills/ directory via a single Git Trees API call.
-   * @param onChunk Optional callback invoked with each finished chunk of skills
+   * Produce the work list for a skills scan via a single Git Trees API call: resolve the
+   * repo coordinates, group all blobs under skills/<id>/, and collect the valid skill ids.
+   * The actual per-skill building is fanned out by the caller so it can stream partials.
    */
-  private async scanSkillsDirectory(
-    onChunk?: (skills: SkillItem[]) => void | Promise<void>
-  ): Promise<SkillItem[]> {
+  private async collectSkillWorkList(): Promise<SkillWorkList> {
     const { owner, repo } = this.parseGitHubUrl();
     const branch = this.defaultBranch;
 
     this.logger.debug(`[SkillsAdapter] Scanning skills via git tree: ${owner}/${repo}@${branch}`);
 
-    try {
-      const tree = await this.fetchRepoTree(owner, repo, branch);
+    const tree = await this.fetchRepoTree(owner, repo, branch);
 
-      // Single O(tree) pass: group all blobs under skills/<id>/. A skill id
-      // requires a top-level SKILL.md — collectSkillIds is the single source of
-      // truth for that rule (also used by validate()/fetchMetadata()).
-      const filesBySkill = new Map<string, GitTreeEntry[]>();
-      for (const entry of tree) {
-        if (entry.type !== 'blob') {
-          continue;
-        }
-        const segments = entry.path.split('/');
-        if (segments[0] !== 'skills' || segments.length < 3) {
-          continue;
-        }
-        const skillId = segments[1];
-        if (!filesBySkill.has(skillId)) {
-          filesBySkill.set(skillId, []);
-        }
-        filesBySkill.get(skillId)!.push(entry);
+    // Single O(tree) pass: group all blobs under skills/<id>/. A skill id
+    // requires a top-level SKILL.md — collectSkillIds is the single source of
+    // truth for that rule (also used by validate()/fetchMetadata()).
+    const filesBySkill = new Map<string, GitTreeEntry[]>();
+    for (const entry of tree) {
+      if (entry.type !== 'blob') {
+        continue;
       }
-      const skillIds = this.collectSkillIds(tree);
-
-      this.logger.debug(`[SkillsAdapter] Found ${skillIds.size} skills in tree`);
-
-      // Build skills in parallel with a concurrency limit to bound raw
-      // SKILL.md fetches without serializing them.
-      const ids = [...skillIds];
-      const skills: SkillItem[] = [];
-      const CONCURRENCY_LIMIT = 15;
-
-      for (let i = 0; i < ids.length; i += CONCURRENCY_LIMIT) {
-        const chunk = ids.slice(i, i + CONCURRENCY_LIMIT);
-        const chunkResults = await Promise.all(
-          chunk.map((skillId) => this.buildSkillFromTree(owner, repo, branch, skillId, filesBySkill.get(skillId) ?? []))
-        );
-        const built = chunkResults.filter((s): s is SkillItem => s !== null);
-        skills.push(...built);
-        await onChunk?.(built);
+      const segments = entry.path.split('/');
+      if (segments[0] !== 'skills' || segments.length < 3) {
+        continue;
       }
-
-      return skills;
-    } catch (error) {
-      this.logger.error(`[SkillsAdapter] Failed to scan skills directory: ${error}`);
-      throw new Error(`Failed to scan skills directory: ${error}`);
+      const skillId = segments[1];
+      if (!filesBySkill.has(skillId)) {
+        filesBySkill.set(skillId, []);
+      }
+      filesBySkill.get(skillId)!.push(entry);
     }
+    const ids = [...this.collectSkillIds(tree)];
+
+    this.logger.debug(`[SkillsAdapter] Found ${ids.length} skills in tree`);
+
+    return { owner, repo, branch, ids, filesBySkill };
   }
 
   /**
@@ -224,8 +163,7 @@ export class SkillsAdapter extends RepositoryAdapter {
     this.logger.debug(`[SkillsAdapter] Parsing SKILL.md from: ${downloadUrl}`);
 
     try {
-      const content = await this.downloadFileContent(downloadUrl);
-      const raw = content.toString('utf8');
+      const raw = await this.getText(downloadUrl);
 
       const frontmatterMatch = raw.match(/^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/);
 
@@ -319,7 +257,6 @@ export class SkillsAdapter extends RepositoryAdapter {
    * @param initialEntries
    */
   private async collectSkillFiles(owner: string, repo: string, initialEntries: GitHubContentItem[]): Promise<GitHubContentItem[]> {
-    const apiBase = 'https://api.github.com';
     const files: GitHubContentItem[] = [];
     const queue: GitHubContentItem[] = [...initialEntries];
 
@@ -333,7 +270,9 @@ export class SkillsAdapter extends RepositoryAdapter {
 
       if (entry.type === 'dir') {
         try {
-          const nestedEntries: GitHubContentItem[] = await this.makeGitHubRequest(`${apiBase}/repos/${owner}/${repo}/contents/${entry.path}`);
+          const nestedEntries = await this.getJson<GitHubContentItem[]>(
+            this.buildContentsUrl(owner, repo, entry.path)
+          );
           queue.push(...nestedEntries);
         } catch (error) {
           this.logger.warn(`[SkillsAdapter] Failed to read nested directory ${entry.path}: ${error}`);
@@ -384,15 +323,15 @@ export class SkillsAdapter extends RepositoryAdapter {
    */
   private async fetchSingleSkill(skillId: string): Promise<SkillItem | null> {
     const { owner, repo } = this.parseGitHubUrl();
-    const apiBase = 'https://api.github.com';
     const skillPath = `skills/${skillId}`;
 
     this.logger.debug(`[SkillsAdapter] Fetching single skill: ${skillId}`);
 
     try {
       // Get skill directory contents
-      const skillContentsUrl = `${apiBase}/repos/${owner}/${repo}/contents/${skillPath}`;
-      const skillContents: GitHubContentItem[] = await this.makeGitHubRequest(skillContentsUrl);
+      const skillContents = await this.getJson<GitHubContentItem[]>(
+        this.buildContentsUrl(owner, repo, skillPath)
+      );
 
       // Find SKILL.md
       const skillMdFile = skillContents.find((item) =>
@@ -453,15 +392,15 @@ export class SkillsAdapter extends RepositoryAdapter {
       const manifestYaml = yamlLib.dump(deploymentManifest);
       zip.addFile('deployment-manifest.yml', Buffer.from(manifestYaml, 'utf8'));
 
-      const apiBase = 'https://api.github.com';
-      const skillContentsUrl = `${apiBase}/repos/${owner}/${repo}/contents/${skill.path}`;
-      const skillContents: GitHubContentItem[] = await this.makeGitHubRequest(skillContentsUrl);
+      const skillContents = await this.getJson<GitHubContentItem[]>(
+        this.buildContentsUrl(owner, repo, skill.path)
+      );
 
       // Use skills/{skill-id}/ structure to match CopilotSyncService expectations
       for (const item of skillContents) {
         if (item.type === 'file' && item.download_url) {
           try {
-            const fileContent = await this.downloadFileContent(item.download_url);
+            const fileContent = await this.getBuffer(item.download_url);
             const filePath = `skills/${skill.id}/${item.name}`;
             zip.addFile(filePath, fileContent);
 
@@ -493,14 +432,14 @@ export class SkillsAdapter extends RepositoryAdapter {
    */
   private async addDirectoryToZip(zip: any, owner: string, repo: string, dirPath: string, zipPath: string): Promise<void> {
     try {
-      const apiBase = 'https://api.github.com';
-      const dirContentsUrl = `${apiBase}/repos/${owner}/${repo}/contents/${dirPath}`;
-      const dirContents: GitHubContentItem[] = await this.makeGitHubRequest(dirContentsUrl);
+      const dirContents = await this.getJson<GitHubContentItem[]>(
+        this.buildContentsUrl(owner, repo, dirPath)
+      );
 
       for (const item of dirContents) {
         if (item.type === 'file' && item.download_url) {
           try {
-            const fileContent = await this.downloadFileContent(item.download_url);
+            const fileContent = await this.getBuffer(item.download_url);
             const filePath = `${zipPath}/${item.name}`;
             zip.addFile(filePath, fileContent);
           } catch (error) {
@@ -572,126 +511,9 @@ export class SkillsAdapter extends RepositoryAdapter {
   }
 
   /**
-   * Download file content from URL
-   * @param url
-   */
-  private async downloadFileContent(url: string): Promise<Buffer> {
-    const https = await import('node:https');
-
-    return new Promise((resolve, reject) => {
-      const headers: Record<string, string> = {
-        'User-Agent': 'Prompt-Registry-VSCode-Extension'
-      };
-
-      const token = this.getAuthToken();
-      if (token) {
-        headers.Authorization = `token ${token}`;
-      }
-
-      https.get(url, { headers }, (res: any) => {
-        const chunks: Buffer[] = [];
-
-        res.on('data', (chunk: Buffer) => {
-          chunks.push(chunk);
-        });
-
-        res.on('end', () => {
-          if (res.statusCode >= 400) {
-            reject(new Error(`HTTP ${res.statusCode}: ${res.statusMessage}`));
-            return;
-          }
-          resolve(Buffer.concat(chunks));
-        });
-      }).on('error', (error: any) => {
-        reject(new Error(`Download failed: ${error.message}`));
-      });
-    });
-  }
-
-  /**
-   * Make GitHub API request with authentication
-   * @param url
-   */
-  private async makeGitHubRequest(url: string): Promise<any> {
-    const https = await import('node:https');
-    const vscode = await import('vscode');
-    const { exec } = await import('node:child_process');
-    const { promisify } = await import('node:util');
-    const execAsync = promisify(exec);
-
-    let authToken: string | undefined;
-
-    const explicitToken = this.getAuthToken();
-    if (explicitToken && explicitToken.trim().length > 0) {
-      authToken = explicitToken.trim();
-      this.logger.debug('[SkillsAdapter] Using explicit token from configuration');
-    } else {
-      try {
-        const session = await vscode.authentication.getSession('github', ['repo'], { createIfNone: false });
-        if (session) {
-          authToken = session.accessToken;
-          this.logger.debug('[SkillsAdapter] Using VSCode GitHub authentication');
-        }
-      } catch (error) {
-        this.logger.debug(`[SkillsAdapter] VSCode auth failed: ${error}`);
-      }
-
-      if (!authToken) {
-        try {
-          const { stdout } = await execAsync('gh auth token');
-          const token = stdout.trim();
-          if (token && token.length > 0) {
-            authToken = token;
-            this.logger.debug('[SkillsAdapter] Using gh CLI authentication');
-          }
-        } catch (error) {
-          this.logger.debug(`[SkillsAdapter] gh CLI auth failed: ${error}`);
-        }
-      }
-    }
-
-    return new Promise((resolve, reject) => {
-      let headers: Record<string, string> = {
-        'User-Agent': 'Prompt-Registry-VSCode-Extension',
-        Accept: 'application/json'
-      };
-
-      if (authToken) {
-        headers = {
-          ...headers,
-          Authorization: `token ${authToken}`
-        };
-        this.logger.debug(`[SkillsAdapter] Request to ${url} with authentication`);
-      } else {
-        this.logger.debug(`[SkillsAdapter] Request to ${url} without authentication`);
-      }
-
-      https.get(url, { headers }, (res: any) => {
-        let data = '';
-        res.on('data', (chunk: any) => data += chunk);
-        res.on('end', () => {
-          if (res.statusCode >= 400) {
-            this.logger.error(`[SkillsAdapter] HTTP ${res.statusCode}: ${res.statusMessage}`);
-            reject(new Error(`HTTP ${res.statusCode}: ${res.statusMessage}`));
-            return;
-          }
-          try {
-            resolve(JSON.parse(data));
-          } catch (error) {
-            this.logger.error(`[SkillsAdapter] Failed to parse JSON response: ${error}`);
-            reject(new Error(`Failed to parse JSON response: ${error}`));
-          }
-        });
-      }).on('error', (error: any) => {
-        this.logger.error(`[SkillsAdapter] Network error: ${error.message}`);
-        reject(new Error(`Request failed: ${error.message}`));
-      });
-    });
-  }
-
-  /**
    * Fetch all skills from the repository as bundles
-   * Each skill becomes a separate bundle
+   * Each skill becomes a separate bundle. Skills are built in bounded-size chunks; after each
+   * chunk the optional callback receives a growing snapshot so the UI can render progressively.
    * @param onPartialBundles Optional callback invoked with a growing snapshot after each chunk
    */
   public async fetchBundles(
@@ -700,22 +522,19 @@ export class SkillsAdapter extends RepositoryAdapter {
     this.logger.info(`[SkillsAdapter] Fetching skills from repository: ${this.source.url}`);
 
     try {
-      const bundles: Bundle[] = [];
+      const { owner, repo, branch, ids, filesBySkill } = await this.collectSkillWorkList();
 
-      const skills = await this.scanSkillsDirectory(async (chunkSkills) => {
-        for (const skill of chunkSkills) {
-          try {
-            const bundle = this.createBundleFromSkill(skill);
-            bundles.push(bundle);
-            this.logger.debug(`[SkillsAdapter] Created bundle: ${bundle.id}`);
-          } catch (error) {
-            this.logger.warn(`[SkillsAdapter] Failed to create bundle from skill ${skill.id}: ${error}`);
-          }
-        }
-        await onPartialBundles?.([...bundles]);
-      });
+      const bundles = await this.processInChunks(
+        ids,
+        15,
+        async (skillId) => {
+          const skill = await this.buildSkillFromTree(owner, repo, branch, skillId, filesBySkill.get(skillId) ?? []);
+          return skill ? this.createBundleFromSkill(skill) : null;
+        },
+        onPartialBundles
+      );
 
-      this.logger.info(`[SkillsAdapter] Found ${skills.length} skills in repository`);
+      this.logger.info(`[SkillsAdapter] Found ${ids.length} skills in repository`);
       this.logger.info(`[SkillsAdapter] Successfully created ${bundles.length} bundles`);
       return bundles;
     } catch (error) {
@@ -736,17 +555,14 @@ export class SkillsAdapter extends RepositoryAdapter {
     try {
       const { owner, repo } = this.parseGitHubUrl();
 
-      const baseValidation = await this.githubAdapter.validate();
+      const baseValidation = await this.validateGitHubRepository();
       if (!baseValidation.valid) {
         return baseValidation;
       }
 
-      const apiBase = 'https://api.github.com';
-
       let hasSkillsDir = false;
       try {
-        const skillsUrl = `${apiBase}/repos/${owner}/${repo}/contents/skills`;
-        await this.makeGitHubRequest(skillsUrl);
+        await this.getJson(this.buildContentsUrl(owner, repo, 'skills'));
         hasSkillsDir = true;
         this.logger.debug(`[SkillsAdapter] Found skills/ directory`);
       } catch (error) {
@@ -824,7 +640,7 @@ export class SkillsAdapter extends RepositoryAdapter {
   public getManifestUrl(bundleId: string, _version?: string): string {
     const { owner, repo } = this.parseGitHubUrl();
     const skillId = bundleId.replace(`skills-${owner}-${repo}-`, '');
-    return `https://raw.githubusercontent.com/${owner}/${repo}/main/skills/${skillId}/SKILL.md`;
+    return this.buildRawUrl(owner, repo, 'main', `skills/${skillId}/SKILL.md`);
   }
 
   /**

--- a/src/services/registry-manager.ts
+++ b/src/services/registry-manager.ts
@@ -1304,7 +1304,11 @@ export class RegistryManager {
     }
 
     const adapter = this.getAdapter(source);
-    const bundles = await adapter.fetchBundles();
+    const bundles = await adapter.fetchBundles(async (partial) => {
+      // Progressive update: cache what we have so far and notify the UI.
+      await this.storage.cacheSourceBundles(sourceId, partial);
+      this._onSourceSynced.fire({ sourceId, bundleCount: partial.length });
+    });
 
     // Reuse still-valid cached readmes so we only re-download when the source revision changed
     await this.reuseCachedReadmes(sourceId, bundles);

--- a/src/services/registry-manager.ts
+++ b/src/services/registry-manager.ts
@@ -1051,11 +1051,10 @@ export class RegistryManager {
    * Bundles whose `readmeRevision` differs (or is not provided by the adapter) are left without a
    * readme so {@link downloadReadmesConcurrently} re-downloads them. This keeps readmes fresh while
    * avoiding redundant downloads on every sync.
-   * @param sourceId - Source ID whose cache should be consulted
+   * @param cached - Snapshot of previously cached bundles, captured before this sync overwrote them
    * @param bundles - Freshly fetched bundles to enrich in place
    */
-  private async reuseCachedReadmes(sourceId: string, bundles: Bundle[]): Promise<void> {
-    const cached = await this.storage.getCachedSourceBundles(sourceId);
+  private reuseCachedReadmes(cached: Bundle[], bundles: Bundle[]): void {
     if (!cached || cached.length === 0) {
       return;
     }
@@ -1304,6 +1303,12 @@ export class RegistryManager {
     }
 
     const adapter = this.getAdapter(source);
+
+    // Snapshot the previously cached bundles BEFORE fetching: the progressive callback below
+    // overwrites the cache mid-fetch with readme-less partials, so reuseCachedReadmes must
+    // consult this pre-fetch snapshot rather than re-reading the (already clobbered) cache.
+    const previouslyCached = await this.storage.getCachedSourceBundles(sourceId);
+
     const bundles = await adapter.fetchBundles(async (partial) => {
       // Progressive update: cache what we have so far and notify the UI.
       await this.storage.cacheSourceBundles(sourceId, partial);
@@ -1311,7 +1316,7 @@ export class RegistryManager {
     });
 
     // Reuse still-valid cached readmes so we only re-download when the source revision changed
-    await this.reuseCachedReadmes(sourceId, bundles);
+    this.reuseCachedReadmes(previouslyCached, bundles);
 
     // Cache bundles
     await this.storage.cacheSourceBundles(sourceId, bundles);

--- a/src/storage/registry-storage.ts
+++ b/src/storage/registry-storage.ts
@@ -21,6 +21,7 @@ import {
 
 const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
+const rename = promisify(fs.rename);
 const mkdir = promisify(fs.mkdir);
 const readdir = promisify(fs.readdir);
 const unlink = promisify(fs.unlink);
@@ -365,7 +366,14 @@ export class RegistryStorage {
     const sanitizedId = this.sanitizeFilename(sourceId);
     const filepath = path.join(this.paths.sourcesCache, `${sanitizedId}.json`);
     const data = JSON.stringify(bundles, null, 2);
-    await writeFile(filepath, data, 'utf8');
+    // Write atomically: progressive sync calls this repeatedly while the UI reads
+    // the same file (see getCachedSourceBundles). A plain writeFile truncates then
+    // streams, so a concurrent read could see partial JSON and fail to parse,
+    // flickering the source to empty. Writing to a temp file then renaming makes
+    // every read observe either the old or the new content, never a partial one.
+    const tempPath = `${filepath}.${process.pid}.tmp`;
+    await writeFile(tempPath, data, 'utf8');
+    await rename(tempPath, filepath);
   }
 
   /**

--- a/src/ui/marketplace-view-provider.ts
+++ b/src/ui/marketplace-view-provider.ts
@@ -34,6 +34,9 @@ import {
   extractBundleSources,
 } from '../utils/filter-utils';
 import {
+  LeadingTrailingThrottle,
+} from '../utils/leading-trailing-throttle';
+import {
   Logger,
 } from '../utils/logger';
 import {
@@ -72,10 +75,47 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
 
   private _view?: vscode.WebviewView;
   private readonly logger: Logger;
-  private sourceSyncDebounceTimer?: NodeJS.Timeout;
+
+  private readonly sourceSyncThrottle = new LeadingTrailingThrottle(
+    () => void this.loadBundles(),
+    UI_CONSTANTS.SOURCE_SYNC_DEBOUNCE_MS
+  );
+
   private isLoadingBundles = false;
+  private loadBundlesPending = false;
   private disposables: vscode.Disposable[] = [];
   private markDownIt: InstanceType<typeof MarkdownIt> | undefined;
+  private readonly sanitizeOptions: sanitizeHtml.IOptions = {
+    allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img']),
+    allowedAttributes: {
+      ...sanitizeHtml.defaults.allowedAttributes,
+      a: ['href', 'title', 'data-external-link', 'rel', 'class'],
+      img: ['src', 'alt', 'title', 'width', 'height']
+    },
+    allowedSchemes: ['https', 'http', 'mailto'],
+    allowedSchemesByTag: {
+      img: ['https'],
+      a: ['https', 'http', 'mailto']
+    },
+    transformTags: {
+      a: (tagName, attribs) => {
+        const href = attribs.href;
+        if (href) {
+          const { href: _dropped, ...rest } = attribs;
+          return {
+            tagName,
+            attribs: {
+              ...rest,
+              'data-external-link': href,
+              class: rest.class ? `${rest.class} external-link` : 'external-link',
+              rel: 'noopener noreferrer'
+            }
+          };
+        }
+        return { tagName, attribs };
+      }
+    }
+  };
 
   constructor(
     private readonly context: vscode.ExtensionContext,
@@ -159,24 +199,7 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
    */
   private handleSourceSynced(event: { sourceId: string; bundleCount: number }): void {
     this.logger.debug(`Source synced: ${event.sourceId} (${event.bundleCount} bundles)`);
-
-    const isFirstEvent = !this.sourceSyncDebounceTimer;
-
-    // Clear existing timer if any
-    if (this.sourceSyncDebounceTimer) {
-      clearTimeout(this.sourceSyncDebounceTimer);
-    }
-
-    // Fire immediately on first event (leading edge)
-    if (isFirstEvent) {
-      void this.loadBundles();
-    }
-
-    // Set trailing edge timer
-    this.sourceSyncDebounceTimer = setTimeout(() => {
-      this.sourceSyncDebounceTimer = undefined;
-      void this.loadBundles();
-    }, UI_CONSTANTS.SOURCE_SYNC_DEBOUNCE_MS);
+    this.sourceSyncThrottle.trigger();
   }
 
   /**
@@ -189,27 +212,6 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
     }
     return this.markDownIt;
   }
-
-  // private handleReadmeDownloaded(sourceId: string, bundleIds: string[], panel: vscode.WebviewPanel): void {
-  //   // TODO handle render through the details view
-  //   // Handle messages from the details panel
-  //   panel.webview.onDidReceiveMessage(
-  //     async (message) => {
-  //       if (message.type === 'openPromptFile') {
-  //         await this.openPromptFileInEditor(message.installPath, message.filePath);
-  //       } else if (message.type === 'toggleAutoUpdate') {
-  //         await this.handleToggleAutoUpdate(message.bundleId, message.enabled);
-  //         // Update the panel with new status
-  //         if (installed) {
-  //           const newStatus = await this.registryManager.autoUpdateService?.isAutoUpdateEnabled(installed.bundleId) || false;
-  //           panel.webview.postMessage({ type: 'autoUpdateStatusChanged', enabled: newStatus });
-  //         }
-  //       }
-  //     },
-  //     undefined,
-  //     this.context.subscriptions
-  //   );
-  // }
 
   /**
    * Find installed bundle by marketplace bundle ID using identity matching
@@ -294,9 +296,13 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
    * Uses cacheOnly mode for fast initial load, then updates progressively via onSourceSynced events
    */
   private async loadBundles(): Promise<void> {
-    // Prevent concurrent loads to avoid UI flicker
+    // Coalesce concurrent loads: if a load is already running, mark that another
+    // is needed and re-run once after it finishes (see finally block). This keeps
+    // the throttle's trailing edge — and any other dropped request — self-healing,
+    // so freshly-cached bundles always render.
     if (this.isLoadingBundles) {
-      this.logger.debug('Skipping loadBundles - already loading');
+      this.loadBundlesPending = true;
+      this.logger.debug('loadBundles already running - scheduling a follow-up load');
       return;
     }
 
@@ -304,9 +310,11 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
     try {
       // Search for all bundles using cache only (non-blocking)
       // This ensures fast initial load - network fetches happen via syncSource which fires onSourceSynced
-      const bundles = await this.registryManager.searchBundles({ cacheOnly: true });
-      const installedBundles = await this.registryManager.listInstalledBundles();
-      const sources = await this.registryManager.listSources();
+      const [bundles, installedBundles, sources] = await Promise.all([
+        this.registryManager.searchBundles({ cacheOnly: true }),
+        this.registryManager.listInstalledBundles(),
+        this.registryManager.listSources()
+      ]);
       const autoUpdateService = this.registryManager.autoUpdateService;
 
       // Preload auto-update preferences once per refresh
@@ -383,6 +391,12 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
       this.logger.error('Failed to load marketplace bundles', error as Error);
     } finally {
       this.isLoadingBundles = false;
+      // A load was requested while this one was in flight — run exactly once more
+      // to pick up cache updates that arrived during this render.
+      if (this.loadBundlesPending) {
+        this.loadBundlesPending = false;
+        void this.loadBundles();
+      }
     }
   }
 
@@ -936,45 +950,7 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
   private getMarkdownRender(rawmarkdown: string): string {
     const md = this.getMarkdownItInstance();
     const html = md.render(rawmarkdown);
-    return sanitizeHtml(html, {
-      // 'a' is already part of the defaults; 'img' is added for inline images
-      allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img']),
-      allowedAttributes: {
-        ...sanitizeHtml.defaults.allowedAttributes,
-        a: ['href', 'title', 'data-external-link', 'rel', 'class'],
-        img: ['src', 'alt', 'title', 'width', 'height']
-      },
-      // Allow safe external link/image schemes — still blocks data: and javascript:
-      allowedSchemes: ['https', 'http', 'mailto'],
-      // Keep images HTTPS-only (matches the webview CSP `img-src https:`); links may
-      // additionally use http/mailto since they are opened via vscode.env.openExternal.
-      allowedSchemesByTag: {
-        img: ['https'],
-        a: ['https', 'http', 'mailto']
-      },
-      transformTags: {
-        // Move the link target into a data attribute and DROP the href. Keeping
-        // href would let VS Code's built-in webview link handling open the URL
-        // directly (bypassing our confirmation prompt). The webview JS reads
-        // data-external-link on click and routes through vscode.env.openExternal.
-        a: (tagName, attribs) => {
-          const href = attribs.href;
-          if (href) {
-            const { href: _dropped, ...rest } = attribs;
-            return {
-              tagName,
-              attribs: {
-                ...rest,
-                'data-external-link': href,
-                class: rest.class ? `${rest.class} external-link` : 'external-link',
-                rel: 'noopener noreferrer'
-              }
-            };
-          }
-          return { tagName, attribs };
-        }
-      }
-    });
+    return sanitizeHtml(html, this.sanitizeOptions);
   }
 
   /**
@@ -1100,12 +1076,10 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
     // Replace all placeholders
     html = html
       .replace('{{cspSource}}', cspSource)
-      .replace('{{bundleName}}', this.escapeHtml(bundle.name))
-      .replace('{{bundleName}}', this.escapeHtml(bundle.name))
+      .replaceAll('{{bundleName}}', this.escapeHtml(bundle.name))
       .replace('{{cssUri}}', cssUri.toString())
       .replace('{{installedBadge}}', installedBadge)
-      .replace('{{author}}', this.escapeHtml(bundle.author || 'Unknown'))
-      .replace('{{author}}', this.escapeHtml(bundle.author || 'Unknown'))
+      .replaceAll('{{author}}', this.escapeHtml(bundle.author || 'Unknown'))
       .replace('{{version}}', bundle.version)
       .replace('{{autoUpdateSection}}', autoUpdateSection)
       .replace('{{description}}', bundle.description || 'No description available')
@@ -1310,10 +1284,7 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
    * Dispose of resources
    */
   public dispose(): void {
-    // Clear debounce timer
-    if (this.sourceSyncDebounceTimer) {
-      clearTimeout(this.sourceSyncDebounceTimer);
-    }
+    this.sourceSyncThrottle.dispose();
 
     // Dispose all event listeners
     this.disposables.forEach((d) => d.dispose());

--- a/src/ui/registry-tree-provider.ts
+++ b/src/ui/registry-tree-provider.ts
@@ -23,6 +23,9 @@ import {
   UI_CONSTANTS,
 } from '../utils/constants';
 import {
+  LeadingTrailingThrottle,
+} from '../utils/leading-trailing-throttle';
+import {
   Logger,
 } from '../utils/logger';
 
@@ -274,7 +277,12 @@ export class RegistryTreeProvider implements vscode.TreeDataProvider<RegistryTre
 
   private readonly logger: Logger;
   private readonly availableUpdates: Map<string, UpdateCheckResult> = new Map();
-  private sourceSyncDebounceTimer?: NodeJS.Timeout;
+
+  private readonly sourceSyncThrottle = new LeadingTrailingThrottle(
+    () => this.refresh(),
+    UI_CONSTANTS.SOURCE_SYNC_DEBOUNCE_MS
+  );
+
   private disposables: vscode.Disposable[] = [];
 
   private viewMode: 'all' | 'favorites' = 'all';
@@ -329,17 +337,7 @@ export class RegistryTreeProvider implements vscode.TreeDataProvider<RegistryTre
    */
   private handleSourceSynced(event: { sourceId: string; bundleCount: number }): void {
     this.logger.debug(`Source synced: ${event.sourceId} (${event.bundleCount} bundles)`);
-
-    // Clear existing timer
-    if (this.sourceSyncDebounceTimer) {
-      clearTimeout(this.sourceSyncDebounceTimer);
-    }
-
-    // Set new timer with shared debounce delay
-    this.sourceSyncDebounceTimer = setTimeout(() => {
-      this.logger.debug('Refreshing tree view after source sync');
-      this.refresh();
-    }, UI_CONSTANTS.SOURCE_SYNC_DEBOUNCE_MS);
+    this.sourceSyncThrottle.trigger();
   }
 
   /**
@@ -1021,10 +1019,7 @@ export class RegistryTreeProvider implements vscode.TreeDataProvider<RegistryTre
    * Dispose of resources
    */
   public dispose(): void {
-    // Clear debounce timer
-    if (this.sourceSyncDebounceTimer) {
-      clearTimeout(this.sourceSyncDebounceTimer);
-    }
+    this.sourceSyncThrottle.dispose();
 
     // Dispose all event listeners
     this.disposables.forEach((d) => d.dispose());

--- a/src/ui/webview/bundle-details/bundle-details.js
+++ b/src/ui/webview/bundle-details/bundle-details.js
@@ -54,10 +54,7 @@
       var readmeContent = document.querySelector('.details-content');
       if (readmeContent) {
         readmeContent.innerHTML = message.readmeHtml;
-        var readmeSection = document.querySelector('#readme-section');
-        if (readmeSection) {
-          readmeSection.style.display = '';
-        }
+        readmeContent.closest('#readme-section')?.removeAttribute('style');
       }
     }
   });

--- a/src/utils/leading-trailing-throttle.ts
+++ b/src/utils/leading-trailing-throttle.ts
@@ -1,0 +1,49 @@
+/**
+ * Leading + trailing edge throttle.
+ *
+ * Runs the action immediately on the first trigger of a burst (leading edge),
+ * then once more after `delayMs` of quiet following the last trigger (trailing
+ * edge). Resetting the timer on every trigger means the trailing edge always
+ * fires after the last event settles — important when the action reads a file
+ * that is still being written during the burst.
+ *
+ * Used by the tree and marketplace views to rate-limit refreshes while a source
+ * streams many partial sync events.
+ */
+export class LeadingTrailingThrottle {
+  private timer?: NodeJS.Timeout;
+
+  constructor(
+    private readonly action: () => void,
+    private readonly delayMs: number
+  ) {}
+
+  /**
+   * Signal an event. Fires the action on the leading edge of a burst and
+   * schedules a single trailing-edge run after the burst goes quiet.
+   */
+  public trigger(): void {
+    const isFirstEvent = !this.timer;
+
+    if (this.timer) {
+      clearTimeout(this.timer);
+    }
+
+    if (isFirstEvent) {
+      this.action(); // leading edge
+    }
+
+    this.timer = setTimeout(() => {
+      this.timer = undefined;
+      this.action(); // trailing edge — fires after the last event settles
+    }, this.delayMs);
+  }
+
+  /** Cancel any pending trailing-edge run. */
+  public dispose(): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+  }
+}

--- a/src/utils/leading-trailing-throttle.ts
+++ b/src/utils/leading-trailing-throttle.ts
@@ -1,26 +1,47 @@
 /**
- * Leading + trailing edge throttle.
+ * Leading + trailing edge throttle with a periodic max-wait flush.
  *
  * Runs the action immediately on the first trigger of a burst (leading edge),
  * then once more after `delayMs` of quiet following the last trigger (trailing
- * edge). Resetting the timer on every trigger means the trailing edge always
- * fires after the last event settles — important when the action reads a file
- * that is still being written during the burst.
+ * edge). Resetting the trailing timer on every trigger means the trailing edge
+ * always fires after the last event settles — important when the action reads a
+ * file that is still being written during the burst.
+ *
+ * A dense, sustained burst never lets the quiet window elapse, so leading +
+ * trailing alone would collapse the whole burst into just two runs — the UI
+ * appears frozen throughout. To avoid that, a periodic max-wait flush fires the
+ * action every `maxWaitMs` for as long as the burst stays active, then stops
+ * once the burst goes quiet (at the trailing edge).
  *
  * Used by the tree and marketplace views to rate-limit refreshes while a source
  * streams many partial sync events.
  */
 export class LeadingTrailingThrottle {
   private timer?: NodeJS.Timeout;
+  private maxWaitTimer?: NodeJS.Timeout;
+  private readonly maxWaitMs: number;
 
   constructor(
     private readonly action: () => void,
-    private readonly delayMs: number
-  ) {}
+    private readonly delayMs: number,
+    maxWaitMs?: number
+  ) {
+    // Default the max-wait to twice the quiet window so a sustained burst still
+    // refreshes periodically without callers needing to opt in.
+    this.maxWaitMs = maxWaitMs ?? delayMs * 2;
+  }
+
+  private clearMaxWaitTimer(): void {
+    if (this.maxWaitTimer) {
+      clearInterval(this.maxWaitTimer);
+      this.maxWaitTimer = undefined;
+    }
+  }
 
   /**
-   * Signal an event. Fires the action on the leading edge of a burst and
-   * schedules a single trailing-edge run after the burst goes quiet.
+   * Signal an event. Fires the action on the leading edge of a burst, schedules
+   * a single trailing-edge run after the burst goes quiet, and — while the burst
+   * remains active — flushes the action periodically every `maxWaitMs`.
    */
   public trigger(): void {
     const isFirstEvent = !this.timer;
@@ -33,17 +54,28 @@ export class LeadingTrailingThrottle {
       this.action(); // leading edge
     }
 
+    // Keep a periodic flush running for the duration of the burst so a dense
+    // stream of triggers produces intermediate refreshes, not just leading +
+    // trailing. Cleared at the trailing edge (below) once the burst goes quiet.
+    if (!this.maxWaitTimer) {
+      this.maxWaitTimer = setInterval(() => {
+        this.action(); // periodic max-wait flush
+      }, this.maxWaitMs);
+    }
+
     this.timer = setTimeout(() => {
       this.timer = undefined;
+      this.clearMaxWaitTimer();
       this.action(); // trailing edge — fires after the last event settles
     }, this.delayMs);
   }
 
-  /** Cancel any pending trailing-edge run. */
+  /** Cancel any pending trailing-edge and periodic-flush runs. */
   public dispose(): void {
     if (this.timer) {
       clearTimeout(this.timer);
       this.timer = undefined;
     }
+    this.clearMaxWaitTimer();
   }
 }

--- a/test/adapters/awesome-copilot-adapter.test.ts
+++ b/test/adapters/awesome-copilot-adapter.test.ts
@@ -323,6 +323,76 @@ items:
       // Content types should be inferred from file extensions
     });
   });
+
+  suite('fetchBundles() — progressive streaming', () => {
+    // Use 12 collections so we always exceed the concurrency limit (5) and get 3 chunks.
+    const setupCollectionMocks = (count: number): void => {
+      const files = Array.from({ length: count }, (_, i) => ({
+        name: `col-${i}.collection.yml`,
+        type: 'file',
+        download_url: `https://raw.githubusercontent.com/test-owner/awesome-copilot/main/collections/col-${i}.collection.yml`
+      }));
+
+      nock('https://api.github.com')
+        .get('/repos/test-owner/awesome-copilot/contents/collections?ref=main')
+        .reply(200, files);
+
+      for (let i = 0; i < count; i++) {
+        nock('https://raw.githubusercontent.com')
+          .get(`/test-owner/awesome-copilot/main/collections/col-${i}.collection.yml`)
+          .reply(200, `id: col-${i}\nname: Collection ${i}\ndescription: Desc ${i}\ntags: []\nitems: []\n`);
+      }
+
+      // fetchBundles stamps readmeRevision from the branch head sha after the chunk loop.
+      nock('https://api.github.com')
+        .get('/repos/test-owner/awesome-copilot/commits/main')
+        .reply(200, { sha: 'branch-sha' });
+    };
+
+    test('calls onPartialBundles more than once when collections exceed one chunk', async () => {
+      setupCollectionMocks(12);
+
+      const adapter = new AwesomeCopilotAdapter(mockSource);
+      const snapshots: number[] = [];
+
+      await adapter.fetchBundles((partial) => {
+        snapshots.push(partial.length);
+      });
+
+      assert.ok(snapshots.length > 1, `Expected >1 callback invocation, got ${snapshots.length}`);
+    });
+
+    test('each partial payload is monotonically non-decreasing and a distinct array', async () => {
+      setupCollectionMocks(12);
+
+      const adapter = new AwesomeCopilotAdapter(mockSource);
+      const refs: Bundle[][] = [];
+
+      await adapter.fetchBundles((partial) => {
+        refs.push(partial);
+      });
+
+      for (let i = 1; i < refs.length; i++) {
+        assert.ok(refs[i].length >= refs[i - 1].length, `Expected non-decreasing lengths: ${refs.map((r) => r.length).join(', ')}`);
+        assert.notStrictEqual(refs[i], refs[i - 1], 'Each callback invocation should receive a distinct array');
+      }
+    });
+
+    test('final bundle set is identical with or without callback', async () => {
+      setupCollectionMocks(12);
+      const withoutCb = await new AwesomeCopilotAdapter(mockSource).fetchBundles();
+
+      nock.cleanAll();
+      setupCollectionMocks(12);
+      const withCb = await new AwesomeCopilotAdapter(mockSource).fetchBundles(() => {});
+
+      assert.strictEqual(withCb.length, withoutCb.length, 'Bundle count must be identical with or without callback');
+      const withoutIds = new Set(withoutCb.map((b) => b.id));
+      for (const bundle of withCb) {
+        assert.ok(withoutIds.has(bundle.id), `Bundle ${bundle.id} present with callback but missing without`);
+      }
+    });
+  });
 });
 
 suite('Skill Kind Support', () => {

--- a/test/adapters/github-adapter.property.test.ts
+++ b/test/adapters/github-adapter.property.test.ts
@@ -232,7 +232,7 @@ suite('GitHubAdapter Property-Based Tests', () => {
 
           // Attempt to make a request
           try {
-            await (adapter as any).makeRequest('https://api.github.com/test');
+            await (adapter as any).getJson('https://api.github.com/test');
 
             // Success expected for JSON responses
             if (!config.contentType.includes('application/json') && config.statusCode === 200) {
@@ -276,7 +276,7 @@ suite('GitHubAdapter Property-Based Tests', () => {
 
           // Attempt to make a request
           try {
-            await (adapter as any).makeRequest('https://api.github.com/test');
+            await (adapter as any).getJson('https://api.github.com/test');
             assert.fail('HTML response should be recognized as error');
           } catch (error: unknown) {
             const err = error as Error;
@@ -318,7 +318,7 @@ suite('GitHubAdapter Property-Based Tests', () => {
           stubHttpsWithResponse(sandbox, 401, htmlBody, 'text/html');
 
           try {
-            await (adapter as any).makeRequest('https://api.github.com/test');
+            await (adapter as any).getJson('https://api.github.com/test');
             assert.fail('Should have thrown error for HTML response');
           } catch (error: unknown) {
             const err = error as Error;
@@ -359,7 +359,7 @@ suite('GitHubAdapter Property-Based Tests', () => {
           stubHttpsWithResponse(sandbox, config.statusCode, htmlContent, 'text/html');
 
           try {
-            await (adapter as any).makeRequest('https://api.github.com/test');
+            await (adapter as any).getJson('https://api.github.com/test');
             assert.fail('Should have thrown error for HTML response');
           } catch (error: unknown) {
             const err = error as Error;
@@ -398,7 +398,7 @@ suite('GitHubAdapter Property-Based Tests', () => {
 
           // Attempt to make a request
           try {
-            await (adapter as any).makeRequest('https://api.github.com/test');
+            await (adapter as any).getJson('https://api.github.com/test');
           } catch (error: unknown) {
             const err = error as Error;
 
@@ -439,7 +439,7 @@ suite('GitHubAdapter Property-Based Tests', () => {
           loggerHelpers.resetHistory();
 
           try {
-            await (adapter as any).makeRequest(testUrl);
+            await (adapter as any).getJson(testUrl);
             assert.fail('Should have thrown error');
           } catch {
             const errorCalls = loggerStub.error.getCalls();
@@ -518,7 +518,7 @@ suite('GitHubAdapter Property-Based Tests', () => {
           stubHttpsWithResponse(sandbox, config.statusCode);
 
           try {
-            await (adapter as any).makeRequest('https://api.github.com/test');
+            await (adapter as any).getJson('https://api.github.com/test');
             assert.fail('Should have thrown error');
           } catch (error: unknown) {
             const err = error as Error;
@@ -565,7 +565,7 @@ suite('GitHubAdapter Property-Based Tests', () => {
           stubHttpsWithResponse(sandbox, 401, JSON.stringify({ message: 'Bad credentials' }));
 
           try {
-            await (adapter as any).makeRequest('https://api.github.com/test');
+            await (adapter as any).getJson('https://api.github.com/test');
             assert.fail('Should have thrown error after exhausting methods');
           } catch (error: unknown) {
             const err = error as Error;

--- a/test/adapters/github-adapter.test.ts
+++ b/test/adapters/github-adapter.test.ts
@@ -9,6 +9,7 @@ import {
   GitHubAdapter,
 } from '../../src/adapters/github-adapter';
 import {
+  Bundle,
   RegistrySource,
 } from '../../src/types/registry';
 import {
@@ -1114,6 +1115,91 @@ tags:
       assert.strictEqual(bundles[0].readmeUrl, undefined, 'readmeUrl should be undefined when manifest omits readme');
       const readmeContent = await adapter.downloadReadme(bundles[0]);
       assert.strictEqual(readmeContent, null);
+    });
+  });
+
+  suite('fetchBundles() — progressive streaming', () => {
+    // Use 25 releases so we always exceed MANIFEST_DOWNLOAD_CONCURRENCY (10) and get 3 chunks.
+    const setupReleaseMocks = (count: number): void => {
+      const releases = Array.from({ length: count }, (_, i) => ({
+        tag_name: `v1.0.${i}`,
+        name: `Release 1.0.${i}`,
+        published_at: '2025-01-01T00:00:00Z',
+        assets: [
+          { name: 'deployment-manifest.json', url: `https://api.github.com/repos/test-owner/test-repo/releases/assets/${100 + i}`, size: 1024 },
+          { name: 'bundle.zip', url: `https://api.github.com/repos/test-owner/test-repo/releases/assets/${200 + i}`, size: 2048 }
+        ]
+      }));
+
+      nock('https://api.github.com')
+        .get('/repos/test-owner/test-repo/releases')
+        .reply(200, releases);
+
+      for (let i = 0; i < count; i++) {
+        nock('https://api.github.com')
+          .get(`/repos/test-owner/test-repo/releases/assets/${100 + i}`)
+          .reply(200, JSON.stringify({ id: `bundle-${i}`, name: `Bundle ${i}`, version: `1.0.${i}` }));
+      }
+    };
+
+    test('calls onPartialBundles more than once when releases exceed one chunk', async () => {
+      setupReleaseMocks(25);
+
+      const adapter = new GitHubAdapter(mockSource);
+      const snapshots: number[] = [];
+
+      await adapter.fetchBundles((partial) => {
+        snapshots.push(partial.length);
+      });
+
+      assert.ok(snapshots.length > 1, `Expected >1 callback invocation, got ${snapshots.length}`);
+    });
+
+    test('each partial payload is monotonically non-decreasing and a distinct array', async () => {
+      setupReleaseMocks(25);
+
+      const adapter = new GitHubAdapter(mockSource);
+      const refs: Bundle[][] = [];
+
+      await adapter.fetchBundles((partial) => {
+        refs.push(partial);
+      });
+
+      for (let i = 1; i < refs.length; i++) {
+        assert.ok(refs[i].length >= refs[i - 1].length, `Expected non-decreasing lengths: ${refs.map((r) => r.length).join(', ')}`);
+        assert.notStrictEqual(refs[i], refs[i - 1], 'Each callback invocation should receive a distinct array');
+      }
+    });
+
+    test('final returned bundles equal the last partial payload', async () => {
+      setupReleaseMocks(25);
+
+      const adapter = new GitHubAdapter(mockSource);
+      let lastPartial: Bundle[] = [];
+
+      const finalBundles = await adapter.fetchBundles((partial) => {
+        lastPartial = partial;
+      });
+
+      assert.strictEqual(finalBundles.length, lastPartial.length);
+      for (const bundle of finalBundles) {
+        assert.ok(lastPartial.some((b) => b.id === bundle.id), `Bundle ${bundle.id} missing from last partial`);
+      }
+    });
+
+    test('final bundle set is identical with or without callback', async () => {
+      setupReleaseMocks(25);
+      const withoutCb = await new GitHubAdapter(mockSource).fetchBundles();
+
+      nock.cleanAll();
+      setupReleaseMocks(25);
+      const withCb = await new GitHubAdapter(mockSource).fetchBundles(() => {});
+
+      assert.strictEqual(withCb.length, withoutCb.length, 'Bundle count must be identical with or without callback');
+      const withoutIds = new Set(withoutCb.map((b) => b.id));
+      for (const bundle of withCb) {
+        assert.ok(withoutIds.has(bundle.id), `Bundle ${bundle.id} present with callback but missing without`);
+      }
     });
   });
 });

--- a/test/adapters/skills-adapter.test.ts
+++ b/test/adapters/skills-adapter.test.ts
@@ -322,8 +322,14 @@ suite('SkillsAdapter Tests', () => {
       nock('https://api.github.com')
         .get('/repos/test-owner/test-skills-repo/contents/skills')
         .reply(200, []);
-      // Tree scan returns one skill
-      setupSkillsTreeMocks([{ id: 'test-skill', name: 'test-skill', description: 'Test skill' }]);
+      // Tree scan returns one skill (no raw SKILL.md interceptor registered — validate must not fetch it)
+      nock('https://api.github.com')
+        .get('/repos/test-owner/test-skills-repo/git/trees/main?recursive=1')
+        .reply(200, { tree: [{ path: 'skills/test-skill/SKILL.md', type: 'blob', sha: 'sha-test' }], truncated: false });
+      // Register a raw SKILL.md scope; assert it is NOT consumed (validate must not download SKILL.md)
+      const rawScope = nock('https://raw.githubusercontent.com')
+        .get('/test-owner/test-skills-repo/main/skills/test-skill/SKILL.md')
+        .reply(200, '---\nname: test-skill\ndescription: Test skill\n---\n\nInstructions');
 
       const adapter = new SkillsAdapter(mockSource);
       const result = await adapter.validate();
@@ -331,6 +337,7 @@ suite('SkillsAdapter Tests', () => {
       assert.strictEqual(result.valid, true);
       assert.strictEqual(result.errors.length, 0);
       assert.strictEqual(result.bundlesFound, 1);
+      assert.ok(!rawScope.isDone(), 'validate() must not download SKILL.md files');
     });
 
     test('should fail validation when skills/ directory is missing', async () => {
@@ -383,6 +390,101 @@ suite('SkillsAdapter Tests', () => {
       const url = adapter.getDownloadUrl('skills-test-owner-test-skills-repo-algorithmic-art');
 
       assert.strictEqual(url, 'https://github.com/test-owner/test-skills-repo/archive/refs/heads/main.zip');
+    });
+  });
+
+  suite('fetchBundles() — progressive streaming', () => {
+    // Use 20 skills so we always exceed the current CONCURRENCY_LIMIT (15) and get 2+ chunks.
+    const makeSkills = (count: number) =>
+      Array.from({ length: count }, (_, i) => ({
+        id: `skill-${i}`,
+        name: `Skill ${i}`,
+        description: `Description ${i}`
+      }));
+
+    test('calls onPartialBundles more than once when skills exceed one chunk', async () => {
+      setupSkillsTreeMocks(makeSkills(20));
+
+      const adapter = new SkillsAdapter(mockSource);
+      const snapshots: number[] = [];
+
+      await adapter.fetchBundles((partial) => {
+        snapshots.push(partial.length);
+      });
+
+      assert.ok(snapshots.length > 1, `Expected >1 callback invocation, got ${snapshots.length}`);
+    });
+
+    test('each partial payload is monotonically non-decreasing in length', async () => {
+      setupSkillsTreeMocks(makeSkills(20));
+
+      const adapter = new SkillsAdapter(mockSource);
+      const snapshots: number[] = [];
+
+      await adapter.fetchBundles((partial) => {
+        snapshots.push(partial.length);
+      });
+
+      for (let i = 1; i < snapshots.length; i++) {
+        assert.ok(
+          snapshots[i] >= snapshots[i - 1],
+          `Expected non-decreasing lengths: ${snapshots.join(', ')}`
+        );
+      }
+    });
+
+    test('each partial payload is a distinct array (snapshot, not shared mutable ref)', async () => {
+      setupSkillsTreeMocks(makeSkills(20));
+
+      const adapter = new SkillsAdapter(mockSource);
+      const refs: unknown[][] = [];
+
+      await adapter.fetchBundles((partial) => {
+        refs.push(partial);
+      });
+
+      // All collected refs must be distinct array instances
+      for (let i = 0; i < refs.length; i++) {
+        for (let j = i + 1; j < refs.length; j++) {
+          assert.notStrictEqual(refs[i], refs[j], 'Each callback invocation should receive a distinct array');
+        }
+      }
+    });
+
+    test('final returned bundles equal the last partial payload', async () => {
+      setupSkillsTreeMocks(makeSkills(20));
+
+      const adapter = new SkillsAdapter(mockSource);
+      let lastPartial: unknown[] = [];
+
+      const finalBundles = await adapter.fetchBundles((partial) => {
+        lastPartial = partial;
+      });
+
+      assert.strictEqual(finalBundles.length, lastPartial.length);
+      for (const bundle of finalBundles) {
+        assert.ok(lastPartial.some((b: any) => b.id === bundle.id), `Bundle ${bundle.id} missing from last partial`);
+      }
+    });
+
+    test('final bundle set is identical with or without callback (regression for concurrency change)', async () => {
+      const skills = makeSkills(20);
+
+      // Without callback
+      setupSkillsTreeMocks(skills);
+      const withoutCb = await new SkillsAdapter(mockSource).fetchBundles();
+
+      // With callback
+      nock.cleanAll();
+      setupSkillsTreeMocks(skills);
+      const withCb = await new SkillsAdapter(mockSource).fetchBundles(() => {});
+
+      assert.strictEqual(withCb.length, withoutCb.length, 'Bundle count must be identical with or without callback');
+
+      const withoutIds = new Set(withoutCb.map((b) => b.id));
+      for (const bundle of withCb) {
+        assert.ok(withoutIds.has(bundle.id), `Bundle ${bundle.id} present with callback but missing without`);
+      }
     });
   });
 });

--- a/test/helpers/ui-test-helpers.ts
+++ b/test/helpers/ui-test-helpers.ts
@@ -34,8 +34,22 @@ const REGISTRY_MANAGER_EVENTS = [
   'onSourceUpdated',
   'onSourceSynced',
   'onAutoUpdatePreferenceChanged',
-  'onRepositoryBundlesChanged'
+  'onRepositoryBundlesChanged',
+  'onReadmeDownloaded',
+  'onReadmeDownloadComplete'
 ] as const;
+
+/** Name of a RegistryManager event emitter. */
+export type RegistryManagerEvent = (typeof REGISTRY_MANAGER_EVENTS)[number];
+
+/**
+ * Optional per-event capture callbacks. When provided for an event, the mock
+ * invokes the capture with the subscriber's callback so tests can drive the
+ * event later (e.g. `{ onSourceSynced: (cb) => { captured = cb; } }`).
+ */
+export type RegistryManagerEventCaptures = Partial<
+  Record<RegistryManagerEvent, (callback: any) => void>
+>;
 
 /**
  * All event emitter names that HubManager exposes.
@@ -61,21 +75,35 @@ function createDisposableStub(sandbox: sinon.SinonSandbox): sinon.SinonStub {
  *
  * This ensures that RegistryTreeProvider and other UI components can
  * subscribe to events without throwing errors.
- * @param registryManagerStub - The sinon stub instance of RegistryManager
+ * @param registryManagerStub - The sinon stub instance (or plain mock) of RegistryManager
  * @param sandbox - The sinon sandbox to use for creating stubs
+ * @param captures - Optional per-event capture callbacks; when provided for an
+ *   event, the mock invokes the capture with the subscriber's callback so the
+ *   test can drive the event later
  * @example
  * ```typescript
  * const sandbox = sinon.createSandbox();
  * const registryManagerStub = sandbox.createStubInstance(RegistryManager);
  * setupRegistryManagerEventMocks(registryManagerStub, sandbox);
+ *
+ * // Capturing a callback to fire it manually:
+ * let onSourceSynced;
+ * setupRegistryManagerEventMocks(mock, sandbox, { onSourceSynced: (cb) => { onSourceSynced = cb; } });
  * ```
  */
 export function setupRegistryManagerEventMocks(
-    registryManagerStub: sinon.SinonStubbedInstance<RegistryManager>,
-    sandbox: sinon.SinonSandbox
+    registryManagerStub: sinon.SinonStubbedInstance<RegistryManager> | Record<string, unknown>,
+    sandbox: sinon.SinonSandbox,
+    captures: RegistryManagerEventCaptures = {}
 ): void {
   for (const eventName of REGISTRY_MANAGER_EVENTS) {
-    (registryManagerStub as any)[eventName] = createDisposableStub(sandbox);
+    const capture = captures[eventName];
+    (registryManagerStub as any)[eventName] = capture
+      ? sandbox.stub().callsFake((callback: any) => {
+        capture(callback);
+        return { dispose: () => {} };
+      })
+      : createDisposableStub(sandbox);
   }
 }
 

--- a/test/services/registry-manager.eventHandling.test.ts
+++ b/test/services/registry-manager.eventHandling.test.ts
@@ -9,9 +9,20 @@ import * as assert from 'node:assert';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import {
+  RegistryManager,
+} from '../../src/services/registry-manager';
+import {
+  RegistryStorage,
+} from '../../src/storage/registry-storage';
+import {
+  Bundle,
   DeploymentManifest,
   InstalledBundle,
+  RegistrySource,
 } from '../../src/types/registry';
+import {
+  BundleBuilder,
+} from '../helpers/bundle-test-helpers';
 
 // Helper to create mock manifest
 function createMockManifest(): DeploymentManifest {
@@ -245,5 +256,132 @@ suite('RegistryManager - Event Handling', () => {
       assert.strictEqual(eventData?.sourceId, 'empty-source', 'Event should contain correct source ID');
       assert.strictEqual(eventData?.bundleCount, 0, 'Event should contain zero bundle count');
     });
+  });
+});
+
+suite('RegistryManager - Progressive syncSource', () => {
+  let sandbox: sinon.SinonSandbox;
+  let manager: RegistryManager;
+  let mockStorage: sinon.SinonStubbedInstance<RegistryStorage>;
+
+  const testSource: RegistrySource = {
+    id: 'progressive-source',
+    name: 'Progressive Source',
+    type: 'skills',
+    url: 'https://github.com/owner/skills-repo',
+    enabled: true,
+    priority: 1
+  };
+
+  const makeBundles = (count: number): Bundle[] =>
+    Array.from({ length: count }, () =>
+      BundleBuilder.github('owner', 'skills-repo').withVersion('1.0.0').build()
+    );
+
+  setup(() => {
+    sandbox = sinon.createSandbox();
+
+    const mockContext: any = {
+      globalState: {
+        get: sandbox.stub().returns(undefined),
+        update: sandbox.stub().resolves(),
+        keys: sandbox.stub().returns([]),
+        setKeysForSync: sandbox.stub()
+      },
+      workspaceState: {
+        get: sandbox.stub().returns(undefined),
+        update: sandbox.stub().resolves(),
+        keys: sandbox.stub().returns([]),
+        setKeysForSync: sandbox.stub()
+      },
+      subscriptions: [],
+      extensionPath: '/mock/path',
+      extensionUri: vscode.Uri.file('/mock/path'),
+      storageUri: vscode.Uri.file('/mock/storage'),
+      globalStorageUri: vscode.Uri.file('/mock/global'),
+      asAbsolutePath: (p: string) => `/mock/path/${p}`
+    };
+
+    manager = RegistryManager.getInstance(mockContext);
+
+    mockStorage = sandbox.createStubInstance(RegistryStorage);
+    mockStorage.getSources.resolves([testSource]);
+    mockStorage.getInstalledBundles.resolves([]);
+    mockStorage.getProfiles.resolves([]);
+    mockStorage.cacheSourceBundles.resolves();
+    (manager as any).storage = mockStorage;
+  });
+
+  teardown(() => {
+    sandbox.restore();
+  });
+
+  test('onSourceSynced fires per batch when adapter invokes callback multiple times', async () => {
+    const batch1 = makeBundles(15);
+    const batch2 = [...batch1, ...makeBundles(5)];
+
+    // Stub adapter that calls onPartialBundles twice then returns full list
+    const fakeAdapter = {
+      fetchBundles: async (onPartial?: (b: Bundle[]) => void | Promise<void>) => {
+        if (onPartial) {
+          await onPartial(batch1);
+          await onPartial(batch2);
+        }
+        return batch2;
+      }
+    };
+    (manager as any).adapters.set(testSource.id, fakeAdapter);
+
+    const firedCounts: number[] = [];
+    const disposable = manager.onSourceSynced((event) => {
+      if (event.sourceId === testSource.id) {
+        firedCounts.push(event.bundleCount);
+      }
+    });
+
+    try {
+      await manager.syncSource(testSource.id);
+    } finally {
+      disposable.dispose();
+    }
+
+    // Should fire at least once for each batch callback invocation (plus the final fire)
+    assert.ok(
+      firedCounts.length >= 2,
+      `Expected ≥2 onSourceSynced fires, got ${firedCounts.length}: [${firedCounts.join(', ')}]`
+    );
+  });
+
+  test('cacheSourceBundles is called incrementally with growing arrays', async () => {
+    const batch1 = makeBundles(15);
+    const batch2 = [...batch1, ...makeBundles(5)];
+
+    const fakeAdapter = {
+      fetchBundles: async (onPartial?: (b: Bundle[]) => void | Promise<void>) => {
+        if (onPartial) {
+          await onPartial(batch1);
+          await onPartial(batch2);
+        }
+        return batch2;
+      }
+    };
+    (manager as any).adapters.set(testSource.id, fakeAdapter);
+
+    await manager.syncSource(testSource.id);
+
+    // cacheSourceBundles should have been called multiple times (per batch + final)
+    assert.ok(
+      mockStorage.cacheSourceBundles.callCount >= 2,
+      `Expected ≥2 cacheSourceBundles calls, got ${mockStorage.cacheSourceBundles.callCount}`
+    );
+
+    // Each call should have non-decreasing bundle counts
+    const callArgs = mockStorage.cacheSourceBundles.args.map(([, bundles]) => bundles.length);
+    for (let i = 1; i < callArgs.length; i++) {
+      assert.ok(
+        callArgs[i] >= callArgs[i - 1],
+        `cacheSourceBundles call counts should be non-decreasing: ${callArgs.join(', ')}`
+      );
+    }
   });
 });

--- a/test/ui/marketplace-view-provider.eventHandling.test.ts
+++ b/test/ui/marketplace-view-provider.eventHandling.test.ts
@@ -21,6 +21,11 @@ import {
 import {
   MarketplaceViewProvider,
 } from '../../src/ui/marketplace-view-provider';
+import {
+  setupRegistryManagerEventMocks,
+} from '../helpers/ui-test-helpers';
+
+const PROJECT_ROOT = process.cwd();
 
 // Helper to create mock manifest
 function createMockManifest(): DeploymentManifest {
@@ -69,31 +74,24 @@ suite('MarketplaceViewProvider - Event Handling', () => {
       extensionMode: 2 // ExtensionMode.Test
     } as any;
 
-    // Create mock RegistryManager with event emitters
+    // Create mock RegistryManager with event emitters, capturing the callbacks
+    // this suite drives directly.
     mockRegistryManager = {
-      onBundleInstalled: sandbox.stub().callsFake((callback) => {
-        onBundleInstalledCallback = callback;
-        return { dispose: () => {} };
-      }),
-      onBundleUninstalled: sandbox.stub().callsFake((callback) => {
-        onBundleUninstalledCallback = callback;
-        return { dispose: () => {} };
-      }),
-      onBundleUpdated: sandbox.stub().callsFake((callback) => {
-        onBundleUpdatedCallback = callback;
-        return { dispose: () => {} };
-      }),
-      onBundlesInstalled: sandbox.stub().returns({ dispose: () => {} }),
-      onBundlesUninstalled: sandbox.stub().returns({ dispose: () => {} }),
-      onSourceSynced: sandbox.stub().returns({ dispose: () => {} }),
-      onAutoUpdatePreferenceChanged: sandbox.stub().returns({ dispose: () => {} }),
-      onRepositoryBundlesChanged: sandbox.stub().returns({ dispose: () => {} }),
-      onReadmeDownloaded: sandbox.stub().returns({ dispose: () => {} }),
-      onReadmeDownloadComplete: sandbox.stub().returns({ dispose: () => {} }),
       searchBundles: sandbox.stub().resolves([]),
       listInstalledBundles: sandbox.stub().resolves([]),
       listSources: sandbox.stub().resolves([])
     } as any;
+    setupRegistryManagerEventMocks(mockRegistryManager, sandbox, {
+      onBundleInstalled: (cb) => {
+        onBundleInstalledCallback = cb;
+      },
+      onBundleUninstalled: (cb) => {
+        onBundleUninstalledCallback = cb;
+      },
+      onBundleUpdated: (cb) => {
+        onBundleUpdatedCallback = cb;
+      }
+    });
 
     // Create mock SetupStateManager
     mockSetupStateManager = {
@@ -357,5 +355,185 @@ suite('MarketplaceViewProvider - Event Handling', () => {
       // The event should have been processed without errors
       assert.ok(true, 'Event processed successfully');
     });
+  });
+});
+
+suite('MarketplaceViewProvider - Throttle on source sync burst', () => {
+  let sandbox: sinon.SinonSandbox;
+  let clock: sinon.SinonFakeTimers;
+  let onSourceSyncedCallback: ((event: { sourceId: string; bundleCount: number }) => void) | undefined;
+  let postedMessages: any[];
+  let mockSearchBundles: sinon.SinonStub;
+
+  setup(() => {
+    sandbox = sinon.createSandbox();
+    clock = sandbox.useFakeTimers();
+    postedMessages = [];
+    mockSearchBundles = sandbox.stub().resolves([]);
+
+    const mockWebview = {
+      postMessage: (message: any) => {
+        postedMessages.push(message);
+        return Promise.resolve(true);
+      },
+      onDidReceiveMessage: sandbox.stub().returns({ dispose: () => {} }),
+      asWebviewUri: (uri: vscode.Uri) => uri,
+      cspSource: "'self'",
+      options: {},
+      html: ''
+    };
+
+    const mockContext: any = {
+      subscriptions: [],
+      extensionUri: vscode.Uri.file(PROJECT_ROOT),
+      extensionPath: PROJECT_ROOT,
+      storagePath: '/mock/storage',
+      globalStoragePath: '/mock/global-storage',
+      logPath: '/mock/logs',
+      extensionMode: 2
+    };
+
+    const mockRegistryManager: any = {
+      searchBundles: mockSearchBundles,
+      listInstalledBundles: sandbox.stub().resolves([]),
+      listSources: sandbox.stub().resolves([]),
+      autoUpdateService: null
+    };
+    setupRegistryManagerEventMocks(mockRegistryManager, sandbox, {
+      onSourceSynced: (cb) => {
+        onSourceSyncedCallback = cb;
+      }
+    });
+
+    const mockSetupStateManager: any = {
+      getState: sandbox.stub().resolves('complete'),
+      isComplete: sandbox.stub().resolves(true),
+      isIncomplete: sandbox.stub().resolves(false)
+    };
+
+    const provider = new MarketplaceViewProvider(mockContext, mockRegistryManager, mockSetupStateManager);
+    (provider as any)._view = { webview: mockWebview };
+  });
+
+  teardown(() => {
+    sandbox.restore();
+  });
+
+  const flushAsync = async () => {
+    // Flush pending microtasks and promise chains (searchBundles, listInstalledBundles, listSources each add ticks)
+    for (let i = 0; i < 10; i++) {
+      await Promise.resolve();
+    }
+  };
+
+  test('fires leading-edge refresh immediately on first source-synced event', async () => {
+    // Fire one event — the leading edge must trigger a refresh right away (before any timer)
+    onSourceSyncedCallback?.({ sourceId: 'test-source', bundleCount: 5 });
+
+    // Drain the microtask queue so the async loadBundles can post its message
+    await flushAsync();
+
+    const countBeforeTimer = postedMessages.filter((m) => m.type === 'bundlesLoaded').length;
+    assert.ok(countBeforeTimer >= 1, `Expected leading-edge bundlesLoaded message before timer, got ${countBeforeTimer}`);
+  });
+
+  test('a burst of 5 source-synced events produces ≥2 bundlesLoaded messages (leading + trailing)', async () => {
+    if (!onSourceSyncedCallback) {
+      assert.fail('onSourceSynced callback was not registered');
+    }
+
+    // Fire 5 events in rapid succession (all within the 500ms window)
+    for (let i = 0; i < 5; i++) {
+      onSourceSyncedCallback({ sourceId: 'test-source', bundleCount: i + 1 });
+    }
+
+    // Drain microtasks so the leading-edge loadBundles completes
+    await flushAsync();
+
+    const afterLeading = postedMessages.filter((m) => m.type === 'bundlesLoaded').length;
+    assert.ok(afterLeading >= 1, `Expected at least leading-edge bundlesLoaded, got ${afterLeading}`);
+
+    // Advance past the throttle window to trigger the trailing edge
+    clock.tick(600);
+    await flushAsync();
+
+    const afterTrailing = postedMessages.filter((m) => m.type === 'bundlesLoaded').length;
+    assert.ok(
+      afterTrailing >= 2,
+      `Expected ≥2 bundlesLoaded messages (leading + trailing), got ${afterTrailing}`
+    );
+  });
+
+  // Gate the FIRST load on a FAKE TIMER (not a hand-resolved promise). This keeps
+  // the entire async chain timer-driven so clock.tickAsync fully controls ordering
+  // and settling — mixing a manually-resolved promise with tickAsync is flaky under
+  // a busy event loop. The gate "releases" at GATE_MS; later calls resolve at once.
+  const GATE_MS = 10_000;
+  const gateFirstLoad = () => {
+    mockSearchBundles.onFirstCall().callsFake(
+      () => new Promise((resolve) => setTimeout(() => resolve([]), GATE_MS))
+    );
+    mockSearchBundles.callsFake(async () => []);
+  };
+  const renderCount = () => postedMessages.filter((m) => m.type === 'bundlesLoaded').length;
+
+  test('does not drop the trailing-edge load when the leading-edge load is still in flight', async () => {
+    if (!onSourceSyncedCallback) {
+      assert.fail('onSourceSynced callback was not registered');
+    }
+
+    gateFirstLoad();
+
+    // Leading edge: starts the (gated) first load and arms the 500ms throttle timer.
+    onSourceSyncedCallback({ sourceId: 'source-a', bundleCount: 3 });
+
+    // Advance past the 500ms throttle window (but not past the gate) so the trailing
+    // edge fires while the first load is still in flight — the call that was
+    // previously swallowed and never rescheduled.
+    await clock.tickAsync(600);
+
+    assert.strictEqual(renderCount(), 0, 'no render should occur while the first load is still gated');
+
+    // Release the gated first load. The coalesced follow-up must run and render again.
+    await clock.tickAsync(GATE_MS);
+
+    assert.ok(
+      renderCount() >= 2,
+      `expected leading-edge render plus a coalesced trailing-edge render, got ${renderCount()}`
+    );
+    assert.ok(
+      mockSearchBundles.callCount >= 2,
+      `expected the coalesced load to re-query the cache, got ${mockSearchBundles.callCount} calls`
+    );
+  });
+
+  test('collapses multiple mid-flight load requests into a single follow-up render', async () => {
+    if (!onSourceSyncedCallback) {
+      assert.fail('onSourceSynced callback was not registered');
+    }
+
+    gateFirstLoad();
+
+    // Leading edge starts the gated load and arms the throttle timer.
+    onSourceSyncedCallback({ sourceId: 'source-a', bundleCount: 1 });
+
+    // Generate several load requests while the first load is still gated: each
+    // trailing edge fires, and a fresh event re-arms the throttle for the next one.
+    await clock.tickAsync(600); // trailing edge #1 → pending
+    onSourceSyncedCallback({ sourceId: 'source-a', bundleCount: 2 }); // re-arms
+    await clock.tickAsync(600); // trailing edge #2 → pending (still just one re-run queued)
+    onSourceSyncedCallback({ sourceId: 'source-a', bundleCount: 3 }); // re-arms
+    await clock.tickAsync(600); // trailing edge #3 → pending
+
+    assert.strictEqual(renderCount(), 0, 'no render should occur while the first load is still gated');
+
+    // Release the gate: exactly one leading render + one coalesced follow-up.
+    await clock.tickAsync(GATE_MS);
+
+    assert.strictEqual(
+      renderCount(),
+      2,
+      `expected exactly leading + one coalesced follow-up render, got ${renderCount()}`
+    );
   });
 });

--- a/test/ui/marketplace-view-provider.eventHandling.test.ts
+++ b/test/ui/marketplace-view-provider.eventHandling.test.ts
@@ -464,6 +464,29 @@ suite('MarketplaceViewProvider - Throttle on source sync burst', () => {
     );
   });
 
+  test('a sustained burst spanning > maxWaitMs produces ≥3 bundlesLoaded messages (leading + periodic + trailing)', async () => {
+    if (!onSourceSyncedCallback) {
+      assert.fail('onSourceSynced callback was not registered');
+    }
+
+    // Simulate a hub-init burst: a source-synced event every 300ms (inside the
+    // 500ms quiet window so the trailing edge never fires mid-burst) for ~3000ms,
+    // which spans several 1000ms max-wait periods. Without the periodic flush this
+    // collapses to leading + trailing only; with it we get intermediate refreshes.
+    for (let elapsed = 0; elapsed < 3000; elapsed += 300) {
+      onSourceSyncedCallback({ sourceId: `source-${elapsed}`, bundleCount: 5 });
+      await clock.tickAsync(300);
+    }
+    // Let the trailing edge settle.
+    await clock.tickAsync(600);
+
+    const renders = postedMessages.filter((m) => m.type === 'bundlesLoaded').length;
+    assert.ok(
+      renders >= 3,
+      `Expected ≥3 bundlesLoaded messages (leading + ≥1 periodic + trailing), got ${renders}`
+    );
+  });
+
   // Gate the FIRST load on a FAKE TIMER (not a hand-resolved promise). This keeps
   // the entire async chain timer-driven so clock.tickAsync fully controls ordering
   // and settling — mixing a manually-resolved promise with tickAsync is flaky under

--- a/test/utils/leading-trailing-throttle.test.ts
+++ b/test/utils/leading-trailing-throttle.test.ts
@@ -1,0 +1,80 @@
+/**
+ * LeadingTrailingThrottle Unit Tests
+ *
+ * Verifies leading-edge, trailing-edge, and periodic max-wait flush behavior
+ * using sinon fake timers (the harness forbids Date.now(); drive time via clock.tick).
+ */
+
+import * as assert from 'node:assert';
+import * as sinon from 'sinon';
+import {
+  LeadingTrailingThrottle,
+} from '../../src/utils/leading-trailing-throttle';
+
+suite('LeadingTrailingThrottle', () => {
+  let sandbox: sinon.SinonSandbox;
+  let clock: sinon.SinonFakeTimers;
+
+  setup(() => {
+    sandbox = sinon.createSandbox();
+    clock = sandbox.useFakeTimers();
+  });
+
+  teardown(() => {
+    sandbox.restore();
+  });
+
+  test('fires the action immediately on the leading edge', () => {
+    let calls = 0;
+    const throttle = new LeadingTrailingThrottle(() => calls++, 500, 1000);
+
+    throttle.trigger();
+
+    assert.strictEqual(calls, 1, 'leading-edge action should fire synchronously on first trigger');
+  });
+
+  test('fires a trailing-edge action after the burst goes quiet', () => {
+    let calls = 0;
+    const throttle = new LeadingTrailingThrottle(() => calls++, 500, 1000);
+
+    throttle.trigger(); // leading edge (1)
+    throttle.trigger();
+    throttle.trigger();
+
+    clock.tick(600); // past the 500ms quiet window
+
+    assert.strictEqual(calls, 2, 'expected leading + trailing edge = 2 calls');
+  });
+
+  test('a sustained burst spanning > maxWaitMs produces >=3 action calls', () => {
+    let calls = 0;
+    const throttle = new LeadingTrailingThrottle(() => calls++, 500, 1000);
+
+    // Fire an event every 100ms for 3000ms. The quiet window (500ms) never elapses
+    // mid-burst, so WITHOUT a max-wait flush we would see only the leading edge.
+    for (let elapsed = 0; elapsed < 3000; elapsed += 100) {
+      throttle.trigger();
+      clock.tick(100);
+    }
+    // Let the trailing edge settle.
+    clock.tick(600);
+
+    assert.ok(
+      calls >= 3,
+      `expected >=3 calls (leading + >=1 periodic flush + trailing), got ${calls}`
+    );
+  });
+
+  test('dispose cancels pending trailing-edge and periodic flushes', () => {
+    let calls = 0;
+    const throttle = new LeadingTrailingThrottle(() => calls++, 500, 1000);
+
+    throttle.trigger(); // leading edge (1)
+    throttle.trigger();
+    throttle.dispose();
+
+    clock.tick(5000);
+
+    assert.strictEqual(calls, 1, 'no further calls should fire after dispose');
+  });
+});


### PR DESCRIPTION
## Description

Fixes the marketplace freeze during first-time hub init: content only appeared after *every* source finished syncing. Root causes — only `SkillsAdapter` streamed progressive events, and the throttle collapsed a burst to two refreshes. Also consolidates the three GitHub-backed adapters onto a shared base class.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ♻️ Code refactoring (no functional changes)
- [x] 📝 Documentation update
- [x] 🧪 Test coverage improvement

## Changes Made

- Add `GitHubBackedAdapter` base class holding shared GitHub logic: URL parsing/validation, auth chain (explicit → VS Code → gh CLI, memoized + retry), `httpGet`/`getJson`/`getText`/`getBuffer` transport, URL builders, `processInChunks`, `validateGitHubRepository`.
- Rewire `GitHubAdapter`, `AwesomeCopilotAdapter`, `SkillsAdapter` onto the base and delete duplicated members (net −632 lines).
- All three adapters now stream partial results via `processInChunks`, so GitHub + Awesome-Copilot fire progressive `onSourceSynced` events (previously only Skills did).
- `SkillsAdapter`: drop the `GitHubAdapter` composition; split `scanSkillsDirectory` into a `collectSkillWorkList()` producer.
- Add periodic max-wait flush to `LeadingTrailingThrottle` so a sustained burst refreshes mid-burst, not just leading + trailing.
- Snapshot the source cache before fetch in `syncSource` so streamed readme-less partials no longer clobber cached readmes before `reuseCachedReadmes` runs.
- Update `src/adapters/AGENTS.md` and `docs/contributor-guide/architecture/adapters.md` with the new hierarchy, `processInChunks`, and refreshed adapter table.

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [x] All existing tests pass

- Added progressive-streaming suites for GitHub + Awesome-Copilot adapters (callback fires >1×, monotonic snapshots, distinct arrays, final == last partial, identical set with/without callback).
- Added `test/utils/leading-trailing-throttle.test.ts` (burst > maxWait → ≥3 flushes) and a marketplace burst test (≥3 `bundlesLoaded`).
- Updated GitHub property test to target the renamed transport method.
- Full unit suite: **2346 passing / 0 failing / 33 pending**. `npm run compile` and `npm run lint` clean (0 errors).

## Documentation

- [x] JSDoc comments added/updated

## Reviewer Guidelines

Please pay special attention to:

- `getJson` 401/403 invalidate-and-retry parity with the old `makeRequest`.
- The `syncSource` cache-snapshot fix — without it, streamed partials cause readmes to re-download every sync.

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**