### PR TITLE
fix: make version sync reliable and release-driven

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![VS Code Marketplace](https://img.shields.io/badge/VS%20Code-Marketplace-blue?logo=visual-studio-code)](https://marketplace.visualstudio.com/items?itemName=AmadeusITGroup.prompt-registry)
 [![Documentation](https://img.shields.io/badge/docs-GitHub%20Pages-blue?logo=github)](https://amadeusitgroup.github.io/prompt-registry/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Version](https://img.shields.io/badge/version-0.0.2-green.svg)](https://github.com/AmadeusITGroup/prompt-registry)
+[![Version](https://img.shields.io/github/v/release/AmadeusITGroup/ai-primitives-hub)](https://github.com/AmadeusITGroup/ai-primitives-hub/releases)
 
 ---
 


### PR DESCRIPTION
- Fix macOS grep -oP bug in update-version.sh (portable sed)
- Match any version in README badge/VSIX replacements so sync works regardless of package.json bump ordering (fixes stale badge)
- Sync package-lock.json via npm version
- Add --yes/CI non-interactive mode
- Sync VSIX filename in testing-ssh-remote.md
- Drive version from GitHub release tag in publish workflow
- Ignore *.backup.* temp files

