### PR TITLE
feat: auto-generate mcp.json inputs from collection definition

### DIFF
--- a/docs/author-guide/collection-schema.md
+++ b/docs/author-guide/collection-schema.md
@@ -28,6 +28,16 @@ items:                              # Required. List of resources (max 50)
     kind: agent
 
 mcp:                                # Optional. MCP server configurations
+  inputs:                           # Optional. Input definitions for secrets/configurable values
+    - id: apiToken                  # Required. Referenced as ${input:apiToken} in server config
+      type: promptString            # Required. One of: promptString, pickString, command
+      description: API access token # Optional. Label shown to the user
+      password: true                # Optional. Mask the value (for secrets)
+    - id: environment
+      type: pickString
+      description: Target environment
+      options: [staging, production]
+      default: staging
   items:
     # Stdio server (local process)
     python-analyzer:                # Server name
@@ -37,6 +47,7 @@ mcp:                                # Optional. MCP server configurations
         - "${bundlePath}/server.py" # ${bundlePath} = installed bundle path
       env:                          # Optional. Environment variables
         LOG_LEVEL: info
+        TOKEN: "${input:apiToken}"  # Reference an input
       envFile: "${bundlePath}/.env" # Optional. Path to env file
       disabled: false               # Optional. Default: false
       description: Python analyzer  # Optional. Human-readable description
@@ -46,7 +57,7 @@ mcp:                                # Optional. MCP server configurations
       type: http                    # Required for remote. One of: http, sse
       url: "https://api.example.com/mcp"  # Required for remote
       headers:                      # Optional. Authentication headers
-        Authorization: "Bearer ${env:API_TOKEN}"
+        Authorization: "Bearer ${input:apiToken}"  # Use an input for secrets
 
     # Remote SSE server
     streaming-server:
@@ -59,6 +70,23 @@ display:                            # Optional. UI preferences
   ordering: manual                  # manual or alphabetical
   show_badge: true                  # Show badge in UI
 ```
+
+## MCP Input Definitions
+
+Use `mcp.inputs` to declare secrets or user-configurable values. VS Code will prompt the user when the server starts. Inputs are referenced in server configuration using `${input:id}`.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `id` | ✅ | Unique identifier (alphanumeric, `-`, `_`) |
+| `type` | ✅ | `promptString`, `pickString`, or `command` |
+| `description` | — | Label shown to the user |
+| `password` | — | Mask the input (use for secrets) |
+| `default` | — | Pre-filled value |
+| `options` | — | List of choices for `pickString` |
+
+**Install behaviour**: inputs from `mcp.inputs` are merged into `.vscode/mcp.json`. Existing inputs with the same `id` are preserved — they are never overwritten.
+
+**Uninstall behaviour**: when a bundle is uninstalled, inputs that are no longer referenced by any remaining MCP server are automatically removed from `mcp.json`.
 
 ## MCP Server Duplicate Detection
 

--- a/docs/contributor-guide/architecture/mcp-integration.md
+++ b/docs/contributor-guide/architecture/mcp-integration.md
@@ -7,8 +7,8 @@ Bundles can include MCP (Model Context Protocol) servers that extend Copilot's c
 | Component | Responsibility |
 |-----------|---------------|
 | **BundleInstaller** | Calls MCP install/uninstall during bundle lifecycle |
-| **McpServerManager** | Orchestrates installation, naming, tracking |
-| **McpConfigService** | Reads/writes VS Code's `mcp.json` |
+| **McpServerManager** | Orchestrates installation, naming, tracking, input merging |
+| **McpConfigService** | Reads/writes VS Code's `mcp.json`, merges/cleans inputs |
 
 ## Installation Flow
 
@@ -16,9 +16,9 @@ Bundles can include MCP (Model Context Protocol) servers that extend Copilot's c
 graph TD
     A["Bundle Install"]
     B["BundleInstaller.installMcpServers()"]
-    C["McpServerManager.installServers()"]
-    D["• Add bundle prefix to name<br/>(prompt-registry:bundleId:server-name)<br/>• Substitute variables<br/>• Write to mcp.json<br/>• Create tracking metadata"]
-    E["MCP servers available to Copilot"]
+    C["McpServerManager.installServers() or\ninstallServersToWorkspace()"]
+    D["• Add bundle prefix to name\n(prompt-registry:bundleId:server-name)\n• Substitute variables\n• mergeInputs() — deduplicate by id\n• Write servers + inputs to mcp.json\n• Create tracking metadata"]
+    E["MCP servers + inputs available to Copilot"]
     
     A --> B
     B --> C
@@ -62,6 +62,66 @@ mcpServers:
 | `${bundleId}` | Bundle identifier |
 | `${bundleVersion}` | Bundle version |
 | `${env:VAR_NAME}` | Environment variable |
+| `${input:id}` | VS Code input prompt (defined in `mcp.inputs`) |
+
+## Input Definitions
+
+Collections can define `mcp.inputs` to declare secrets or configurable values that VS Code will prompt the user for. These follow the [VS Code `mcp.json` inputs spec](https://code.visualstudio.com/docs/copilot/chat/mcp-servers).
+
+### Schema
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Unique identifier, referenced as `${input:id}` in server config |
+| `type` | `promptString` \| `pickString` \| `command` | Input type |
+| `description` | string | Label shown to the user |
+| `password` | boolean | Mask the value (for secrets) |
+| `default` | string | Pre-filled default value |
+| `options` | string[] | Choices for `pickString` type |
+
+### Example
+
+```yaml
+mcp:
+  inputs:
+    - id: serviceToken
+      type: promptString
+      description: "Service access token (not stored)"
+      password: true
+    - id: serviceUser
+      type: promptString
+      description: "Service username"
+    - id: servicePassword
+      type: promptString
+      description: "Service password or app password"
+      password: true
+  items:
+    server-a:
+      type: stdio
+      command: podman
+      args:
+        - run
+        - -e
+        - "TOKEN=${input:serviceToken}"
+        - my-mcp-server-a:latest
+    server-b:
+      type: stdio
+      command: podman
+      args:
+        - run
+        - -e
+        - "USERNAME=${input:serviceUser}"
+        - -e
+        - "PASSWORD=${input:servicePassword}"
+        - my-mcp-server-b:latest
+```
+
+### Merge Behaviour
+
+When a collection is installed, its `mcp.inputs` are **merged** into the existing `mcp.json`:
+- Inputs are deduplicated by `id` — the **existing** definition takes priority over incoming ones
+- This allows multiple collections to share the same input without conflict
+- Inputs are added to the top-level `inputs` array of `mcp.json`
 
 ## Example
 
@@ -81,8 +141,11 @@ mcpServers:
 
 1. Read tracking metadata for bundle's servers
 2. Remove servers from `mcp.json`
-3. Update tracking metadata
-4. Atomic operations with backup/rollback
+3. Remove **orphaned inputs** — any `${input:id}` no longer referenced by any remaining server is removed from the `inputs` array
+4. Update tracking metadata
+5. Atomic operations with backup/rollback
+
+> **Shared inputs are preserved**: if another installed bundle's server still references an input, it is kept.
 
 ## Duplicate Detection Algorithm
 

--- a/schemas/collection.schema.json
+++ b/schemas/collection.schema.json
@@ -235,6 +235,46 @@
             }
           },
           "additionalProperties": false
+        },
+        "inputs": {
+          "type": "array",
+          "description": "Input definitions for MCP server secrets or configurable values (follows VS Code mcp.json inputs spec)",
+          "items": {
+            "type": "object",
+            "required": ["id", "type"],
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "Unique identifier for this input, referenced in args/env as ${input:id}",
+                "pattern": "^[a-zA-Z0-9_-]+$",
+                "examples": ["apiToken", "bbUser", "ocToken"]
+              },
+              "type": {
+                "type": "string",
+                "description": "Input type",
+                "enum": ["promptString", "pickString", "command"]
+              },
+              "description": {
+                "type": "string",
+                "description": "Human-readable description shown to the user"
+              },
+              "password": {
+                "type": "boolean",
+                "description": "If true, the input is masked (for secrets). Only applies to promptString.",
+                "default": false
+              },
+              "default": {
+                "type": "string",
+                "description": "Default value pre-filled in the prompt"
+              },
+              "options": {
+                "type": "array",
+                "description": "List of options for pickString type",
+                "items": { "type": "string" }
+              }
+            },
+            "additionalProperties": false
+          }
         }
       },
       "additionalProperties": false

--- a/src/adapters/awesome-copilot-adapter.ts
+++ b/src/adapters/awesome-copilot-adapter.ts
@@ -63,6 +63,7 @@ interface CollectionManifest {
   };
   mcp?: {
     items?: Record<string, any>;
+    inputs?: any[];
   };
   mcpServers?: Record<string, any>;
 }
@@ -192,9 +193,13 @@ export class AwesomeCopilotAdapter extends RepositoryAdapter {
       (bundle as any).collectionFile = collectionFile;
       (bundle as any).breakdown = breakdown;
 
-      // Attach MCP servers for pre-installation display
+      // Attach MCP servers and inputs for pre-installation display
       if (mcpServers && Object.keys(mcpServers).length > 0) {
         (bundle as any).mcpServers = mcpServers;
+      }
+      const mcpInputs = collection.mcp?.inputs;
+      if (mcpInputs && mcpInputs.length > 0) {
+        (bundle as any).mcpInputs = mcpInputs;
       }
 
       return bundle;
@@ -339,7 +344,8 @@ export class AwesomeCopilotAdapter extends RepositoryAdapter {
       license: 'MIT',
       tags: collection.tags || [],
       prompts,
-      ...(mcpServers && Object.keys(mcpServers).length > 0 ? { mcpServers } : {})
+      ...(mcpServers && Object.keys(mcpServers).length > 0 ? { mcpServers } : {}),
+      ...(collection.mcp?.inputs && collection.mcp.inputs.length > 0 ? { mcpInputs: collection.mcp.inputs } : {})
     };
   }
 
@@ -638,7 +644,7 @@ export class AwesomeCopilotAdapter extends RepositoryAdapter {
 
                 break;
               }
-                        // No default
+              // No default
             }
             reject(new Error(errorMsg));
           }

--- a/src/adapters/local-awesome-copilot-adapter.ts
+++ b/src/adapters/local-awesome-copilot-adapter.ts
@@ -79,6 +79,7 @@ interface CollectionManifest {
   };
   mcp?: {
     items?: Record<string, any>;
+    inputs?: any[];
   };
   mcpServers?: Record<string, any>;
 }
@@ -242,9 +243,13 @@ export class LocalAwesomeCopilotAdapter extends RepositoryAdapter {
       (bundle as any).collectionFile = collectionFile;
       (bundle as any).breakdown = breakdown;
 
-      // Attach MCP servers for pre-installation display
+      // Attach MCP servers and inputs for pre-installation display
       if (mcpServers && Object.keys(mcpServers).length > 0) {
         (bundle as any).mcpServers = mcpServers;
+      }
+      const mcpInputs = collection.mcp?.inputs;
+      if (mcpInputs && mcpInputs.length > 0) {
+        (bundle as any).mcpInputs = mcpInputs;
       }
 
       return bundle;
@@ -382,7 +387,8 @@ export class LocalAwesomeCopilotAdapter extends RepositoryAdapter {
       license: 'MIT',
       tags: collection.tags || [],
       prompts,
-      ...(mcpServers && Object.keys(mcpServers).length > 0 ? { mcpServers } : {})
+      ...(mcpServers && Object.keys(mcpServers).length > 0 ? { mcpServers } : {}),
+      ...(collection.mcp?.inputs && collection.mcp.inputs.length > 0 ? { mcpInputs: collection.mcp.inputs } : {})
     };
   }
 

--- a/src/services/bundle-installer.ts
+++ b/src/services/bundle-installer.ts
@@ -586,7 +586,8 @@ export class BundleInstaller {
             overwrite: false,
             skipOnConflict: false,
             createBackup: true
-          }
+          },
+          manifest.mcpInputs
         );
 
         if (workspaceInstallationResult.success) {
@@ -612,7 +613,8 @@ export class BundleInstaller {
           overwrite: false,
           skipOnConflict: false,
           createBackup: true
-        }
+        },
+        manifest.mcpInputs
       );
 
       if (result.success) {

--- a/src/services/mcp-config-service.ts
+++ b/src/services/mcp-config-service.ts
@@ -3,6 +3,7 @@ import * as jsonc from 'jsonc-parser';
 import {
   isRemoteServerConfig,
   McpConfiguration,
+  McpInputDefinition,
   McpInstallOptions,
   McpRemoteServerConfig,
   McpServerConfig,
@@ -299,15 +300,40 @@ export class McpConfigService {
     return { duplicatesDisabled, config };
   }
 
+  /**
+   * Merge new input definitions into existing ones, deduplicating by id.
+   * Existing inputs with the same id are preserved unchanged.
+   * @param existing - Current inputs array from mcp.json
+   * @param incoming - New inputs to add
+   */
+  public mergeInputs(
+    existing: McpInputDefinition[] | undefined,
+    incoming: McpInputDefinition[] | undefined
+  ): McpInputDefinition[] | undefined {
+    if (!incoming || incoming.length === 0) {
+      return existing;
+    }
+    const merged = existing ? [...existing] : [];
+    const existingIds = new Set(merged.map((i) => i.id));
+    for (const input of incoming) {
+      if (!existingIds.has(input.id)) {
+        merged.push(input);
+        existingIds.add(input.id);
+      }
+    }
+    return merged.length > 0 ? merged : undefined;
+  }
+
   public async mergeServers(
     existingConfig: McpConfiguration,
     newServers: Record<string, McpServerConfig>,
-    options: McpInstallOptions
+    options: McpInstallOptions,
+    newInputs?: McpInputDefinition[]
   ): Promise<{ config: McpConfiguration; conflicts: string[]; warnings: string[] }> {
     const result: McpConfiguration = {
       servers: { ...existingConfig.servers },
       tasks: existingConfig.tasks ? { ...existingConfig.tasks } : undefined,
-      inputs: existingConfig.inputs ? [...existingConfig.inputs] : undefined
+      inputs: this.mergeInputs(existingConfig.inputs, newInputs)
     };
     const conflicts: string[] = [];
     const warnings: string[] = [];
@@ -331,6 +357,60 @@ export class McpConfigService {
     return { config: result, conflicts, warnings };
   }
 
+  /**
+   * Collect all ${input:id} references across all server configurations.
+   * @param servers
+   */
+  // eslint-disable-next-line @typescript-eslint/member-ordering -- private method added after public ones, ordering is intentional
+  private collectInputReferences(servers: Record<string, McpServerConfig>): Set<string> {
+    const inputPattern = /\$\{input:([^}]+)\}/g;
+    const referenced = new Set<string>();
+
+    const scan = (value: string | undefined): void => {
+      if (!value) {
+        return;
+      }
+      let match: RegExpExecArray | null;
+      while ((match = inputPattern.exec(value)) !== null) {
+        referenced.add(match[1]);
+      }
+    };
+
+    for (const serverConfig of Object.values(servers)) {
+      if (isRemoteServerConfig(serverConfig)) {
+        scan(serverConfig.url);
+        if (serverConfig.headers) {
+          Object.values(serverConfig.headers).forEach((v) => scan(v));
+        }
+      } else {
+        scan(serverConfig.command);
+        serverConfig.args?.forEach((v) => scan(v));
+        if (serverConfig.env) {
+          Object.values(serverConfig.env).forEach((v) => scan(v));
+        }
+      }
+    }
+
+    return referenced;
+  }
+
+  /**
+   * Remove inputs that are no longer referenced by any remaining server.
+   * Inputs referenced by at least one server are kept, even across bundles.
+   * @param config
+   */
+  public removeOrphanedInputs(config: McpConfiguration): McpConfiguration {
+    if (!config.inputs || config.inputs.length === 0) {
+      return config;
+    }
+    const referenced = this.collectInputReferences(config.servers);
+    const filteredInputs = config.inputs.filter((input) => referenced.has(input.id));
+    return {
+      ...config,
+      inputs: filteredInputs.length > 0 ? filteredInputs : undefined
+    };
+  }
+
   public async removeServersForBundle(bundleId: string, scope: 'user' | 'workspace'): Promise<string[]> {
     const config = await this.readMcpConfig(scope);
     const tracking = await this.readTrackingMetadata(scope);
@@ -347,7 +427,8 @@ export class McpConfigService {
     }
 
     if (removedServers.length > 0) {
-      await this.writeMcpConfig(config, scope, true);
+      const cleanedConfig = this.removeOrphanedInputs(config);
+      await this.writeMcpConfig(cleanedConfig, scope, true);
       await this.writeTrackingMetadata(tracking, scope);
       this.logger.info(`Removed ${removedServers.length} MCP servers for bundle ${bundleId}`);
     }

--- a/src/services/mcp-server-manager.ts
+++ b/src/services/mcp-server-manager.ts
@@ -2,6 +2,7 @@ import * as path from 'node:path';
 import * as fs from 'fs-extra';
 import {
   McpConfiguration,
+  McpInputDefinition,
   McpInstallOptions,
   McpInstallResult,
   McpServersManifest,
@@ -356,7 +357,8 @@ export class McpServerManager {
     bundleVersion: string,
     bundlePath: string,
     serversManifest: McpServersManifest,
-    options: McpInstallOptions
+    options: McpInstallOptions,
+    inputsManifest?: McpInputDefinition[]
   ): Promise<McpInstallResult> {
     const result: McpInstallResult = {
       success: false,
@@ -406,7 +408,8 @@ export class McpServerManager {
       const mergeResult = await this.configService.mergeServers(
         existingConfig,
         serversToInstall,
-        options
+        options,
+        inputsManifest
       );
 
       result.warnings?.push(...mergeResult.warnings);
@@ -489,13 +492,15 @@ export class McpServerManager {
    * @param workspaceRoot - Path to workspace root
    * @param serversManifest - MCP servers to install
    * @param options - Installation options including commitMode
+   * @param inputsManifest
    */
   public async installServersToWorkspace(
     bundleId: string,
     bundleVersion: string,
     workspaceRoot: string,
     serversManifest: McpServersManifest,
-    options: McpWorkspaceInstallOptions
+    options: McpWorkspaceInstallOptions,
+    inputsManifest?: McpInputDefinition[]
   ): Promise<McpInstallResult> {
     const result: McpInstallResult = {
       success: false,
@@ -567,7 +572,7 @@ export class McpServerManager {
       const mergedConfig: McpConfiguration = {
         servers: { ...existingConfig.servers, ...serversToInstall },
         tasks: existingConfig.tasks,
-        inputs: existingConfig.inputs
+        inputs: this.configService.mergeInputs(existingConfig.inputs, inputsManifest)
       };
 
       // Write config and tracking
@@ -628,7 +633,8 @@ export class McpServerManager {
       }
 
       if (removedServers.length > 0) {
-        await this.writeWorkspaceMcpConfig(workspaceRoot, config, true);
+        const cleanedConfig = this.configService.removeOrphanedInputs(config);
+        await this.writeWorkspaceMcpConfig(workspaceRoot, cleanedConfig, true);
         await this.writeWorkspaceTrackingMetadata(workspaceRoot, tracking);
         this.logger.info(`Removed ${removedServers.length} MCP servers for bundle ${bundleId} from workspace`);
       } else {

--- a/src/types/mcp.ts
+++ b/src/types/mcp.ts
@@ -79,10 +79,19 @@ export interface McpTaskDefinition {
   description?: string;
 }
 
+export interface McpInputDefinition {
+  id: string;
+  type: 'promptString' | 'pickString' | 'command';
+  description?: string;
+  password?: boolean;
+  default?: string;
+  options?: string[];
+}
+
 export interface McpConfiguration {
   servers: Record<string, McpServerConfig>;
   tasks?: Record<string, McpTaskDefinition>;
-  inputs?: any[]; // Legacy field, preserved for compatibility
+  inputs?: McpInputDefinition[];
 }
 
 /**

--- a/src/types/registry.ts
+++ b/src/types/registry.ts
@@ -2,6 +2,7 @@
  * Core type definitions for the AI Primitives Hub system
  */
 import {
+  McpInputDefinition,
   McpServersManifest,
 } from './mcp';
 
@@ -332,4 +333,5 @@ export interface DeploymentManifest {
     type?: 'prompt' | 'instructions' | 'chatmode' | 'agent' | 'skill'; // GitHub Copilot file type
   }[];
   mcpServers?: McpServersManifest;
+  mcpInputs?: McpInputDefinition[];
 }

--- a/test/services/mcp-config-service.inputs.test.ts
+++ b/test/services/mcp-config-service.inputs.test.ts
@@ -1,0 +1,247 @@
+/**
+ * McpConfigService - Input Merging Tests
+ *
+ * Tests for mergeInputs() and the inputs propagation through mergeServers().
+ */
+import * as assert from 'node:assert';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as fs from 'fs-extra';
+import * as sinon from 'sinon';
+import {
+  McpConfigService,
+} from '../../src/services/mcp-config-service';
+import {
+  McpConfiguration,
+  McpInputDefinition,
+} from '../../src/types/mcp';
+
+suite('McpConfigService - Input Merging', () => {
+  let sandbox: sinon.SinonSandbox;
+  let configService: McpConfigService;
+  let testDir: string;
+  let mockConfigPath: string;
+
+  const writeTestConfig = async (config: McpConfiguration): Promise<void> => {
+    await fs.writeFile(mockConfigPath, JSON.stringify(config, null, 2));
+  };
+
+  setup(() => {
+    sandbox = sinon.createSandbox();
+    configService = new McpConfigService();
+    testDir = path.join(os.tmpdir(), 'mcp-inputs-test-' + Date.now());
+    fs.ensureDirSync(testDir);
+    mockConfigPath = path.join(testDir, 'mcp.json');
+  });
+
+  teardown(async () => {
+    sandbox.restore();
+    if (fs.existsSync(testDir)) {
+      await fs.remove(testDir);
+    }
+  });
+
+  suite('mergeInputs()', () => {
+    test('should return undefined when both existing and incoming are undefined', () => {
+      const result = configService.mergeInputs(undefined, undefined);
+      assert.strictEqual(result, undefined);
+    });
+
+    test('should return undefined when incoming is empty', () => {
+      const result = configService.mergeInputs(undefined, []);
+      assert.strictEqual(result, undefined);
+    });
+
+    test('should return existing unchanged when incoming is empty', () => {
+      const existing: McpInputDefinition[] = [{ id: 'token', type: 'promptString' }];
+      const result = configService.mergeInputs(existing, []);
+      assert.deepStrictEqual(result, existing);
+    });
+
+    test('should add new inputs when existing is undefined', () => {
+      const incoming: McpInputDefinition[] = [
+        { id: 'ocToken', type: 'promptString', description: 'OpenShift token', password: true }
+      ];
+      const result = configService.mergeInputs(undefined, incoming);
+      assert.deepStrictEqual(result, incoming);
+    });
+
+    test('should add new inputs that do not conflict with existing ones', () => {
+      const existing: McpInputDefinition[] = [
+        { id: 'existingToken', type: 'promptString' }
+      ];
+      const incoming: McpInputDefinition[] = [
+        { id: 'newToken', type: 'promptString', password: true }
+      ];
+
+      const result = configService.mergeInputs(existing, incoming);
+
+      assert.strictEqual(result?.length, 2);
+      assert.ok(result?.some((i) => i.id === 'existingToken'));
+      assert.ok(result?.some((i) => i.id === 'newToken'));
+    });
+
+    test('should deduplicate inputs by id, preserving the existing definition', () => {
+      const existing: McpInputDefinition[] = [
+        { id: 'sharedToken', type: 'promptString', description: 'Original description' }
+      ];
+      const incoming: McpInputDefinition[] = [
+        { id: 'sharedToken', type: 'promptString', description: 'New description' }
+      ];
+
+      const result = configService.mergeInputs(existing, incoming);
+
+      assert.strictEqual(result?.length, 1);
+      assert.strictEqual(result?.[0].description, 'Original description');
+    });
+
+    test('should merge multiple inputs handling duplicates and new ones together', () => {
+      const existing: McpInputDefinition[] = [
+        { id: 'bbUser', type: 'promptString' },
+        { id: 'bbPassword', type: 'promptString', password: true }
+      ];
+      const incoming: McpInputDefinition[] = [
+        { id: 'bbUser', type: 'promptString', description: 'Should be ignored (duplicate)' },
+        { id: 'ocToken', type: 'promptString', password: true }
+      ];
+
+      const result = configService.mergeInputs(existing, incoming);
+
+      assert.strictEqual(result?.length, 3);
+      assert.ok(result?.some((i) => i.id === 'bbUser' && !i.description));
+      assert.ok(result?.some((i) => i.id === 'bbPassword'));
+      assert.ok(result?.some((i) => i.id === 'ocToken'));
+    });
+  });
+
+  suite('removeOrphanedInputs()', () => {
+    test('should return config unchanged when no inputs are defined', () => {
+      const config: McpConfiguration = {
+        servers: { 'my-server': { command: 'node', args: ['--token', '${input:token}'] } }
+      };
+      const result = configService.removeOrphanedInputs(config);
+      assert.strictEqual(result.inputs, undefined);
+    });
+
+    test('should keep inputs still referenced by a remaining server', () => {
+      const config: McpConfiguration = {
+        servers: { 'my-server': { command: 'node', args: ['-e', 'BB_USER=${input:bbUser}'] } },
+        inputs: [
+          { id: 'bbUser', type: 'promptString' },
+          { id: 'bbPassword', type: 'promptString', password: true }
+        ]
+      };
+      const result = configService.removeOrphanedInputs(config);
+      assert.strictEqual(result.inputs?.length, 1);
+      assert.strictEqual(result.inputs?.[0].id, 'bbUser');
+    });
+
+    test('should remove all inputs when no servers reference any input', () => {
+      const config: McpConfiguration = {
+        servers: { 'plain-server': { command: 'node', args: ['server.js'] } },
+        inputs: [{ id: 'orphaned', type: 'promptString' }]
+      };
+      const result = configService.removeOrphanedInputs(config);
+      assert.strictEqual(result.inputs, undefined);
+    });
+
+    test('should remove all inputs when no servers remain', () => {
+      const config: McpConfiguration = {
+        servers: {},
+        inputs: [{ id: 'ocToken', type: 'promptString', password: true }]
+      };
+      const result = configService.removeOrphanedInputs(config);
+      assert.strictEqual(result.inputs, undefined);
+    });
+
+    test('should keep input referenced in headers of a remote server', () => {
+      const config: McpConfiguration = {
+        servers: {
+          'remote-server': {
+            type: 'http',
+            url: 'https://api.example.com/mcp',
+            headers: { Authorization: 'Bearer ${input:apiToken}' }
+          }
+        },
+        inputs: [
+          { id: 'apiToken', type: 'promptString', password: true },
+          { id: 'unused', type: 'promptString' }
+        ]
+      };
+      const result = configService.removeOrphanedInputs(config);
+      assert.strictEqual(result.inputs?.length, 1);
+      assert.strictEqual(result.inputs?.[0].id, 'apiToken');
+    });
+
+    test('should keep shared input if still referenced by at least one remaining server', () => {
+      const config: McpConfiguration = {
+        servers: {
+          'bundle-a:bitbucket': { command: 'podman', args: ['-e', 'BB_USER=${input:bbUser}'] }
+        },
+        inputs: [
+          { id: 'bbUser', type: 'promptString' },
+          { id: 'bbPassword', type: 'promptString', password: true }
+        ]
+      };
+      const result = configService.removeOrphanedInputs(config);
+      assert.strictEqual(result.inputs?.length, 1);
+      assert.strictEqual(result.inputs?.[0].id, 'bbUser');
+    });
+  });
+
+  suite('mergeServers() with inputs', () => {
+    test('should propagate new inputs into the merged config', async () => {
+      const existingConfig: McpConfiguration = {
+        servers: {},
+        inputs: [{ id: 'existingInput', type: 'promptString' }]
+      };
+
+      const newInputs: McpInputDefinition[] = [
+        { id: 'ocToken', type: 'promptString', password: true }
+      ];
+
+      const { config } = await configService.mergeServers(existingConfig, {}, { scope: 'user', overwrite: false, skipOnConflict: false }, newInputs);
+
+      assert.strictEqual(config.inputs?.length, 2);
+      assert.ok(config.inputs?.some((i) => i.id === 'existingInput'));
+      assert.ok(config.inputs?.some((i) => i.id === 'ocToken'));
+    });
+
+    test('should produce no inputs field when none are provided', async () => {
+      const existingConfig: McpConfiguration = { servers: {} };
+
+      const { config } = await configService.mergeServers(existingConfig, {}, { scope: 'user', overwrite: false, skipOnConflict: false });
+
+      assert.strictEqual(config.inputs, undefined);
+    });
+
+    test('should write inputs to mcp.json via writeMcpConfig', async () => {
+      const initialConfig: McpConfiguration = { servers: {} };
+      await writeTestConfig(initialConfig);
+
+      // Stub McpConfigLocator to point at our test dir
+      const { McpConfigLocator } = await import('../../src/utils/mcp-config-locator');
+      sandbox.stub(McpConfigLocator, 'getMcpConfigLocation').returns({
+        configPath: mockConfigPath,
+        trackingPath: path.join(testDir, 'mcp-tracking.json'),
+        exists: true
+      });
+      sandbox.stub(McpConfigLocator, 'ensureConfigDirectory').resolves();
+
+      const inputs: McpInputDefinition[] = [
+        { id: 'bbUser', type: 'promptString', description: 'Bitbucket username' },
+        { id: 'bbPassword', type: 'promptString', password: true }
+      ];
+
+      const existingConfig = await configService.readMcpConfig('user');
+      const { config } = await configService.mergeServers(existingConfig, {}, { scope: 'user', overwrite: false, skipOnConflict: false }, inputs);
+      await configService.writeMcpConfig(config, 'user', false);
+
+      const written = JSON.parse(await fs.readFile(mockConfigPath, 'utf8')) as McpConfiguration;
+      assert.strictEqual(written.inputs?.length, 2);
+      assert.strictEqual(written.inputs?.[0].id, 'bbUser');
+      assert.strictEqual(written.inputs?.[1].id, 'bbPassword');
+      assert.strictEqual(written.inputs?.[1].password, true);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Add support for automatic inputs generation in mcp.json when a collection defines MCP servers. Collections can now declare mcp.inputs in their .collection.yml to specify secrets and configurable values (e.g., tokens, usernames, passwords). These inputs are automatically merged into VS Code's mcp.json on install and cleaned up on uninstall.

## Type of Change

<!-- Mark relevant items with an [x] -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔧 Configuration/build changes

## Related Issues

<!-- Link to related issues using #issue_number -->

Closes #298 (https://github.com/AmadeusITGroup/ai-primitives-hub/issues/298)
Fixes #
Relates to #

## Changes Made

- Add McpInputDefinition type to mcp.ts and replace inputs?: any[] with a strongly-typed array in McpConfiguration
- Add mcpInputs?: McpInputDefinition[] field to DeploymentManifest in registry.ts
- Extend CollectionManifest in awesome-copilot-adapter.ts and local-awesome-copilot-adapter.ts to support mcp.inputs; propagate inputs into bundle metadata and deployment manifest
- Add mergeInputs() to McpConfigService: merges incoming inputs into existing ones, deduplicating by id (existing definition takes priority)
- Add removeOrphanedInputs() to McpConfigService: scans remaining server configs for ${input:id} references and removes inputs no longer referenced by any server
- Update mergeServers() in McpConfigService to accept and apply newInputs?: McpInputDefinition[]
- Update installServers() and installServersToWorkspace() in McpServerManager to accept and pass inputsManifest
- Call removeOrphanedInputs() in both removeServersForBundle() and uninstallServersFromWorkspace() on bundle removal
- Pass manifest.mcpInputs through BundleInstaller.installMcpServers() to both install paths
- Add mcp.inputs array schema to collection.schema.json
- Update collection-schema.md with mcp.inputs example and reference table
- Update mcp-integration.md with Input Definitions section, updated installation flow diagram, and updated uninstallation description
- Update validation.md to mention mcp.inputs

## Testing

<!-- Describe the testing you've done -->

### Test Coverage

- [X] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

### Manual Testing Steps

1. Clone the fork and check out the feature branch

git clone https://github.com/lanzamelissa-sketch/ai-primitives-hub.git
cd ai-primitives-hub
git checkout feat/mcp-inputs-auto-generation
npm install && npm run compile

2. Launch the extension in development mode by pressing F5 in VS Code — a new Extension Development Host window opens
3.  In VS Code settings (settings.json), add a local-awesome-copilot source pointing to a local repository that contains a collections folder with a .collection.yml file defining mcp.inputs and mcp.items referencing ${input:id} variables:

{
  "promptregistry.sources": [{
    "id": "test-local",
    "name": "Test Local",
    "url": "C:\\path\\to\\your\\repo",
    "type": "local-awesome-copilot",
    "config": { "collectionsPath": "collections" }
  }]
}
4. Open the AI Primitives Hub marketplace, find the collection and install it 
5. Install a second collection that shares an input with the same id
6. Uninstall the first collection

### Tested On

- [ ] macOS
- [X] Windows
- [ ] Linux

- [X] VS Code Stable
- [ ] VS Code Insiders

## Screenshots

<img width="1913" height="1016" alt="image" src="https://github.com/user-attachments/assets/6d240439-03ba-4721-9f5d-328e3e87cf64" />

<img width="1878" height="1017" alt="image" src="https://github.com/user-attachments/assets/bcd2e23a-989c-4ef1-935f-3dadd067f924" />

<img width="1912" height="1020" alt="image" src="https://github.com/user-attachments/assets/f49a212a-b3bb-4c34-8721-4b2c87de23ac" />

<img width="1898" height="1023" alt="image" src="https://github.com/user-attachments/assets/692af050-5281-46a1-be53-4a30ecda79f1" />

<img width="1915" height="1028" alt="image" src="https://github.com/user-attachments/assets/8b427292-4117-4582-b5c9-76fe041ddd88" />


## Checklist

<!-- Mark completed items with an [x] -->

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or errors
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Documentation

<!-- Describe any documentation changes needed -->

- [ ] README.md updated
- [ ] JSDoc comments added/updated
- [ ] No documentation changes needed

## Additional Notes

<!-- Add any additional notes for reviewers -->

## Reviewer Guidelines

<!-- For reviewers: What should they focus on? -->

Please pay special attention to:

- 
- 

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**
