### PR TITLE
feat(cli): introduces a CLI

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,21 @@
+# @ai-primitives-hub/cli
+
+Thin Clipanion delivery adapter over `@ai-primitives-hub/app`. Depends on
+`core`, `infra`, and `app`. Commands parse arguments, call into `app`, and
+format output — no business logic lives here (see migration plan §3.3.3 for
+why this rule exists and what happens when it's violated).
+
+Status: **scaffolding only** (Phase 1 of `.tmp/ai-primitives-hub-next-migration-plan.md`).
+Real commands land in Phase 5 (§7.6): framework wiring (Clipanion, RC pin
+accepted per decision 8), foundational commands (`status`, `config`,
+`target`, `source`), hub/profile commands, index/search/discovery commands,
+install/uninstall, collection/scaffolding commands, and doctor/diagnostics
+(including HTTP-proxy/TLS-CA support carried over from prior work).
+
+## Development
+
+```bash
+pnpm --filter @ai-primitives-hub/cli build
+pnpm --filter @ai-primitives-hub/cli test
+pnpm --filter @ai-primitives-hub/cli lint
+```

--- a/packages/cli/bin/ai-primitives-hub.js
+++ b/packages/cli/bin/ai-primitives-hub.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+const { run } = require('../dist/index.js');
+
+run().then((exitCode) => {
+  process.exitCode = exitCode;
+}).catch((err) => {
+  console.error(err instanceof Error ? err.stack ?? err.message : err);
+  process.exitCode = 70;
+});

--- a/packages/cli/esbuild.config.mjs
+++ b/packages/cli/esbuild.config.mjs
@@ -1,0 +1,24 @@
+import esbuild from 'esbuild';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+await esbuild.build({
+  entryPoints: ['src/sea-entry.ts'],
+  bundle: true,
+  platform: 'node',
+  target: 'node24',
+  outfile: 'dist/ai-primitives-hub-bundle.js',
+  format: 'cjs',
+  external: [],
+  minify: true,
+  minifyIdentifiers: true,
+  minifySyntax: true,
+  minifyWhitespace: true,
+  sourcemap: false,
+  treeShaking: true,
+  metafile: true,
+  absWorkingDir: __dirname
+});

--- a/packages/cli/eslint.config.mjs
+++ b/packages/cli/eslint.config.mjs
@@ -1,0 +1,59 @@
+import {
+  defineConfig,
+  globalIgnores,
+} from 'eslint/config';
+import {
+  createSharedConfig,
+  temporaryWarnRules,
+  temporaryWarnRulesTs,
+} from '../../eslint.shared.mjs';
+
+export default defineConfig([
+  globalIgnores(
+    [
+      'dist/',
+      '**/*.d.ts',
+      'node_modules/'
+    ],
+    'cli/ignores'
+  ),
+  ...createSharedConfig({
+    name: 'cli',
+    tsProjects: ['tsconfig.json', 'tsconfig.test.json'],
+    tsconfigRootDir: import.meta.dirname
+  }),
+  {
+    // Clipanion's `Command.Usage(...)` is a static factory, not a
+    // constructor — exempt it from `new-cap`'s "capitalized names must
+    // be `new`-called" heuristic.
+    name: 'cli/clipanion-usage-factory',
+    files: ['**/*.ts'],
+    rules: {
+      'new-cap': ['error', { capIsNewExceptions: ['Usage'] }]
+    }
+  },
+  {
+    // TODO to be discussed and fixed in a future PR
+    name: 'cli/temporary-warn-rules-ts',
+    files: ['**/*.ts'],
+    rules: temporaryWarnRulesTs
+  },
+  {
+    // TODO to be discussed and fixed in a future PR
+    name: 'cli/temporary-warn-rules',
+    files: ['**/*.{j,t}s'],
+    rules: temporaryWarnRules
+  },
+  {
+    name: 'cli/test-ts-rules',
+    files: ['test/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-require-imports': 'off'
+    }
+  }
+]);

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@ai-primitives-hub/cli",
+  "version": "0.0.1-alpha.1",
+  "description": "ai-primitives-hub CLI. Thin Clipanion delivery adapter over @ai-primitives-hub/app — argument parsing and output formatting only, never business logic.",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "bin": {
+    "ai-primitives-hub": "./bin/ai-primitives-hub.js"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AmadeusITGroup/ai-primitives-hub.git",
+    "directory": "packages/cli"
+  },
+  "keywords": [
+    "ai-primitives-hub",
+    "cli"
+  ],
+  "author": {
+    "name": "Amadeus IT Group",
+    "email": "opensource@amadeus.com"
+  },
+  "files": [
+    "dist",
+    "bin"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc --watch",
+    "lint": "eslint src test",
+    "lint:fix": "eslint src test --fix",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "build:sea": "node scripts/build-sea.mjs",
+    "build:sea:local": "node scripts/build-sea.mjs --local",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@ai-primitives-hub/app": "workspace:*",
+    "@ai-primitives-hub/core": "workspace:*",
+    "@ai-primitives-hub/infra": "workspace:*",
+    "archiver": "^7.0.1",
+    "clipanion": "4.0.0-rc.4",
+    "inquirer": "^9.3.8",
+    "js-yaml": "^4.0.0",
+    "semver": "^7.5.4",
+    "typanion": "^3.14.0"
+  },
+  "devDependencies": {
+    "@types/archiver": "^7.0.0",
+    "@types/inquirer": "^9.0.9",
+    "@types/js-yaml": "^4.0.9",
+    "@types/node": "^22.0.0",
+    "@types/semver": "^7.5.6",
+    "@vitest/coverage-v8": "^4.1.7",
+    "esbuild": "^0.28.1",
+    "postject": "1.0.0-alpha.6",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.7"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/packages/cli/scripts/build-sea.mjs
+++ b/packages/cli/scripts/build-sea.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import crypto from 'crypto';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.join(__dirname, '..');
+
+const isLocal = process.argv.includes('--local');
+const platform = process.platform;
+const arch = process.arch;
+
+console.log(`Building SEA for ${platform}-${arch}...`);
+
+// Step 1: Build TypeScript
+console.log('Building TypeScript...');
+execSync('pnpm run build', { cwd: rootDir, stdio: 'inherit' });
+
+// Step 2: Bundle with esbuild
+console.log('Bundling with esbuild...');
+execSync('node esbuild.config.mjs', { cwd: rootDir, stdio: 'inherit' });
+
+// Step 3: Generate SEA blob
+console.log('Generating SEA blob...');
+execSync('node --experimental-sea-config sea-config.json', { cwd: rootDir, stdio: 'inherit' });
+
+// Step 4: Copy Node executable
+const nodePath = process.execPath;
+const outputName = isLocal
+  ? `ai-primitives-hub-${platform}-${arch}${platform === 'win32' ? '.exe' : ''}`
+  : `ai-primitives-hub${platform === 'win32' ? '.exe' : ''}`;
+const outputPath = path.join(rootDir, 'dist', outputName);
+
+console.log(`Copying Node executable to ${outputPath}...`);
+fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+fs.copyFileSync(nodePath, outputPath);
+
+// Step 5: Remove signature (macOS)
+if (platform === 'darwin') {
+  console.log('Removing signature (macOS)...');
+  try {
+    execSync(`codesign --remove-signature "${outputPath}"`, { stdio: 'inherit' });
+  } catch (e) {
+    // Ignore if already unsigned
+  }
+}
+
+// Step 6: Inject blob with postject
+console.log('Injecting blob with postject...');
+execSync(
+  `npx -y postject "${outputPath}" NODE_SEA_BLOB sea-prep.blob ` +
+  `--sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2 ` +
+  `--macho-segment-name NODE_SEA`,
+  { cwd: rootDir, stdio: 'inherit' }
+);
+
+// Step 7: Sign binary (macOS)
+if (platform === 'darwin') {
+  console.log('Signing binary (macOS)...');
+  try {
+    execSync(`codesign --sign - "${outputPath}"`, { stdio: 'inherit' });
+  } catch (e) {
+    // Ignore if signing fails
+  }
+}
+
+// Step 8: Make executable
+if (platform !== 'win32') {
+  console.log('Making executable...');
+  fs.chmodSync(outputPath, '0755');
+}
+
+// Step 9: Generate checksum
+console.log('Generating checksum...');
+const hash = crypto.createHash('sha256');
+const fileBuffer = fs.readFileSync(outputPath);
+hash.update(fileBuffer);
+const checksum = hash.digest('hex');
+fs.writeFileSync(`${outputPath}.sha256`, checksum);
+
+// Step 10: Clean up
+console.log('Cleaning up...');
+fs.unlinkSync(path.join(rootDir, 'sea-prep.blob'));
+
+console.log(`Single executable created at: ${outputPath}`);
+console.log(`File size: ${(fs.statSync(outputPath).size / 1024 / 1024).toFixed(2)} MB`);
+console.log(`SHA256: ${checksum}`);

--- a/packages/cli/sea-config.json
+++ b/packages/cli/sea-config.json
@@ -1,0 +1,5 @@
+{
+  "main": "dist/ai-primitives-hub-bundle.js",
+  "output": "sea-prep.blob",
+  "disableExperimentalSEAWarning": true
+}

--- a/packages/cli/src/commands/agent-create.ts
+++ b/packages/cli/src/commands/agent-create.ts
@@ -1,0 +1,161 @@
+/**
+ * `agent create` subcommand.
+ *
+ * Creates a new agent file with proper structure using templates.
+ *
+ * Usage:
+ *   ai-primitives-hub agent create coder \
+ *     --description "Coding assistant agent"
+ * @module commands/agent-create
+ */
+import * as path from 'node:path';
+import {
+  readCollection,
+  writeCollection,
+} from '@ai-primitives-hub/app';
+import {
+  generateSanitizedId,
+  TemplateContext,
+} from '@ai-primitives-hub/core';
+import type {
+  CollectionItem,
+} from '@ai-primitives-hub/core';
+import {
+  TEMPLATE_PATHS,
+  TemplateEngine,
+} from '@ai-primitives-hub/infra';
+import {
+  Command,
+  type Context,
+  formatOutput,
+  Option,
+  type OutputFormat,
+  RegistryError,
+  renderError,
+} from '../framework';
+
+/**
+ * Agent create command class.
+ */
+export class AgentCreateCommand extends Command {
+  public static readonly paths = [['agent', 'create']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Create a new agent file',
+    category: 'Primitive',
+    details: `
+      Usage: ai-primitives-hub agent create <name> [options]
+
+      Options:
+        --description <text>   Agent description
+        --path <dir>           Output directory (default: agents/)
+        -o, --output <format>  Output format (text, json, yaml, ndjson)
+
+      Examples:
+        ai-primitives-hub agent create coder
+        ai-primitives-hub agent create coder --description "Coding assistant agent"
+    `
+  });
+
+  public name = Option.String({ required: true });
+  public description = Option.String('--description');
+  public collection = Option.String('--collection');
+  public pathOption = Option.String('--path');
+  public output = Option.String('-o', '--output') as OutputFormat | undefined;
+  public commandContext!: { ctx: Context };
+
+  public async execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+    const fmt = (this.output ?? 'text');
+
+    try {
+      // Determine agent name
+      const agentName = generateSanitizedId(this.name);
+      const displayName = this.name;
+
+      // Build template context
+      const context: TemplateContext = {
+        projectName: agentName,
+        collectionId: agentName,
+        name: displayName,
+        description: this.description || `A ${displayName} agent`
+      };
+
+      // Determine output path
+      const outputPath = this.pathOption || 'agents';
+      const targetPath = path.isAbsolute(outputPath) ? outputPath : path.join(ctx.cwd(), outputPath);
+
+      // Initialize template engine
+      const templateEngine = new TemplateEngine(TEMPLATE_PATHS.agent);
+
+      // Scaffold the agent
+      const result = await templateEngine.scaffoldProject(targetPath, context);
+
+      if (!result.success) {
+        const err = new RegistryError({
+          code: 'FS.SCAFFOLD_FAILED',
+          message: result.error || 'Scaffolding failed'
+        });
+        renderError(err, ctx);
+        return 1;
+      }
+
+      // Add to collection if specified
+      if (this.collection) {
+        const collectionId = this.collection;
+        const collectionFile = path.join(ctx.cwd(), 'collections', `${collectionId}.collection.yml`);
+
+        try {
+          const collection = readCollection(ctx.cwd(), collectionFile);
+
+          // Calculate repo-root relative path
+          const createdFile = result.createdFiles[0];
+          const relativePath = path.relative(ctx.cwd(), createdFile).replace(/\\/g, '/');
+
+          // Add item to collection
+          const newItem: CollectionItem = {
+            path: relativePath,
+            kind: 'agent',
+            name: displayName,
+            description: this.description
+          };
+
+          collection.items.push(newItem);
+          writeCollection(ctx.cwd(), collectionFile, collection);
+        } catch (error) {
+          const err = new RegistryError({
+            code: 'FS.COLLECTION_UPDATE_FAILED',
+            message: `Failed to add agent to collection: ${(error as Error).message}`
+          });
+          renderError(err, ctx);
+          return 1;
+        }
+      }
+
+      // Format output
+      formatOutput({
+        ctx,
+        command: 'agent create',
+        output: fmt,
+        status: 'ok',
+        data: {
+          name: agentName,
+          path: result.createdFiles[0],
+          createdFiles: result.createdFiles,
+          collection: this.collection
+        }
+      });
+      return 0;
+    } catch (error) {
+      const registryError = error instanceof RegistryError
+        ? error
+        : new RegistryError({
+          code: 'INTERNAL.UNEXPECTED',
+          message: (error as Error).message
+        });
+
+      renderError(registryError, ctx);
+      return 1;
+    }
+  }
+}

--- a/packages/cli/src/commands/apply.ts
+++ b/packages/cli/src/commands/apply.ts
@@ -1,0 +1,150 @@
+/**
+ * `apply` command.
+ *
+ * Idempotent "make the system match the config" entry point: re-syncs
+ * the active hub (unless `--no-sync`) and re-activates whatever profile
+ * `ProfileActivationStore` currently records as active, on every
+ * configured target.
+ *
+ * Intended for CI and post-clone developer setup:
+ *   ai-primitives-hub apply
+ *
+ * Reuses `profile.ts`'s `buildHubMgr`/`runProfileActivation` — this
+ * command is, in effect, "re-run `profile activate <currentProfileId>`"
+ * (see those functions' docs for the write/lockfile/activation-state
+ * details). Unlike the reference branch's own `apply.ts`, the "which
+ * profile is active" question is answered via `ProfileActivationStore`,
+ * not a `lock.useProfile` field — our lockfile schema has no such field
+ * (see `stores/json-lockfile-store.ts`'s module doc, and `profile.ts`'s
+ * own module doc for why).
+ * @module commands/apply
+ */
+import type {
+  HttpClient,
+  TokenProvider,
+} from '@ai-primitives-hub/core';
+import {
+  Command,
+  failWith,
+  loadTargets,
+  Option,
+  requireActiveHubOrFail,
+} from '../framework';
+import {
+  type Context,
+  formatOutput,
+  type OutputFormat,
+  RegistryError,
+} from '../framework';
+import {
+  buildHubMgr,
+  runProfileActivation,
+} from './profile';
+
+/**
+ * Context passed to the apply command's execute method.
+ */
+interface ApplyCommandContext {
+  ctx: Context;
+  http?: HttpClient;
+  tokens?: TokenProvider;
+}
+
+/**
+ * `apply` command class.
+ */
+export class ApplyCommand extends Command {
+  public static readonly paths = [['apply']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Idempotent: sync active hub and re-activate the currently active profile.',
+    category: 'Install & Manage',
+    details: `
+      Usage: ai-primitives-hub apply [options]
+
+      Options:
+        --no-sync                Skip hub sync (useful in offline/CI environments)
+        -o, --output <format>     Output format (text, json, yaml, ndjson)
+
+      Examples:
+        ai-primitives-hub apply
+        ai-primitives-hub apply --no-sync
+    `
+  });
+
+  public output = Option.String('-o', '--output') as OutputFormat | undefined;
+  public noSync = Option.Boolean('--no-sync', false);
+  public commandContext!: ApplyCommandContext;
+
+  public async execute(): Promise<number> {
+    const { ctx, http, tokens } = this.commandContext;
+    const fmt = this.output ?? 'text';
+    const built = buildHubMgr(ctx, http, tokens);
+
+    const allActive = await built.activations.listAll();
+    const cur = allActive[0];
+    if (!cur) {
+      return failWith(ctx, fmt, 'apply', new RegistryError({
+        code: 'USAGE.MISSING_FLAG',
+        message: 'apply: no active profile',
+        hint: 'Run `ai-primitives-hub profile activate <profileId>` first to activate one.'
+      }));
+    }
+
+    if (!this.noSync) {
+      try {
+        await built.mgr.syncHub(cur.hubId);
+      } catch {
+        ctx.stderr.write(`warn: hub sync failed for "${cur.hubId}", continuing with cached config\n`);
+      }
+    }
+
+    const active = await requireActiveHubOrFail(built.mgr, cur.hubId, 'apply', ctx, fmt);
+    if (typeof active === 'number') {
+      return active;
+    }
+    const profile = active.config.profiles.find((p) => p.id === cur.profileId);
+    if (profile === undefined) {
+      return failWith(ctx, fmt, 'apply', new RegistryError({
+        code: 'BUNDLE.NOT_FOUND',
+        message: `apply: profile "${cur.profileId}" not found in hub "${cur.hubId}"`,
+        hint: 'Run `ai-primitives-hub profile list` to see available profiles.'
+      }));
+    }
+
+    const targets = await loadTargets(ctx);
+    if (targets.length === 0) {
+      return failWith(ctx, fmt, 'apply', new RegistryError({
+        code: 'USAGE.MISSING_FLAG',
+        message: 'apply: no targets configured',
+        hint: 'Run `ai-primitives-hub target add <name> --type <kind>` to configure a target.'
+      }));
+    }
+
+    const { state, written, failures } = await runProfileActivation(ctx, built, cur.hubId, profile, targets);
+
+    const status = failures.length === 0 ? 'ok' : 'warning';
+    formatOutput({
+      ctx,
+      command: 'apply',
+      output: fmt,
+      status,
+      data: {
+        hubId: cur.hubId,
+        profileId: profile.id,
+        synced: !this.noSync,
+        state,
+        written,
+        failures
+      },
+      warnings: failures.length > 0 ? failures.map((f) => `${f.bundleId} (${f.target}): ${f.reason}`) : undefined,
+      textRenderer: (d) => `Applied: hub "${d.hubId}" → profile "${d.profileId}"\n`
+        + `  Bundles: ${[...new Set(d.state.syncedBundles)].join(', ')}\n`
+        + `  Targets: ${Object.keys(d.written).join(', ')}\n`
+        + (d.failures.length > 0
+          ? `  Failures:\n${d.failures.map((f) => `    - ${f.bundleId} (${f.target}): ${f.reason}\n`).join('')}`
+          : '')
+    });
+    return failures.length === 0 ? 0 : 1;
+  }
+}

--- a/packages/cli/src/commands/bundle-build.ts
+++ b/packages/cli/src/commands/bundle-build.ts
@@ -1,0 +1,262 @@
+/**
+ * `bundle build` subcommand.
+ *
+ * Generates a deployment manifest (delegating to `bundle manifest`'s
+ * in-process helper) and zips it together with the referenced primitive
+ * files into a reproducible `<collection-id>.bundle.zip`.
+ *
+ * Reproducibility:
+ *   - All entries get the same fixed timestamp (`1980-01-01T00:00:00Z`).
+ *   - File entries are sorted lexicographically before being added to
+ *     the archive.
+ *   - `archiver` is configured with maximum zlib compression for
+ *     deterministic byte-identical output across runs.
+ * @module commands/bundle-build
+ */
+// archiver needs a real Node WriteStream. Context.fs is a high-level
+// abstraction (read/write/exists/mkdir) and does not expose stream APIs. The
+// bounded usage is the single createWriteStream call inside
+// createDeterministicZip; the natural moment to add Context.fs.createWriteStream
+// is when install downloads are added.
+import {
+  createWriteStream,
+  existsSync,
+  unlinkSync,
+} from 'node:fs';
+import * as path from 'node:path';
+import {
+  readCollection,
+  resolveCollectionItemPaths,
+} from '@ai-primitives-hub/app';
+import {
+  generateBundleId,
+  normalizeRepoRelativePath,
+} from '@ai-primitives-hub/core';
+import archiver from 'archiver';
+import {
+  Command,
+  type Context,
+  formatOutput,
+  Option,
+  type OutputFormat,
+  RegistryError,
+  renderError,
+} from '../framework';
+import {
+  generateBundleManifest,
+} from './bundle-manifest';
+
+/**
+ * Bundle build data.
+ */
+interface BundleBuildData {
+  collectionId: string;
+  version: string;
+  outDir: string;
+  manifestAsset: string;
+  zipAsset: string;
+  bundleId: string;
+}
+
+/** Fixed date for reproducible bundle timestamps. */
+const FIXED_DATE = new Date('1980-01-01T00:00:00.000Z');
+
+/**
+ * Create a deterministic ZIP archive with fixed timestamps and sorted entries.
+ * @param input - Zip creation parameters.
+ * @param input.repoRoot
+ * @param input.zipPath
+ * @param input.manifestPath
+ * @param input.itemPaths
+ * @returns Promise that resolves when the ZIP is created.
+ */
+const createDeterministicZip = (input: {
+  repoRoot: string;
+  zipPath: string;
+  manifestPath: string;
+  itemPaths: string[];
+}): Promise<void> => {
+  // The single archiver/streams use site in this command file.
+  // Reproducible timestamps, sorted entry order, max zlib compression.
+  return new Promise((resolve, reject) => {
+    const output = createWriteStream(input.zipPath);
+    const archive = archiver('zip', { zlib: { level: 9 } });
+
+    // Flag to prevent double-cleanup if both output and archive error handlers fire
+    let cleaned = false;
+
+    // Cleanup function to remove partially written zip on error
+    const cleanup = () => {
+      if (cleaned) {
+        return;
+      }
+      cleaned = true;
+      try {
+        // Use destroy() instead of close() for error cleanup - it aborts the stream
+        // immediately without waiting for buffered data to flush
+        output.destroy();
+        if (existsSync(input.zipPath)) {
+          unlinkSync(input.zipPath);
+        }
+      } catch {
+        // Ignore cleanup errors
+      }
+    };
+
+    output.on('close', resolve);
+    output.on('error', (err) => {
+      cleanup();
+      reject(err);
+    });
+    archive.on('error', (err) => {
+      cleanup();
+      reject(err);
+    });
+    archive.pipe(output);
+    archive.file(input.manifestPath, { name: 'deployment-manifest.yml', date: FIXED_DATE });
+    const sorted = input.itemPaths
+      .map((p) => normalizeRepoRelativePath(p))
+      .toSorted((a, b) => a.localeCompare(b));
+    for (const rel of sorted) {
+      const abs = path.join(input.repoRoot, rel);
+      archive.file(abs, { name: rel, date: FIXED_DATE });
+    }
+    archive.finalize().catch(() => { /* handled by archive.on('error') above */ });
+  });
+};
+
+/**
+ * Emit error in appropriate format.
+ * @param ctx CLI context.
+ * @param output Output format.
+ * @param err Registry error.
+ */
+const emitError = (ctx: Context, output: OutputFormat, err: RegistryError): void => {
+  if (output === 'json' || output === 'yaml' || output === 'ndjson') {
+    formatOutput({
+      ctx,
+      command: 'bundle.build',
+      output,
+      status: 'error',
+      data: null,
+      errors: [err.toJSON()]
+    });
+  } else {
+    renderError(err, ctx);
+  }
+};
+
+/**
+ * Bundle build command class.
+ */
+export class BundleBuildCommand extends Command {
+  public static readonly paths = [['bundle', 'build']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Generate a deployment manifest and zip collection items into a bundle.',
+    category: 'Build & Author',
+    details: `
+      Usage: ai-primitives-hub bundle build [options]
+
+      Options:
+        -o, --output <format>       Output format (text, json, yaml, ndjson)
+        --collection-file <path>    Collection file path (repo-relative)
+        --version <version>         Bundle version (e.g. 1.0.0)
+        --out-dir <dir>             Output directory (default: dist)
+        --repo-slug <slug>          Repo slug (owner-repo, or GITHUB_REPOSITORY env var, or cwd dirname)
+    `
+  });
+
+  public output = Option.String('-o', '--output') as OutputFormat | undefined;
+  public collectionFile = Option.String('--collection-file');
+  public version = Option.String('--version');
+  public outDir = Option.String('--out-dir');
+  public repoSlug = Option.String('--repo-slug');
+  public commandContext!: { ctx: Context };
+
+  public async execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+    const fmt = (this.output ?? 'text');
+    const collectionFile = this.collectionFile ?? '';
+    const version = this.version ?? '';
+
+    try {
+      const cwd = ctx.cwd();
+      const repoSlug = (this.repoSlug
+        ?? (ctx.env.GITHUB_REPOSITORY ?? '').replaceAll('/', '-'))
+      || path.basename(cwd);
+      // Resolve outDir against ctx.cwd() so the command honors
+      // injected working directories (Context invariant).
+      const outDirRel = this.outDir ?? 'dist';
+      const outDir = path.isAbsolute(outDirRel) ? outDirRel : path.join(cwd, outDirRel);
+      const collection = readCollection(cwd, collectionFile);
+      const collectionId = collection.id;
+      if (typeof collectionId !== 'string' || collectionId.length === 0) {
+        throw new RegistryError({
+          code: 'BUNDLE.INVALID_MANIFEST',
+          message: 'collection.id is required'
+        });
+      }
+
+      const bundleId = generateBundleId(repoSlug, collectionId, version);
+      const collectionOutDir = path.join(outDir, collectionId);
+      await ctx.fs.mkdir(collectionOutDir, { recursive: true });
+
+      // Generate the deployment-manifest.yml in the bundle output
+      // directory by calling `bundle manifest`'s exported helper
+      // in-process (its own errors propagate via the same try/catch).
+      const standaloneManifestPath = path.join(collectionOutDir, 'deployment-manifest.yml');
+      // Suppress the manifest sub-step's own stdout envelope so it
+      // doesn't pollute this command's output. The OutputStream
+      // contract is just `{ write(chunk: string): void }`.
+      const subCtx: Context = {
+        ...ctx,
+        stdout: { write: () => undefined }
+      };
+      await generateBundleManifest(
+        subCtx,
+        cwd,
+        { output: 'json', version, collectionFile },
+        standaloneManifestPath
+      );
+
+      const itemPaths = resolveCollectionItemPaths(cwd, collection);
+      const zipPath = path.join(collectionOutDir, `${collectionId}.bundle.zip`);
+      await createDeterministicZip({
+        repoRoot: cwd,
+        zipPath,
+        manifestPath: standaloneManifestPath,
+        itemPaths
+      });
+
+      const data: BundleBuildData = {
+        collectionId,
+        version,
+        outDir: collectionOutDir.replaceAll('\\', '/'),
+        manifestAsset: standaloneManifestPath.replaceAll('\\', '/'),
+        zipAsset: zipPath.replaceAll('\\', '/'),
+        bundleId
+      };
+      formatOutput({
+        ctx,
+        command: 'bundle.build',
+        output: fmt,
+        status: 'ok',
+        data,
+        textRenderer: (d) =>
+          `Built ${d.zipAsset} (bundle id: ${d.bundleId}, version: ${d.version})\n`
+      });
+      return 0;
+    } catch (err) {
+      const re = err instanceof RegistryError
+        ? err
+        : new RegistryError({
+          code: 'INTERNAL.UNEXPECTED',
+          message: err instanceof Error ? err.message : String(err),
+          cause: err
+        });
+      emitError(ctx, fmt, re);
+      return 1;
+    }
+  }
+}

--- a/packages/cli/src/commands/bundle-manifest.ts
+++ b/packages/cli/src/commands/bundle-manifest.ts
@@ -1,0 +1,469 @@
+/**
+ * `bundle manifest` subcommand.
+ *
+ * Reads a collection YAML file plus the referenced primitive files, then
+ * writes a deployment manifest YAML to `outFile`.
+ * @module commands/bundle-manifest
+ */
+import * as path from 'node:path';
+import {
+  normalizeRepoRelativePath,
+} from '@ai-primitives-hub/core';
+import * as yaml from 'js-yaml';
+import {
+  Command,
+  type Context,
+  formatOutput,
+  Option,
+  type OutputFormat,
+  RegistryError,
+  renderError,
+} from '../framework';
+
+/**
+ * Bundle manifest data.
+ */
+interface BundleManifestData {
+  id: string;
+  version: string;
+  outFile: string;
+  totalItems: number;
+  itemsByType: Record<string, number>;
+  mcpServerCount: number;
+}
+
+/**
+ * Options accepted by {@link generateBundleManifest}.
+ */
+export interface BundleManifestOptions {
+  /** Output format. Default 'text'. */
+  output?: OutputFormat;
+  /** Bundle version (e.g. '1.0.0'). Required. */
+  version: string;
+  /**
+   * Collection file (repo-relative). When unset, the first
+   * `*.collection.yml` under `<cwd>/collections/` is used.
+   */
+  collectionFile?: string;
+}
+
+/**
+ * Kind to type mapping for deployment manifest.
+ */
+const KIND_TO_TYPE_MAP: Record<string, string> = {
+  instruction: 'instructions',
+  'chat-mode': 'chatmode',
+  plugin: 'plugin',
+  hook: 'hook'
+};
+
+/**
+ * Raw collection structure.
+ */
+interface RawCollection {
+  id?: string;
+  name?: string;
+  description?: string;
+  author?: string;
+  tags?: string[];
+  items?: { path?: string; kind?: string }[];
+  mcpServers?: Record<string, unknown>;
+  mcp?: { items?: Record<string, unknown> };
+}
+
+interface PromptEntry {
+  id: string;
+  name: string;
+  description: string;
+  file: string;
+  type: string;
+  tags: string[];
+}
+
+/**
+ * Extract item metadata from markdown content.
+ * @param itemContent Markdown content.
+ * @returns Extracted name and description.
+ */
+function extractItemMetadata(itemContent: string): { name: string; description: string } {
+  const nameMatch = /^#\s+(.+)$/m.exec(itemContent);
+  const descMatch = /^##?\s*Description[:\s]+(.+)$/im.exec(itemContent)
+    ?? /^>\s*(.+)$/m.exec(itemContent);
+  return {
+    name: nameMatch === null ? '' : nameMatch[1],
+    description: descMatch === null ? '' : descMatch[1]
+  };
+}
+
+/**
+ * Extract item metadata from JSON content (plugin.json or hook config).
+ * Falls back to empty strings when fields are absent.
+ * @param itemContent Raw JSON string.
+ * @returns Extracted name and description.
+ */
+function extractJsonItemMetadata(itemContent: string): { name: string; description: string } {
+  try {
+    const parsed = JSON.parse(itemContent) as Record<string, unknown>;
+    return {
+      name: typeof parsed.name === 'string' ? parsed.name : '',
+      description: typeof parsed.description === 'string' ? parsed.description : ''
+    };
+  } catch {
+    return { name: '', description: '' };
+  }
+}
+
+/**
+ * Extract item metadata from file content, dispatching by extension.
+ * @param itemContent Raw file content.
+ * @param itemPath Repo-relative path (used to determine format).
+ * @returns Extracted name and description.
+ */
+function extractItemMetadataByPath(
+  itemContent: string,
+  itemPath: string
+): { name: string; description: string } {
+  return itemPath.endsWith('.json')
+    ? extractJsonItemMetadata(itemContent)
+    : extractItemMetadata(itemContent);
+}
+
+/**
+ * Generate item ID from path and kind.
+ * @param itemPath Item path.
+ * @param kind Item kind.
+ * @returns Generated item ID.
+ */
+function generateItemId(itemPath: string, kind: string): string {
+  const extension = path.extname(itemPath);
+  if (kind === 'skill' || kind === 'plugin') {
+    const parts = itemPath.split('/');
+    return parts.length >= 2
+      ? (parts.at(-2) ?? path.basename(itemPath, extension))
+      : path.basename(itemPath, extension);
+  }
+  return path.basename(itemPath, extension);
+}
+
+/**
+ * Build a prompt entry for the deployment manifest.
+ * @param item Collection item.
+ * @param item.path
+ * @param item.kind
+ * @param itemPath Item path.
+ * @param collection Raw collection.
+ * @param itemContent Item markdown content.
+ * @returns Prompt entry.
+ */
+function buildPromptEntry(
+  item: { path?: string; kind?: string },
+  itemPath: string,
+  collection: RawCollection,
+  itemContent: string
+): PromptEntry {
+  const { name, description } = extractItemMetadataByPath(itemContent, itemPath);
+  const itemId = generateItemId(itemPath, item.kind || '');
+  const tags = Array.isArray(collection.tags) ? [...collection.tags] : [];
+  const type = KIND_TO_TYPE_MAP[item.kind || ''] ?? item.kind ?? '';
+  return {
+    id: itemId,
+    name: name || itemId,
+    description,
+    file: itemPath,
+    type,
+    tags
+  };
+}
+
+/**
+ * Process collection items into prompt entries.
+ * @param items Collection items.
+ * @param collection Raw collection.
+ * @param ctx CLI context.
+ * @param cwd Current working directory.
+ * @returns Array of prompt entries.
+ */
+async function processCollectionItems(
+  items: { path?: string; kind?: string }[],
+  collection: RawCollection,
+  ctx: Context,
+  cwd: string
+): Promise<PromptEntry[]> {
+  const prompts: PromptEntry[] = [];
+  for (const item of items) {
+    if (item.path === undefined || item.kind === undefined) {
+      continue;
+    }
+    const itemPath = normalizeRepoRelativePath(item.path);
+    const itemAbs = path.join(cwd, itemPath);
+    if (!(await ctx.fs.exists(itemAbs))) {
+      throw new RegistryError({
+        code: 'BUNDLE.ITEM_NOT_FOUND',
+        message: `Referenced ${item.kind} file not found: ${itemPath}`,
+        context: { itemPath, kind: item.kind }
+      });
+    }
+    const itemContent = await ctx.fs.readFile(itemAbs);
+    prompts.push(buildPromptEntry(item, itemPath, collection, itemContent));
+  }
+  return prompts;
+}
+
+/**
+ * Count items by type.
+ * @param prompts Prompt entries.
+ * @returns Record of type to count.
+ */
+function countItemsByType(prompts: { type: string }[]): Record<string, number> {
+  const itemsByType: Record<string, number> = {};
+  for (const p of prompts) {
+    itemsByType[p.type] = (itemsByType[p.type] ?? 0) + 1;
+  }
+  return itemsByType;
+}
+
+/**
+ * Write manifest file to disk.
+ * @param collection Raw collection.
+ * @param prompts Prompt entries.
+ * @param version Bundle version.
+ * @param outFile Output file path.
+ * @param ctx CLI context.
+ */
+async function writeManifestFile(
+  collection: RawCollection,
+  prompts: PromptEntry[],
+  version: string,
+  outFile: string,
+  ctx: Context
+): Promise<void> {
+  const manifest = buildManifest(collection, prompts, version);
+  await ctx.fs.mkdir(path.dirname(outFile), { recursive: true });
+  await ctx.fs.writeFile(outFile, yaml.dump(manifest, { lineWidth: -1 }));
+}
+
+/**
+ * Build manifest data for output.
+ * @param collection Raw collection.
+ * @param prompts Prompt entries.
+ * @param version Bundle version.
+ * @param outFile Output file path.
+ * @returns Bundle manifest data.
+ */
+function buildManifestData(
+  collection: RawCollection,
+  prompts: PromptEntry[],
+  version: string,
+  outFile: string
+): BundleManifestData {
+  const itemsByType = countItemsByType(prompts);
+  const manifestId = collection.id ?? 'unknown';
+  const mcpServers = collection.mcpServers ?? collection.mcp?.items;
+  return {
+    id: manifestId,
+    version,
+    outFile,
+    totalItems: prompts.length,
+    itemsByType,
+    mcpServerCount: mcpServers === undefined ? 0 : Object.keys(mcpServers).length
+  };
+}
+
+/**
+ * Build deployment manifest.
+ * @param collection Raw collection.
+ * @param prompts Prompt entries.
+ * @param version Bundle version.
+ * @returns Deployment manifest object.
+ */
+function buildManifest(
+  collection: RawCollection,
+  prompts: PromptEntry[],
+  version: string
+): unknown {
+  const manifestId = collection.id ?? 'unknown';
+  const mcpServers = collection.mcpServers ?? collection.mcp?.items;
+  return {
+    id: manifestId,
+    version,
+    name: collection.name ?? '',
+    description: collection.description ?? '',
+    author: collection.author ?? 'Prompt Registry',
+    tags: collection.tags ?? [],
+    environments: ['vscode', 'windsurf', 'cursor'],
+    license: 'MIT',
+    repository: '',
+    prompts,
+    dependencies: [],
+    ...(mcpServers !== undefined && Object.keys(mcpServers).length > 0 ? { mcpServers } : {})
+  };
+}
+
+/**
+ * Resolve collection file path.
+ * @param ctx CLI context.
+ * @param cwd Current working directory.
+ * @param explicit Explicit collection file path.
+ * @returns Resolved collection file path.
+ */
+const resolveCollectionFile = async (
+  ctx: Context,
+  cwd: string,
+  explicit: string | undefined
+): Promise<string> => {
+  if (explicit !== undefined) {
+    return explicit;
+  }
+  const collectionsDir = path.join(cwd, 'collections');
+  if (!(await ctx.fs.exists(collectionsDir))) {
+    throw new RegistryError({
+      code: 'FS.NOT_FOUND',
+      message: `collections/ directory not found under ${cwd}`,
+      hint: 'Pass --collection-file or run from a repo with a collections/ folder.'
+    });
+  }
+  const entries = await ctx.fs.readDir(collectionsDir);
+  const first = entries.find((e) => e.endsWith('.collection.yml'));
+  if (first === undefined) {
+    throw new RegistryError({
+      code: 'BUNDLE.NOT_FOUND',
+      message: 'no `*.collection.yml` files in collections/'
+    });
+  }
+  return path.join('collections', first);
+};
+
+/**
+ * Render bundle manifest data as text.
+ * @param d Bundle manifest data.
+ * @returns Formatted text output.
+ */
+const renderText = (d: BundleManifestData): string => {
+  const lines: string[] = [`Generated ${d.outFile}`, `  id: ${d.id}`, `  version: ${d.version}`, `  total items: ${d.totalItems}`];
+  for (const [type, count] of Object.entries(d.itemsByType)) {
+    lines.push(`    ${type}: ${count}`);
+  }
+  if (d.mcpServerCount > 0) {
+    // Capitalised "MCP Servers" preserves the legacy script's text
+    // (a legacy regression test asserted the exact substring
+    // `MCP Servers: <n>` to keep CI logs stable).
+    lines.push(`  MCP Servers: ${d.mcpServerCount}`);
+  }
+  return `${lines.join('\n')}\n`;
+};
+
+/**
+ * Emit error in appropriate format.
+ * @param ctx CLI context.
+ * @param output Output format.
+ * @param err Registry error.
+ */
+const emitError = (ctx: Context, output: OutputFormat, err: RegistryError): void => {
+  if (output === 'json' || output === 'yaml' || output === 'ndjson') {
+    formatOutput({
+      ctx,
+      command: 'bundle.manifest',
+      output,
+      status: 'error',
+      data: null,
+      errors: [err.toJSON()]
+    });
+  } else {
+    renderError(err, ctx);
+  }
+};
+
+/**
+ * Generate a deployment manifest from a collection, writing it to
+ * `outFile` and emitting the result via `formatOutput`.
+ *
+ * Exported (unlike the reference branch's module-private equivalent) so
+ * `bundle build` can call it directly as an in-process sub-step instead
+ * of constructing a `CommandDefinition` and invoking `.run()` — this
+ * branch dropped that dual class/`defineCommand` indirection everywhere
+ * (see `target-*`/`index-*` PROGRESS.md notes), so the sub-step call
+ * goes straight to the underlying function instead.
+ * @param ctx CLI context.
+ * @param cwd Current working directory.
+ * @param opts Command options.
+ * @param outFile Output file path.
+ */
+export async function generateBundleManifest(
+  ctx: Context,
+  cwd: string,
+  opts: BundleManifestOptions,
+  outFile: string
+): Promise<void> {
+  const collectionFile = await resolveCollectionFile(ctx, cwd, opts.collectionFile);
+  const collectionAbs = path.isAbsolute(collectionFile)
+    ? collectionFile
+    : path.join(cwd, collectionFile);
+  const collection = yaml.load(await ctx.fs.readFile(collectionAbs)) as RawCollection;
+  const items = Array.isArray(collection.items) ? collection.items : [];
+  const prompts = await processCollectionItems(items, collection, ctx, cwd);
+
+  await writeManifestFile(collection, prompts, opts.version, outFile, ctx);
+  const data = buildManifestData(collection, prompts, opts.version, outFile);
+  formatOutput({
+    ctx,
+    command: 'bundle.manifest',
+    output: opts.output ?? 'text',
+    status: 'ok',
+    data,
+    textRenderer: renderText
+  });
+}
+
+/**
+ * Bundle manifest command class.
+ */
+export class BundleManifestCommand extends Command {
+  public static readonly paths = [['bundle', 'manifest']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Generate a deployment-manifest.yml from a collection.yml.',
+    category: 'Build & Author',
+    details: `
+      Usage: ai-primitives-hub bundle manifest [options]
+
+      Options:
+        -o, --output <format>       Output format (text, json, yaml, ndjson)
+        --version <version>         Bundle version (e.g. 1.0.0)
+        --collection-file <path>    Collection file path (repo-relative)
+        --out-file <path>          Output file path (default: deployment-manifest.yml)
+    `
+  });
+
+  public output = Option.String('-o', '--output') as OutputFormat | undefined;
+  public version = Option.String('--version');
+  public collectionFile = Option.String('--collection-file');
+  public outFile = Option.String('--out-file');
+  public commandContext!: { ctx: Context };
+
+  public async execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+    const fmt = (this.output ?? 'text');
+    const version = this.version ?? '';
+    const collectionFile = this.collectionFile;
+    const cwd = ctx.cwd();
+    const outFileRel = this.outFile ?? 'deployment-manifest.yml';
+    // Resolve against ctx.cwd() (not process.cwd()) so the command
+    // honors injected working directories (Context invariant — see
+    // bundle-build.ts's outDir resolution for the same pattern).
+    const outFile = path.isAbsolute(outFileRel) ? outFileRel : path.join(cwd, outFileRel);
+    try {
+      await generateBundleManifest(ctx, cwd, { version, collectionFile, output: fmt }, outFile);
+      return 0;
+    } catch (err) {
+      const re = err instanceof RegistryError
+        ? err
+        : new RegistryError({
+          code: 'INTERNAL.UNEXPECTED',
+          message: err instanceof Error ? err.message : String(err),
+          cause: err
+        });
+      emitError(ctx, fmt, re);
+      return 1;
+    }
+  }
+}

--- a/packages/cli/src/commands/collection-affected.ts
+++ b/packages/cli/src/commands/collection-affected.ts
@@ -1,0 +1,114 @@
+/**
+ * `collection affected` subcommand.
+ *
+ * Given a list of changed paths (typically produced by `git diff
+ * --name-only` in a CI workflow), emits the collections whose
+ * `.collection.yml` itself or any item-path is in that set.
+ *
+ * Path normalization: backslash-to-slash, strip a leading `/`, trim.
+ * Strings that normalize to empty are dropped silently.
+ * @module commands/collection-affected
+ */
+import {
+  listCollectionFiles,
+  readCollection,
+  resolveCollectionItemPaths,
+} from '@ai-primitives-hub/app';
+import {
+  Command,
+  type Context,
+  formatOutput,
+  Option,
+  type OutputFormat,
+} from '../framework';
+
+/**
+ * Affected collection record.
+ */
+interface AffectedRecord {
+  id: string;
+  file: string;
+}
+
+/**
+ * Normalize path for comparison.
+ * @param p Path to normalize.
+ * @returns Normalized path.
+ */
+const normalize = (p: string): string =>
+  String(p).replaceAll('\\', '/').replaceAll(/^\/+/g, '').trim();
+
+/**
+ * Render affected collections as text.
+ * @param d Affected data.
+ * @param d.affected
+ * @returns Formatted text output.
+ */
+const renderText = (d: { affected: AffectedRecord[] }): string => {
+  if (d.affected.length === 0) {
+    return 'no affected collections\n';
+  }
+  return d.affected.map((a) => `${a.id}  ${a.file}`).join('\n') + '\n';
+};
+
+/**
+ * Collection affected command class.
+ */
+export class CollectionAffectedCommand extends Command {
+  public static readonly paths = [['collection', 'affected']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Print collections that overlap with the supplied changed-path list.',
+    category: 'Build & Author',
+    details: `
+      Usage: ai-primitives-hub collection affected [options]
+
+      Options:
+        -o, --output <format>       Output format (text, json, yaml, ndjson)
+        --changed-path <path>       Changed path to check against (can be repeated)
+    `
+  });
+
+  public output = Option.String('-o', '--output') as OutputFormat | undefined;
+  public changedPath = Option.Array('--changed-path');
+  public commandContext!: { ctx: Context };
+
+  public execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+    const fmt = (this.output ?? 'text');
+    const cwd = ctx.cwd();
+    const changed = (this.changedPath ?? [])
+      .map((p) => normalize(p))
+      .filter((s) => s.length > 0);
+    const changedSet = new Set(changed);
+
+    const collectionFiles = listCollectionFiles(cwd);
+    const affected: AffectedRecord[] = [];
+    for (const file of collectionFiles) {
+      const collection = readCollection(cwd, file);
+      const itemPaths = resolveCollectionItemPaths(cwd, collection).map((p) => normalize(p));
+      const itemPathsSet = new Set(itemPaths);
+      const normalizedFile = normalize(file);
+      if (changedSet.has(normalizedFile)) {
+        affected.push({ id: collection.id, file });
+        continue;
+      }
+      for (const c of changed) {
+        if (itemPathsSet.has(c)) {
+          affected.push({ id: collection.id, file });
+          break;
+        }
+      }
+    }
+
+    formatOutput({
+      ctx,
+      command: 'collection.affected',
+      output: fmt,
+      status: 'ok',
+      data: { affected },
+      textRenderer: renderText
+    });
+    return Promise.resolve(0);
+  }
+}

--- a/packages/cli/src/commands/collection-create.ts
+++ b/packages/cli/src/commands/collection-create.ts
@@ -1,0 +1,146 @@
+/**
+ * `collection create` subcommand.
+ *
+ * Creates a new collection file with proper structure using templates.
+ *
+ * Usage:
+ *   ai-primitives-hub collection create my-collection \
+ *     --description "My prompt collection" \
+ *     --author "Author Name" \
+ *     --tags "ai,coding"
+ * @module commands/collection-create
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  generateSanitizedId,
+  TemplateContext,
+} from '@ai-primitives-hub/core';
+import {
+  TEMPLATE_PATHS,
+  TemplateEngine,
+} from '@ai-primitives-hub/infra';
+import {
+  Command,
+  type Context,
+  formatOutput,
+  Option,
+  type OutputFormat,
+  RegistryError,
+  renderError,
+} from '../framework';
+
+/**
+ * Collection create command class.
+ */
+export class CollectionCreateCommand extends Command {
+  public static readonly paths = [['collection', 'create']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Create a new collection file',
+    category: 'Build & Author',
+    details: `
+      Usage: ai-primitives-hub collection create <id> [options]
+
+      Options:
+        --name <name>          Display name (default: id)
+        --description <text>   Collection description
+        --author <name>        Author name
+        --tags <tags>          Comma-separated tags
+        --path <dir>           Output directory (default: collections/)
+        -o, --output <format>  Output format (text, json, yaml, ndjson)
+
+      Examples:
+        ai-primitives-hub collection create my-collection
+        ai-primitives-hub collection create my-collection --description "My prompts"
+        ai-primitives-hub collection create my-collection --author "John Doe" --tags "ai,coding"
+    `
+  });
+
+  public name = Option.String({ required: true });
+  public nameOption = Option.String('--name');
+  public description = Option.String('--description');
+  public author = Option.String('--author');
+  public tags = Option.String('--tags');
+  public pathOption = Option.String('--path');
+  public output = Option.String('-o', '--output') as OutputFormat | undefined;
+  public commandContext!: { ctx: Context };
+
+  public async execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+    const fmt = (this.output ?? 'text');
+
+    try {
+      // Determine collection ID and display name
+      const collectionId = generateSanitizedId(this.name);
+      const displayName = this.nameOption || this.name;
+
+      // Parse tags
+      const tags = this.tags ? this.tags.split(',').map((t) => t.trim()).filter((t) => t.length > 0) : [];
+      const tagsLine = tags.length > 0 ? `tags: ${tags.map((t) => `"${t}"`).join(', ')}` : '';
+
+      // Build template context
+      const context: TemplateContext = {
+        projectName: collectionId,
+        collectionId,
+        name: displayName,
+        description: this.description,
+        author: this.author,
+        tags: tags.length > 0 ? tags : undefined,
+        tags_line: tagsLine
+      };
+
+      // Determine output path
+      const outputPath = this.pathOption || 'collections';
+      const targetPath = path.isAbsolute(outputPath) ? outputPath : path.join(ctx.cwd(), outputPath);
+
+      // Use collection ID in filename
+      const collectionFileName = `${collectionId}.collection.yml`;
+
+      // Initialize template engine
+      const templateEngine = new TemplateEngine(TEMPLATE_PATHS.collection);
+
+      // Scaffold the collection
+      const result = await templateEngine.scaffoldProject(targetPath, context);
+
+      if (!result.success) {
+        const err = new RegistryError({
+          code: 'FS.SCAFFOLD_FAILED',
+          message: result.error || 'Scaffolding failed'
+        });
+        renderError(err, ctx);
+        return 1;
+      }
+
+      // Rename collection file to use collection ID
+      const oldPath = result.createdFiles[0];
+      const newPath = path.join(path.dirname(oldPath), collectionFileName);
+      fs.renameSync(oldPath, newPath);
+      result.createdFiles[0] = newPath;
+
+      // Format output
+      formatOutput({
+        ctx,
+        command: 'collection create',
+        output: fmt,
+        status: 'ok',
+        data: {
+          collectionId,
+          path: result.createdFiles[0],
+          createdFiles: result.createdFiles
+        }
+      });
+      return 0;
+    } catch (error) {
+      const registryError = error instanceof RegistryError
+        ? error
+        : new RegistryError({
+          code: 'INTERNAL.UNEXPECTED',
+          message: (error as Error).message
+        });
+
+      renderError(registryError, ctx);
+      return 1;
+    }
+  }
+}

--- a/packages/cli/src/commands/collection-list.ts
+++ b/packages/cli/src/commands/collection-list.ts
@@ -1,0 +1,142 @@
+/**
+ * `collection list` subcommand.
+ *
+ * Lists `*.collection.yml` files under `<cwd>/collections/` and prints
+ * their id/name/path. Emits via `formatOutput` (text/json/yaml/ndjson).
+ * @module commands/collection-list
+ */
+import * as path from 'node:path';
+import * as yaml from 'js-yaml';
+import {
+  Command,
+  type Context,
+  formatOutput,
+  Option,
+  type OutputFormat,
+  RegistryError,
+  renderError,
+  renderTable,
+} from '../framework';
+
+/**
+ * Collection record.
+ */
+interface CollectionRecord {
+  id: string;
+  name: string;
+  file: string;
+}
+
+/**
+ * List collections from directory.
+ * @param ctx CLI context.
+ * @param collectionsDir Collections directory path.
+ * @param cwd Current working directory.
+ * @returns Array of collection records.
+ */
+const listCollections = async (
+  ctx: Context,
+  collectionsDir: string,
+  cwd: string
+): Promise<CollectionRecord[]> => {
+  const entries = await ctx.fs.readDir(collectionsDir);
+  const ymlFiles = entries.filter((e) => e.endsWith('.collection.yml')).toSorted((a, b) => a.localeCompare(b));
+  const records: CollectionRecord[] = [];
+  for (const filename of ymlFiles) {
+    const absolute = path.join(collectionsDir, filename);
+    const text = await ctx.fs.readFile(absolute);
+    const doc = yaml.load(text) as { id?: unknown; name?: unknown } | null;
+    if (doc === null || typeof doc !== 'object') {
+      // Skip ill-formed YAML files; bad files are caught by `collection validate`.
+      continue;
+    }
+    const id = typeof doc.id === 'string' ? doc.id : '';
+    const name = typeof doc.name === 'string' ? doc.name : id;
+    records.push({
+      id,
+      name,
+      file: path.relative(cwd, absolute)
+    });
+  }
+  return records;
+};
+
+/**
+ * Render collections as text.
+ * @param records Collection records.
+ * @returns Formatted text output.
+ */
+const renderCollectionsText = (records: CollectionRecord[]): string =>
+  renderTable<CollectionRecord>({
+    columns: [
+      { header: 'ID', get: (r) => r.id },
+      { header: 'NAME', get: (r) => r.name },
+      { header: 'FILE', get: (r) => r.file }
+    ],
+    rows: records,
+    emptyMessage: 'no collections found\n'
+  });
+
+/**
+ * Collection list command class.
+ */
+export class CollectionListCommand extends Command {
+  public static readonly paths = [['collection', 'list']];
+
+  public static readonly usage = Command.Usage({
+    description: 'List `*.collection.yml` files and print their id/name/path.',
+    category: 'Build & Author',
+    details: `
+      Usage: ai-primitives-hub collection list [options]
+
+      Options:
+        -o, --output <format>  Output format (text, json, yaml, ndjson)
+    `
+  });
+
+  public output = Option.String('-o', '--output') as OutputFormat | undefined;
+  public commandContext!: { ctx: Context };
+
+  public async execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+    const fmt = (this.output ?? 'text');
+    const cwd = ctx.cwd();
+    const collectionsDir = path.join(cwd, 'collections');
+    const dirExists = await ctx.fs.exists(collectionsDir);
+    if (!dirExists) {
+      const err = new RegistryError({
+        code: 'FS.NOT_FOUND',
+        message: `collections/ directory not found under ${cwd}`,
+        hint: 'Run from a repo root that contains a `collections/` folder, '
+          + 'or pass `--cwd <path>` once that flag lands.',
+        context: { collectionsDir }
+      });
+      if (fmt === 'json' || fmt === 'yaml' || fmt === 'ndjson') {
+        // Machine-readable: error in the envelope.
+        formatOutput({
+          ctx,
+          command: 'collection.list',
+          output: fmt,
+          status: 'error',
+          data: null,
+          errors: [err.toJSON()]
+        });
+      } else {
+        // Text mode: human-readable error to stderr.
+        renderError(err, ctx);
+      }
+      return 1;
+    }
+
+    const records = await listCollections(ctx, collectionsDir, cwd);
+    formatOutput({
+      ctx,
+      command: 'collection.list',
+      output: fmt,
+      status: 'ok',
+      data: records,
+      textRenderer: renderCollectionsText
+    });
+    return 0;
+  }
+}

--- a/packages/cli/src/commands/collection-validate.ts
+++ b/packages/cli/src/commands/collection-validate.ts
@@ -1,0 +1,167 @@
+/**
+ * `collection validate` subcommand.
+ *
+ * Wraps `@ai-primitives-hub/app`'s `validateAllCollections()`/
+ * `generateMarkdown()` (ported from the reference branch's
+ * `lib/src/validate.ts`) so the validator's behavior stays verbatim.
+ *
+ * - Goes through `Context` for the existence check + the markdown
+ *   write (`ctx.fs.exists`, `ctx.fs.writeFile`).
+ * - Output formatter routes via text/json/yaml/ndjson.
+ * - Missing `collections/` dir fails with a `FS.NOT_FOUND`
+ *   `RegistryError` (renderError -> stderr in text mode; envelope
+ *   error in JSON mode).
+ * @module commands/collection-validate
+ */
+import * as path from 'node:path';
+import {
+  generateMarkdown,
+  listCollectionFiles,
+  validateAllCollections,
+} from '@ai-primitives-hub/app';
+import type {
+  AllCollectionsResult,
+} from '@ai-primitives-hub/core';
+import {
+  Command,
+  type Context,
+  formatOutput,
+  Option,
+  type OutputFormat,
+  RegistryError,
+  renderError,
+} from '../framework';
+
+/**
+ * Validation data.
+ */
+interface ValidateData {
+  ok: boolean;
+  totalFiles: number;
+  fileResults: AllCollectionsResult['fileResults'];
+  errors: string[];
+}
+
+/**
+ * Emit error in appropriate format.
+ * @param ctx CLI context.
+ * @param output Output format.
+ * @param err Registry error.
+ */
+const emitError = (ctx: Context, output: OutputFormat, err: RegistryError): void => {
+  if (output === 'json' || output === 'yaml' || output === 'ndjson') {
+    formatOutput({
+      ctx,
+      command: 'collection.validate',
+      output,
+      status: 'error',
+      data: null,
+      errors: [err.toJSON()]
+    });
+  } else {
+    renderError(err, ctx);
+  }
+};
+
+/**
+ * Render validation results as text.
+ * @param d Validation data.
+ * @param verbose Verbose flag.
+ * @returns Formatted text output.
+ */
+const renderText = (d: ValidateData, verbose: boolean): string => {
+  const lines: string[] = [`Found ${d.totalFiles} collection(s)`];
+  for (const fileResult of d.fileResults) {
+    if (!fileResult.ok) {
+      lines.push(`[FAIL] ${fileResult.file}: invalid`);
+      for (const e of fileResult.errors) {
+        lines.push(`  - ${e}`);
+      }
+    } else if (verbose) {
+      lines.push(`[ OK ] ${fileResult.file}: valid`);
+    }
+  }
+  const crossCollectionErrors = d.errors.filter((e) => e.includes('Duplicate collection'));
+  if (crossCollectionErrors.length > 0) {
+    lines.push('', 'Cross-collection errors:');
+    for (const e of crossCollectionErrors) {
+      lines.push(`  - ${e}`);
+    }
+  }
+  if (d.ok) {
+    lines.push('', `All ${d.totalFiles} collection(s) valid`);
+  } else {
+    lines.push('', `Validation failed with ${d.errors.length} error(s)`);
+  }
+  return `${lines.join('\n')}\n`;
+};
+
+/**
+ * Collection validate command class.
+ */
+export class CollectionValidateCommand extends Command {
+  public static readonly paths = [['collection', 'validate']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Validate `*.collection.yml` files against the schema.',
+    category: 'Build & Author',
+    details: `
+      Usage: ai-primitives-hub collection validate [options]
+
+      Options:
+        -o, --output <format>       Output format (text, json, yaml, ndjson)
+        --markdown-path <path>     Write markdown report to file
+        --collection-file <path>    Collection file path (can be repeated)
+        --verbose                   Print each ok file in text mode
+    `
+  });
+
+  public output = Option.String('-o', '--output') as OutputFormat | undefined;
+  public markdownPath = Option.String('--markdown-path');
+  public collectionFile = Option.Array('--collection-file');
+  public verbose = Option.Boolean('--verbose', false);
+  public commandContext!: { ctx: Context };
+
+  public async execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+    const fmt = (this.output ?? 'text');
+    const cwd = ctx.cwd();
+    const collectionsDir = path.join(cwd, 'collections');
+    if (!(await ctx.fs.exists(collectionsDir))) {
+      const err = new RegistryError({
+        code: 'FS.NOT_FOUND',
+        message: `collections/ directory not found under ${cwd}`,
+        hint: 'Run from a repo root that contains a `collections/` folder.',
+        context: { collectionsDir }
+      });
+      emitError(ctx, fmt, err);
+      return 1;
+    }
+
+    const files = this.collectionFile && this.collectionFile.length > 0
+      ? this.collectionFile
+      : listCollectionFiles(cwd);
+    const result = validateAllCollections(cwd, files);
+    const data: ValidateData = {
+      ok: result.ok,
+      totalFiles: files.length,
+      fileResults: result.fileResults,
+      errors: result.errors
+    };
+
+    if (this.markdownPath !== undefined) {
+      const md = generateMarkdown(result, files.length);
+      await ctx.fs.writeFile(this.markdownPath, md);
+    }
+
+    formatOutput({
+      ctx,
+      command: 'collection.validate',
+      output: fmt,
+      status: result.ok ? 'ok' : 'error',
+      data,
+      textRenderer: (d) => renderText(d, this.verbose)
+    });
+    return result.ok ? 0 : 1;
+  }
+}

--- a/packages/cli/src/commands/completion.ts
+++ b/packages/cli/src/commands/completion.ts
@@ -1,0 +1,287 @@
+/**
+ * `ai-primitives-hub completion` — shell completion script generator.
+ *
+ * Generates bash and zsh completion scripts that can be sourced.
+ * @module commands/completion
+ */
+import {
+  Command,
+  getCommandContext,
+  Option,
+} from '../framework';
+
+/**
+ * Completion command class.
+ */
+export class CompletionCommand extends Command {
+  public static readonly paths = [['completion']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Generate shell completion script for bash or zsh.',
+    category: 'Configure & Debug',
+    details: `
+      Usage: ai-primitives-hub completion <shell>
+
+      Generates a shell completion script for the specified shell.
+      Output the script to a file and source it in your shell configuration.
+
+      Options:
+        --shell <shell>          Shell type: bash or zsh (required)
+
+      Examples:
+        ai-primitives-hub completion bash > ~/.local/share/bash-completion/completions/ai-primitives-hub
+        ai-primitives-hub completion zsh > ~/.zsh/completion/_ai-primitives-hub
+        source <(ai-primitives-hub completion bash)
+    `
+  });
+
+  public shell = Option.String('--shell');
+
+  private generateBashCompletion(): string {
+    return `# bash completion for ai-primitives-hub
+_ai_primitives_hub_completion() {
+  local cur words cword
+  _init_completion || return
+
+  # Command list
+  local commands="apply collection completion config discover doctor explain hub index init install plugins profile skill source status target uninstall update bundle version"
+
+  # Index subcommands
+  local index_commands="bench build eval export harvest report search shortlist stats"
+
+  # Hub subcommands
+  local hub_commands="add create list refresh remove sync use"
+
+  # Profile subcommands
+  local profile_commands="activate create deactivate list publish show current edit"
+
+  # Source subcommands
+  local source_commands="add list remove"
+
+  # Target subcommands
+  local target_commands="add list remove types"
+
+  # Collection subcommands
+  local collection_commands="affected create list validate"
+
+  # Config subcommands
+  local config_commands="get list"
+
+  # Index shortlist subcommands
+  local shortlist_commands="add list new remove"
+
+  case \${words[0]} in
+    ai-primitives-hub)
+      if [[ \${cword} -eq 1 ]]; then
+        COMPREPLY=($(compgen -W "$commands" -- "$cur"))
+      fi
+      ;;
+    index)
+      if [[ \${cword} -eq 2 ]]; then
+        COMPREPLY=($(compgen -W "$index_commands" -- "$cur"))
+      fi
+      ;;
+    hub)
+      if [[ \${cword} -eq 2 ]]; then
+        COMPREPLY=($(compgen -W "$hub_commands" -- "$cur"))
+      fi
+      ;;
+    profile)
+      if [[ \${cword} -eq 2 ]]; then
+        COMPREPLY=($(compgen -W "$profile_commands" -- "$cur"))
+      fi
+      ;;
+    source)
+      if [[ \${cword} -eq 2 ]]; then
+        COMPREPLY=($(compgen -W "$source_commands" -- "$cur"))
+      fi
+      ;;
+    target)
+      if [[ \${cword} -eq 2 ]]; then
+        COMPREPLY=($(compgen -W "$target_commands" -- "$cur"))
+      fi
+      ;;
+    collection)
+      if [[ \${cword} -eq 2 ]]; then
+        COMPREPLY=($(compgen -W "$collection_commands" -- "$cur"))
+      fi
+      ;;
+    config)
+      if [[ \${cword} -eq 2 ]]; then
+        COMPREPLY=($(compgen -W "$config_commands" -- "$cur"))
+      fi
+      ;;
+    shortlist)
+      if [[ \${cword} -eq 2 ]]; then
+        COMPREPLY=($(compgen -W "$shortlist_commands" -- "$cur"))
+      fi
+      ;;
+    *)
+      # File completion for arguments
+      COMPREPLY=($(compgen -f -- "$cur"))
+      ;;
+  esac
+}
+
+complete -F _ai_primitives_hub_completion ai-primitives-hub
+`;
+  }
+
+  private generateZshCompletion(): string {
+    return `#compdef ai-primitives-hub
+
+_ai_primitives_hub() {
+  local -a commands
+  commands=(
+    'apply:Idempotent: sync active hub and re-activate profile'
+    'collection:Manage collections'
+    'completion:Generate shell completion script'
+    'config:Read or list config values'
+    'discover:Discover relevant Copilot resources'
+    'doctor:Run environment self-checks'
+    'explain:Print documentation for error codes'
+    'hub:Manage hub configuration'
+    'index:Index and search primitives'
+    'init:Bootstrap a project'
+    'install:Install bundles to targets'
+    'plugins:List ai-primitives-hub plugins'
+    'profile:Manage profiles'
+    'skill:Manage agent skills'
+    'source:Manage sources'
+    'status:Show configuration state'
+    'target:Manage install targets'
+    'uninstall:Remove bundles from targets'
+    'update:Check for bundle updates'
+    'bundle:Build and manage bundles'
+    'version:Compute collection versions'
+  )
+
+  if [[ CURRENT -eq 1 ]]; then
+    _describe 'command' commands
+    return
+  fi
+
+  case $words[1] in
+    index)
+      local -a index_commands
+      index_commands=(
+        'bench:Run search microbenchmark'
+        'build:Build primitive index'
+        'eval:Run relevance eval'
+        'export:Export shortlist as profile'
+        'harvest:Fetch and write primitive index'
+        'report:Render harvest report'
+        'search:Search primitive index'
+        'shortlist:Manage shortlists'
+        'stats:Show index statistics'
+      )
+      if [[ CURRENT -eq 2 ]]; then
+        _describe 'index command' index_commands
+      fi
+      ;;
+    hub)
+      local -a hub_commands
+      hub_commands=(
+        'add:Import a hub'
+        'create:Scaffold hub-config.yml'
+        'list:List imported hubs'
+        'refresh:Sync active hub'
+        'remove:Remove a hub'
+        'sync:Re-fetch and sync hub'
+        'use:Set/clear active hub'
+      )
+      if [[ CURRENT -eq 2 ]]; then
+        _describe 'hub command' hub_commands
+      fi
+      ;;
+    profile)
+      local -a profile_commands
+      profile_commands=(
+        'activate:Activate a profile'
+        'create:Create local profile'
+        'current:Show current profile'
+        'deactivate:Deactivate profile'
+        'edit:Edit a profile'
+        'list:List profiles'
+        'publish:Publish profile to hub'
+        'show:Show profile details'
+      )
+      if [[ CURRENT -eq 2 ]]; then
+        _describe 'profile command' profile_commands
+      fi
+      ;;
+    source)
+      local -a source_commands
+      source_commands=(
+        'add:Add detached source'
+        'list:List sources'
+        'remove:Remove source'
+      )
+      if [[ CURRENT -eq 2 ]]; then
+        _describe 'source command' source_commands
+      fi
+      ;;
+    target)
+      local -a target_commands
+      target_commands=(
+        'add:Register install target'
+        'list:List configured targets'
+        'remove:Remove target'
+        'types:List target types'
+      )
+      if [[ CURRENT -eq 2 ]]; then
+        _describe 'target command' target_commands
+      fi
+      ;;
+    collection)
+      local -a collection_commands
+      collection_commands=(
+        'affected:Print overlapping collections'
+        'create:Create collection'
+        'list:List collections'
+        'validate:Validate collections'
+      )
+      if [[ CURRENT -eq 2 ]]; then
+        _describe 'collection command' collection_commands
+      fi
+      ;;
+    config)
+      local -a config_commands
+      config_commands=(
+        'get:Read config value'
+        'list:Print resolved config'
+      )
+      if [[ CURRENT -eq 2 ]]; then
+        _describe 'config command' config_commands
+      fi
+      ;;
+    *)
+      # File completion
+      _files
+      ;;
+  esac
+}
+
+_ai_primitives_hub
+`;
+  }
+
+  public execute(): Promise<number | void> {
+    const ctx = getCommandContext(this);
+    const shell = this.shell;
+
+    if (!shell) {
+      ctx.stderr.write('Error: --shell is required. Use "bash" or "zsh".\n');
+      return Promise.resolve(1);
+    }
+
+    if (shell !== 'bash' && shell !== 'zsh') {
+      ctx.stderr.write(`Error: Unsupported shell "${shell}". Use "bash" or "zsh".\n`);
+      return Promise.resolve(1);
+    }
+
+    const script = shell === 'bash' ? this.generateBashCompletion() : this.generateZshCompletion();
+    ctx.stdout.write(script);
+    return Promise.resolve(0);
+  }
+}

--- a/packages/cli/src/commands/config-get.ts
+++ b/packages/cli/src/commands/config-get.ts
@@ -1,0 +1,154 @@
+/**
+ * `config get` subcommand.
+ *
+ * Reads a value from the layered YAML config (see `loadConfig`'s own
+ * precedence chain). The dotted key path (e.g., `output`) drills into
+ * the resolved object.
+ *
+ * Scope is intentionally minimal: load config + read key. `config list`
+ * follows the same shape.
+ * @module commands/config-get
+ */
+import {
+  Command,
+  type Context,
+  formatOutput,
+  loadConfig,
+  Option,
+  type OutputFormat,
+  RegistryError,
+  renderError,
+} from '../framework';
+
+/**
+ * Config get data.
+ */
+interface ConfigGetData {
+  key: string;
+  value: unknown;
+}
+
+/**
+ * Read value from object using dotted key path.
+ * @param obj Object to read from.
+ * @param key Dotted key path.
+ * @returns Value at key path, or undefined if not found.
+ */
+const readDottedKey = (obj: unknown, key: string): unknown => {
+  const parts = key.split('.');
+  let cursor: unknown = obj;
+  for (const p of parts) {
+    if (cursor === null || cursor === undefined || typeof cursor !== 'object') {
+      return undefined;
+    }
+    cursor = (cursor as Record<string, unknown>)[p];
+  }
+  return cursor;
+};
+
+/**
+ * Emit error in appropriate format.
+ * @param ctx CLI context.
+ * @param output Output format.
+ * @param err Registry error.
+ */
+const emitError = (ctx: Context, output: OutputFormat, err: RegistryError): void => {
+  if (output === 'json' || output === 'yaml' || output === 'ndjson') {
+    formatOutput({
+      ctx,
+      command: 'config.get',
+      output,
+      status: 'error',
+      data: null,
+      errors: [err.toJSON()]
+    });
+  } else {
+    renderError(err, ctx);
+  }
+};
+
+/**
+ * Render config get data as text.
+ * @param d Config get data.
+ * @returns Formatted text output.
+ */
+const renderText = (d: ConfigGetData): string => {
+  let valueStr: string;
+  if (d.value === undefined) {
+    valueStr = '(unset)';
+  } else if (typeof d.value === 'string') {
+    valueStr = d.value;
+  } else {
+    valueStr = JSON.stringify(d.value);
+  }
+  return `${d.key}: ${valueStr}\n`;
+};
+
+/**
+ * Config get command class.
+ */
+export class ConfigGetCommand extends Command {
+  public static readonly paths = [['config', 'get']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Read a config value by dotted key path (e.g., `output`).',
+    category: 'Configure & Debug',
+    details: `
+      Usage: ai-primitives-hub config get <dotted.key> [options]
+
+      Options:
+        -o, --output <format>  Output format (text, json, yaml, ndjson)
+
+      Examples:
+        ai-primitives-hub config get output
+        ai-primitives-hub config get targets -o json
+    `
+  });
+
+  public output = Option.String('-o', '--output') as OutputFormat | undefined;
+  public key = Option.String(); // Positional argument
+  public commandContext!: { ctx: Context };
+
+  public async execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+    const fmt = this.output ?? 'text';
+    const key = this.key ?? '';
+
+    if (key.length === 0) {
+      const err = new RegistryError({
+        code: 'USAGE.MISSING_FLAG',
+        message: 'config get: missing key',
+        hint: 'Usage: `ai-primitives-hub config get <dotted.key>`'
+      });
+      emitError(ctx, fmt, err);
+      return 1;
+    }
+    try {
+      const config = await loadConfig({
+        cwd: ctx.cwd(),
+        env: ctx.env,
+        fs: ctx.fs
+      });
+      const value = readDottedKey(config, key);
+      formatOutput({
+        ctx,
+        command: 'config.get',
+        output: fmt,
+        status: 'ok',
+        data: { key, value },
+        textRenderer: renderText
+      });
+      return 0;
+    } catch (err) {
+      const re = err instanceof RegistryError
+        ? err
+        : new RegistryError({
+          code: 'CONFIG.LOAD_FAILED',
+          message: err instanceof Error ? err.message : String(err),
+          cause: err
+        });
+      emitError(ctx, fmt, re);
+      return 1;
+    }
+  }
+}

--- a/packages/cli/src/commands/config-list.ts
+++ b/packages/cli/src/commands/config-list.ts
@@ -1,0 +1,182 @@
+/**
+ * `config list` subcommand.
+ *
+ * Dumps the resolved config (after the layered merge — see `loadConfig`)
+ * as text or the JSON envelope. Useful for debugging precedence: a user
+ * can `ai-primitives-hub config list -o yaml` and see exactly what the
+ * commands see.
+ * @module commands/config-list
+ */
+import {
+  Command,
+  type Context,
+  formatOutput,
+  loadConfig,
+  Option,
+  type OutputFormat,
+} from '../framework';
+
+/**
+ * Render the hubs section.
+ * @param hubs Hubs config object.
+ * @returns Formatted lines.
+ */
+const renderHubsSection = (hubs: Record<string, unknown>): string[] => {
+  const lines: string[] = ['=== Hubs ===', `Active hub: ${(hubs.activeHub as string | undefined) ?? 'none'}`];
+  const configuredHubs = hubs.configuredHubs as Record<string, unknown> | undefined;
+  if (configuredHubs !== undefined && typeof configuredHubs === 'object') {
+    lines.push(`Configured hubs: ${Object.keys(configuredHubs).join(', ') || 'none'}`);
+  }
+  lines.push('');
+  return lines;
+};
+
+/**
+ * Render the targets section.
+ * @param rawTargets Raw targets value from config.
+ * @returns Formatted lines.
+ */
+const renderTargetsSection = (rawTargets: unknown): string[] => {
+  const targetArray: { name: string; type: string }[] | undefined = Array.isArray(rawTargets)
+    ? (rawTargets as { name: string; type: string }[])
+    : ((rawTargets as Record<string, unknown> | undefined)?.targets as { name: string; type: string }[] | undefined);
+  if (targetArray === undefined) {
+    return [];
+  }
+  const items = targetArray.length === 0
+    ? ['No targets configured']
+    : targetArray.map((t) => `  - ${t.name} (${t.type})`);
+  return ['=== Targets ===', ...items, ''];
+};
+
+/**
+ * Render the profiles section.
+ * @param profiles Profiles config object.
+ * @returns Formatted lines.
+ */
+const renderProfilesSection = (profiles: Record<string, unknown>): string[] => [
+  '=== Profiles ===',
+  `Active profile: ${(profiles.activeProfile as string | undefined) ?? 'none'}`,
+  ''
+];
+
+/**
+ * Render the GitHub authentication section.
+ * @param github GitHub config object.
+ * @returns Formatted lines.
+ */
+const renderGithubSection = (github: Record<string, unknown>): string[] => [
+  '=== GitHub Authentication ===',
+  `Token configured: ${(github.token as string | undefined) ? 'yes' : 'no'}`,
+  ''
+];
+
+/**
+ * Render the paths section.
+ * @param paths Paths config object.
+ * @returns Formatted lines.
+ */
+const renderPathsSection = (paths: Record<string, unknown>): string[] => {
+  const lines: string[] = ['=== Paths ==='];
+  const configPath = paths.configPath as string | undefined;
+  const cachePath = paths.cachePath as string | undefined;
+  if (configPath !== undefined) {
+    lines.push(`Config path: ${configPath}`);
+  }
+  if (cachePath !== undefined) {
+    lines.push(`Cache path: ${cachePath}`);
+  }
+  lines.push('');
+  return lines;
+};
+
+/**
+ * Render config in a human-readable format.
+ * @param config Resolved config object.
+ * @returns Formatted string.
+ */
+const renderConfigText = (config: Record<string, unknown>): string => {
+  const versionStr = typeof config.version === 'string' || typeof config.version === 'number'
+    ? String(config.version)
+    : 'unknown';
+  const outputStr = typeof config.output === 'string' ? config.output : 'text';
+  const lines: string[] = [
+    '=== AI Primitives Hub Configuration ===\n',
+    `Version: ${versionStr}`,
+    `Output format: ${outputStr}`,
+    `Verbose: ${String(Boolean(config.verbose))}`,
+    `Quiet: ${String(Boolean(config.quiet))}`,
+    ''
+  ];
+  const hubs = config.hubs as Record<string, unknown> | undefined;
+  if (hubs !== undefined && typeof hubs === 'object') {
+    lines.push(...renderHubsSection(hubs));
+  }
+  lines.push(...renderTargetsSection(config.targets));
+  const profiles = config.profiles as Record<string, unknown> | undefined;
+  if (profiles !== undefined && typeof profiles === 'object') {
+    lines.push(...renderProfilesSection(profiles));
+  }
+  const github = config.github as Record<string, unknown> | undefined;
+  if (github !== undefined && typeof github === 'object') {
+    lines.push(...renderGithubSection(github));
+  }
+  const paths = config.paths as Record<string, unknown> | undefined;
+  if (paths !== undefined && typeof paths === 'object') {
+    lines.push(...renderPathsSection(paths));
+  }
+  return lines.join('\n');
+};
+
+/**
+ * Config list command class.
+ */
+export class ConfigListCommand extends Command {
+  public static readonly paths = [['config', 'list']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Print the resolved config (post-merge across all precedence layers). Shows hubs, targets, profiles, and paths.',
+    category: 'Configure & Debug',
+    details: `
+      Usage: ai-primitives-hub config list [options]
+
+      Options:
+        -o, --output <format>  Output format (text, json, yaml, ndjson)
+
+      Examples:
+        ai-primitives-hub config list
+        ai-primitives-hub config list -o yaml
+    `
+  });
+
+  public output = Option.String('-o', '--output') as OutputFormat | undefined;
+  public commandContext!: { ctx: Context };
+
+  public async execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+    const config = await loadConfig({
+      cwd: ctx.cwd(),
+      env: ctx.env,
+      fs: ctx.fs
+    });
+
+    const fmt = this.output ?? 'text';
+
+    // For text output, write directly to stdout to avoid envelope wrapping
+    if (fmt === 'text') {
+      ctx.stdout.write(renderConfigText(config));
+      return 0;
+    }
+
+    // For other formats (json, yaml, ndjson), use the envelope
+    formatOutput({
+      ctx,
+      command: 'config.list',
+      output: fmt,
+      status: 'ok',
+      data: config,
+      textRenderer: (d) => renderConfigText(d as Record<string, unknown>)
+    });
+    return 0;
+  }
+}

--- a/packages/cli/src/commands/discover.ts
+++ b/packages/cli/src/commands/discover.ts
@@ -1,0 +1,233 @@
+/**
+ * `ai-primitives-hub discover` — context-aware resource discovery.
+ *
+ * Analyzes project context (tech stack, domain, activity) and searches
+ * the primitive index for relevant Copilot resources.
+ *
+ * The non-AI path is implemented today. The `--ai` and `--interactive`
+ * flags are reserved for a future Copilot SDK integration and currently
+ * fail with a clear, structured error.
+ * @module commands/discover
+ */
+import type {
+  DetectedContext,
+} from '@ai-primitives-hub/app';
+import {
+  buildSearchQueries,
+  ContextDetector,
+} from '@ai-primitives-hub/app';
+import type {
+  PrimitiveKind,
+  SearchHit,
+} from '@ai-primitives-hub/infra';
+import {
+  defaultIndexFile,
+  loadIndex,
+} from '@ai-primitives-hub/infra';
+import {
+  Command,
+  failWith,
+  formatOutput,
+  getCommandContext,
+  Option,
+  type OutputFormat,
+  parseCsvKinds,
+  RegistryError,
+} from '../framework';
+
+/**
+ * Deduplicate search hits by primitive identity, keeping the highest score.
+ * @param hits Search hits.
+ * @returns Deduplicated hits.
+ */
+export function deduplicateHits(hits: SearchHit[]): SearchHit[] {
+  const unique = new Map<string, SearchHit>();
+
+  for (const hit of hits) {
+    const key = `${hit.primitive.id}:${hit.primitive.bundle.sourceId}:${hit.primitive.bundle.bundleId}`;
+    const existing = unique.get(key);
+    if (!existing || hit.score > existing.score) {
+      unique.set(key, hit);
+    }
+  }
+
+  return Array.from(unique.values());
+}
+
+/**
+ * Render discovery results as human-readable text.
+ * @param context Detected context.
+ * @param queries Search queries used.
+ * @param results Search hits.
+ * @returns Formatted text.
+ */
+export function renderDiscoveryText(
+  context: DetectedContext,
+  queries: string[],
+  results: SearchHit[]
+): string {
+  const lines = [
+    'Detected Context:',
+    `  Languages: ${context.techStack.languages.join(', ') || 'none'}`,
+    `  Frameworks: ${context.techStack.frameworks.join(', ') || 'none'}`,
+    `  Domain: ${context.domain.category || context.domain.businessDomain || 'unknown'}`,
+    '',
+    'Search Queries:',
+    ...queries.map((q) => `  - ${q}`),
+    '',
+    `Recommendations (${results.length}):`,
+    ...results.flatMap((hit) => {
+      const p = hit.primitive;
+      const line = `  [${hit.score.toFixed(3)}] [${p.kind}] ${p.title} (${p.bundle.sourceId}/${p.bundle.bundleId})`;
+      return p.description.length > 0 ? [line, `      ${p.description}`] : [line];
+    }),
+    ''
+  ];
+
+  return lines.join('\n');
+}
+
+/**
+ * Classify errors for the discover command.
+ * @param cause Error cause.
+ * @param indexPath Index path.
+ * @returns RegistryError.
+ */
+const classifyError = (cause: unknown, indexPath: string): RegistryError => {
+  if (cause instanceof RegistryError) {
+    return cause;
+  }
+  const msg = cause instanceof Error ? cause.message : String(cause);
+  if (/ENOENT|no such file/i.test(msg)) {
+    return new RegistryError({
+      code: 'INDEX.NOT_FOUND',
+      message: `index not found: ${indexPath}`,
+      hint: 'Run `ai-primitives-hub index build` or `ai-primitives-hub index harvest` first.',
+      cause: cause instanceof Error ? cause : undefined
+    });
+  }
+  if (/EACCES|permission/i.test(msg)) {
+    return new RegistryError({
+      code: 'INDEX.PERMISSION',
+      message: `permission denied accessing index: ${indexPath}`,
+      hint: 'Check file permissions.',
+      cause: cause instanceof Error ? cause : undefined
+    });
+  }
+  return new RegistryError({
+    code: 'INDEX.ERROR',
+    message: `failed to load index: ${msg}`,
+    context: { indexFile: indexPath },
+    cause: cause instanceof Error ? cause : undefined
+  });
+};
+
+/**
+ * Discover command class.
+ */
+export class DiscoverCommand extends Command {
+  public static readonly paths = [['discover']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Discover relevant Copilot resources based on project context.',
+    category: 'Hub & Discovery',
+    details: `
+      Usage: ai-primitives-hub discover [options]
+
+      Examples:
+        ai-primitives-hub discover
+        ai-primitives-hub discover --limit 20
+        ai-primitives-hub discover --kinds prompt,skill
+        ai-primitives-hub discover --index ./primitive-index.json
+
+      Options:
+        --index <path>         Path to index JSON (default: XDG cache/primitive-index.json)
+        --limit <n>            Limit number of recommendations (default: 10)
+        --kinds <kinds>        Filter by primitive kind (comma-separated)
+        --ai                   Enable AI-powered recommendations (not yet implemented)
+        --interactive          Enable interactive mode (not yet implemented)
+        -o, --output <format>  Output format (text, json, yaml, ndjson)
+    `
+  });
+
+  public output = Option.String('-o,--output');
+  public index = Option.String('--index');
+  public limit = Option.String('--limit');
+  public kinds = Option.String('--kinds');
+  public enableAI = Option.Boolean('--ai');
+  public interactive = Option.Boolean('--interactive');
+
+  public async execute(): Promise<number> {
+    const ctx = getCommandContext(this);
+    const fmt = (this.output ?? 'text') as OutputFormat;
+    const indexPath = this.index ?? defaultIndexFile(ctx.env);
+    const limit = this.limit ? Number.parseInt(this.limit, 10) : undefined;
+    const cwd = ctx.cwd();
+
+    if (this.enableAI) {
+      return failWith(ctx, fmt, 'discover', new RegistryError({
+        code: 'USAGE.AI_NOT_IMPLEMENTED',
+        message: 'AI-powered discovery is not yet implemented',
+        hint: 'Run `ai-primitives-hub discover` without `--ai` for context-aware index search.'
+      }));
+    }
+
+    if (this.interactive) {
+      return failWith(ctx, fmt, 'discover', new RegistryError({
+        code: 'USAGE.INTERACTIVE_NOT_IMPLEMENTED',
+        message: 'Interactive discovery is not yet implemented',
+        hint: 'Run `ai-primitives-hub discover` without `--interactive`.'
+      }));
+    }
+
+    let kinds: PrimitiveKind[] | undefined;
+    try {
+      kinds = parseCsvKinds(this.kinds);
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      return failWith(ctx, fmt, 'discover', new RegistryError({
+        code: 'USAGE.INVALID_FLAG',
+        message: msg,
+        hint: 'Use a comma-separated list of primitive kinds.'
+      }));
+    }
+
+    try {
+      const detector = new ContextDetector({ cwd });
+      const context = await detector.detect();
+
+      const idx = loadIndex(indexPath);
+      const queries = buildSearchQueries(context);
+
+      const allHits: SearchHit[] = [];
+      for (const query of queries) {
+        const result = idx.search({
+          q: query,
+          kinds,
+          limit: limit ?? 5
+        });
+        allHits.push(...result.hits);
+      }
+
+      const uniqueHits = deduplicateHits(allHits);
+      const sortedHits = uniqueHits.toSorted((a, b) => b.score - a.score);
+      const rankedHits = sortedHits.slice(0, limit ?? 10);
+
+      formatOutput({
+        ctx,
+        command: 'discover',
+        output: fmt,
+        status: 'ok',
+        data: {
+          context,
+          queries,
+          results: rankedHits
+        },
+        textRenderer: (d) => renderDiscoveryText(d.context, d.queries, d.results)
+      });
+      return 0;
+    } catch (cause) {
+      return failWith(ctx, fmt, 'discover', classifyError(cause, indexPath));
+    }
+  }
+}

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,0 +1,775 @@
+/**
+ * `doctor` subcommand.
+ *
+ * `ai-primitives-hub doctor` performs a self-check and reports findings
+ * via the formatter. It exercises every framework slice:
+ * Context (fs / env / cwd), formatOutput, and (on failure) RegistryError.
+ * @module commands/doctor
+ */
+import {
+  spawnSync,
+} from 'node:child_process';
+import * as path from 'node:path';
+import {
+  resolveUserConfigPaths,
+} from '@ai-primitives-hub/app';
+import {
+  ActiveHubStore,
+  defaultTokenProvider,
+  findProjectConfigPath,
+  HubStore,
+  NodeHttpClient,
+  readTargets,
+  summarizeProxyEnv,
+} from '@ai-primitives-hub/infra';
+import {
+  type DiagnosticsResult,
+  getDiagnosticCommandClasses,
+  runDiagnostics,
+} from '../doctor/diagnostics';
+import {
+  Command,
+  type Context,
+  formatOutput,
+  Option,
+  type OutputFormat,
+  type OutputStatus,
+} from '../framework';
+
+/**
+ * A single log line captured while a check is running.
+ */
+interface DoctorLogLine {
+  /** One of `info`, `input`, `output`, `error`. */
+  level: 'info' | 'input' | 'output' | 'error';
+  /** Human-readable message. */
+  message: string;
+}
+
+/**
+ * Doctor check result.
+ */
+interface DoctorCheck {
+  name: string;
+  status: 'ok' | 'warn' | 'fail';
+  detail: string;
+  /** Detailed log lines emitted while running the check. */
+  logs?: DoctorLogLine[];
+}
+
+/**
+ * Doctor result summary.
+ */
+interface DoctorResult {
+  checks: DoctorCheck[];
+  summary: { ok: number; warn: number; fail: number };
+  /** True when verbose mode produced per-check logs. */
+  verbose?: boolean;
+}
+
+/**
+ * Base class for doctor commands.
+ */
+abstract class BaseDoctorCommand extends Command {
+  public commandContext!: { ctx: Context };
+
+  public output = Option.String('-o,--output');
+  public verbose = Option.Boolean('-v,--verbose', false);
+}
+
+/**
+ * Native clipanion class command for doctor.
+ */
+export class DoctorCommand extends BaseDoctorCommand {
+  public static readonly paths = [['doctor']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Run environment self-checks and print a health report.',
+    category: 'Configure & Debug',
+    details: `
+      Usage: ai-primitives-hub doctor [options]
+
+      Checks Node version, project config, install targets, GitHub auth, network
+      configuration, and API reachability.
+
+      Options:
+        -o, --output <format>  Output format (text, json, yaml, ndjson)
+        -v, --verbose          Show detailed per-check logs
+
+      Examples:
+        ai-primitives-hub doctor
+        ai-primitives-hub doctor -v
+        ai-primitives-hub doctor -o json
+    `
+  });
+
+  public async execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+    const fmt = (this.output ?? 'text') as OutputFormat;
+    const result = await runDoctorChecks(ctx, this.verbose);
+    const statusValue = result.summary.warn > 0 ? 'warning' : 'ok';
+    const status: OutputStatus = result.summary.fail > 0 ? 'error' : statusValue;
+    formatOutput({
+      ctx,
+      command: 'doctor',
+      output: fmt,
+      status,
+      data: result,
+      textRenderer: renderDoctorText
+    });
+    return result.summary.fail > 0 ? 1 : 0;
+  }
+}
+
+/**
+ * Native clipanion class command for doctor diagnostics.
+ */
+export class DoctorDiagnosticsCommand extends BaseDoctorCommand {
+  public static readonly paths = [['doctor', 'diagnostics']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Run a self-contained end-to-end diagnostic smoke test.',
+    category: 'Configure & Debug',
+    details: `
+      Usage: ai-primitives-hub doctor diagnostics [options]
+
+      Creates an isolated temporary workspace, runs a representative subset of the
+      E2E user flow (target add, hub add, sync, profile activate, index build,
+      install, uninstall), and reports every step with captured input/output.
+
+      The workspace is always cleaned up before exiting.
+
+      Options:
+        -o, --output <format>  Output format (text, json, yaml, ndjson)
+        -v, --verbose          Print per-step progress to stderr
+
+      Examples:
+        ai-primitives-hub doctor diagnostics
+        ai-primitives-hub doctor diagnostics -v
+    `
+  });
+
+  public async execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+    const fmt = (this.output ?? 'text') as OutputFormat;
+    const result = await runDiagnostics({
+      ctx,
+      commandClasses: getDiagnosticCommandClasses(),
+      verbose: this.verbose
+    });
+    const status: OutputStatus = result.ok ? 'ok' : 'error';
+    formatOutput({
+      ctx,
+      command: 'doctor diagnostics',
+      output: fmt,
+      status,
+      data: result,
+      textRenderer: renderDiagnosticsText
+    });
+    return result.ok ? 0 : 1;
+  }
+}
+
+/**
+ * Execute every check and aggregate the result.
+ * @param ctx Application Context — fs/env/cwd accessed only via this.
+ * @param verbose When true, capture detailed per-check logs.
+ * @returns Aggregated `DoctorResult` (every check is reported regardless of pass/fail).
+ */
+const runDoctorChecks = async (ctx: Context, verbose: boolean): Promise<DoctorResult> => {
+  const checks: DoctorCheck[] = [
+    checkNodeVersion(ctx, verbose),
+    await checkCwdReadable(ctx, verbose),
+    checkPathEnvVar(ctx, verbose),
+    await checkProjectConfig(ctx, verbose),
+    await checkTargets(ctx, verbose),
+    checkNetworkConfig(ctx, verbose),
+    await checkXdgConfig(ctx, verbose),
+    await checkGitHubAuth(ctx, verbose),
+    await checkGitHubCli(ctx, verbose),
+    await checkActiveHub(ctx, verbose),
+    await checkApiReachable(ctx, verbose)
+  ];
+  const summary = checks.reduce(
+    (acc, c) => {
+      acc[c.status] += 1;
+      return acc;
+    },
+    { ok: 0, warn: 0, fail: 0 }
+  );
+  return { checks, summary, verbose };
+};
+
+/**
+ * Create a log builder that only records lines when verbose is true.
+ * @param verbose Whether to record logs.
+ * @returns Mutable log buffer.
+ */
+const createLogger = (verbose: boolean): DoctorLogLine[] => (verbose ? [] : undefined) as unknown as DoctorLogLine[];
+
+/**
+ * Append a log line to a log buffer when verbose.
+ * @param logs Log buffer.
+ * @param level Log level.
+ * @param message Log message.
+ */
+const log = (
+  logs: DoctorLogLine[] | undefined,
+  level: DoctorLogLine['level'],
+  message: string
+): void => {
+  if (logs !== undefined) {
+    logs.push({ level, message });
+  }
+};
+
+/**
+ * Check Node version.
+ * @param ctx CLI context.
+ * @param verbose Whether to record logs.
+ * @returns Doctor check result.
+ */
+const checkNodeVersion = (ctx: Context, verbose: boolean): DoctorCheck => {
+  const logs = createLogger(verbose);
+  const v = ctx.env.NODE_VERSION ?? extractRuntimeNodeVersion();
+  const execPath = process.execPath;
+  log(logs, 'info', `runtime: ${v}`);
+  log(logs, 'info', `execPath: ${execPath}`);
+  const vStripped = v.startsWith('v') ? v.slice(1) : v;
+  const major = Number.parseInt(vStripped.split('.')[0] ?? '0', 10);
+  if (Number.isFinite(major) && major >= 20) {
+    return { name: 'node-version', status: 'ok', detail: `Node ${v} satisfies >=20.`, logs };
+  }
+  return {
+    name: 'node-version',
+    status: 'fail',
+    detail: `Node ${v} < required minimum 20. See engines.node in package.json.`,
+    logs
+  };
+};
+
+/**
+ * Extract runtime Node version.
+ * @returns Node version string.
+ */
+const extractRuntimeNodeVersion = (): string => process.version;
+
+/**
+ * Check if CWD is readable.
+ * @param ctx CLI context.
+ * @param verbose Whether to record logs.
+ * @returns Doctor check result.
+ */
+const checkCwdReadable = async (ctx: Context, verbose: boolean): Promise<DoctorCheck> => {
+  const logs = createLogger(verbose);
+  try {
+    const cwd = ctx.cwd();
+    log(logs, 'input', `cwd: ${cwd}`);
+    const ok = await ctx.fs.exists(cwd);
+    log(logs, 'output', `exists: ${ok ? 'true' : 'false'}`);
+    if (!ok) {
+      return {
+        name: 'cwd-accessible',
+        status: 'fail',
+        detail: `Working directory ${cwd} does not exist or is not accessible.`,
+        logs
+      };
+    }
+    return { name: 'cwd-accessible', status: 'ok', detail: `Working directory ${cwd} accessible.`, logs };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log(logs, 'error', msg);
+    return {
+      name: 'cwd-accessible',
+      status: 'fail',
+      detail: msg,
+      logs
+    };
+  }
+};
+
+// Install-related checks.
+/**
+ * Check project config.
+ * @param ctx CLI context.
+ * @param verbose Whether to record logs.
+ * @returns Doctor check result.
+ */
+const checkProjectConfig = async (ctx: Context, verbose: boolean): Promise<DoctorCheck> => {
+  const logs = createLogger(verbose);
+  try {
+    const cwd = ctx.cwd();
+    log(logs, 'input', `cwd: ${cwd}`);
+    const { file, exists } = await findProjectConfigPath({ cwd, fs: ctx.fs });
+    log(logs, 'output', `file: ${file}, exists: ${exists ? 'true' : 'false'}`);
+    if (!exists) {
+      return {
+        name: 'project-config',
+        status: 'warn',
+        detail: `No ai-primitives-hub.yml found from ${cwd} upward. Run \`ai-primitives-hub target add ...\` to create one.`,
+        logs
+      };
+    }
+    return {
+      name: 'project-config',
+      status: 'ok',
+      detail: `Project config: ${file}`,
+      logs
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log(logs, 'error', msg);
+    return {
+      name: 'project-config',
+      status: 'fail',
+      detail: msg,
+      logs
+    };
+  }
+};
+
+/**
+ * Check install targets.
+ * @param ctx CLI context.
+ * @param verbose Whether to record logs.
+ * @returns Doctor check result.
+ */
+const checkTargets = async (ctx: Context, verbose: boolean): Promise<DoctorCheck> => {
+  const logs = createLogger(verbose);
+  try {
+    const targets = await readTargets({ cwd: ctx.cwd(), fs: ctx.fs });
+    log(logs, 'output', `targets: ${targets.map((t) => `${t.name}(${t.type})`).join(', ')}`);
+    if (targets.length === 0) {
+      return {
+        name: 'install-targets',
+        status: 'warn',
+        detail: 'No install targets configured. Add one with `ai-primitives-hub target add <name> --type <kind>`.',
+        logs
+      };
+    }
+    return {
+      name: 'install-targets',
+      status: 'ok',
+      detail: `${targets.length} target${targets.length === 1 ? '' : 's'}: ${targets.map((t) => t.name + '(' + t.type + ')').join(', ')}`,
+      logs
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log(logs, 'error', msg);
+    return {
+      name: 'install-targets',
+      status: 'fail',
+      detail: msg,
+      logs
+    };
+  }
+};
+
+/**
+ * Check PATH environment variable.
+ * @param ctx CLI context.
+ * @param verbose Whether to record logs.
+ * @returns Doctor check result.
+ */
+const checkPathEnvVar = (ctx: Context, verbose: boolean): DoctorCheck => {
+  const logs = createLogger(verbose);
+  const p = ctx.env.PATH ?? '';
+  const entries = p.split(path.delimiter);
+  log(logs, 'info', `PATH entries: ${entries.length}`);
+  if (verbose) {
+    entries.forEach((entry, idx) => log(logs, 'info', `  ${idx}: ${entry}`));
+  }
+  if (p.length === 0) {
+    return {
+      name: 'path-env',
+      status: 'warn',
+      detail: 'PATH env var is empty; subprocess plugins (PATH-binary discovery) will not work.',
+      logs
+    };
+  }
+  return { name: 'path-env', status: 'ok', detail: `PATH has ${entries.length} entries.`, logs };
+};
+
+/**
+ * Check network / proxy configuration.
+ * @param ctx CLI context.
+ * @param verbose Whether to record logs.
+ * @returns Doctor check result.
+ */
+const checkNetworkConfig = (ctx: Context, verbose: boolean): DoctorCheck => {
+  const logs = createLogger(verbose);
+  const proxy = summarizeProxyEnv(ctx.env);
+  log(logs, 'info', `proxyConfigured: ${proxy.configured ? 'true' : 'false'}`);
+  if (proxy.source !== undefined) {
+    log(logs, 'info', `proxySource: ${proxy.source}`);
+  }
+  if (proxy.httpProxy !== undefined) {
+    log(logs, 'info', `HTTP_PROXY: ${proxy.httpProxy}`);
+  }
+  if (proxy.httpsProxy !== undefined) {
+    log(logs, 'info', `HTTPS_PROXY: ${proxy.httpsProxy}`);
+  }
+  if (proxy.noProxy !== undefined) {
+    log(logs, 'info', `NO_PROXY: ${proxy.noProxy}`);
+  }
+  if (ctx.env.NODE_EXTRA_CA_CERTS !== undefined) {
+    log(logs, 'info', `NODE_EXTRA_CA_CERTS: ${ctx.env.NODE_EXTRA_CA_CERTS}`);
+  }
+  if (proxy.configured) {
+    const parts: string[] = [];
+    if (proxy.source === 'git-config' || proxy.source === 'both') {
+      parts.push('git config http.proxy');
+    }
+    if (proxy.source === 'env' || proxy.source === 'both') {
+      parts.push([
+        proxy.httpProxy === undefined ? '' : 'HTTP_PROXY',
+        proxy.httpsProxy === undefined ? '' : 'HTTPS_PROXY',
+        proxy.noProxy === undefined ? '' : 'NO_PROXY'
+      ].filter(Boolean).join(', '));
+    }
+    return {
+      name: 'network-config',
+      status: 'ok',
+      detail: `Proxy configured via ${parts.join(' + ')}.`,
+      logs
+    };
+  }
+  return {
+    name: 'network-config',
+    status: 'ok',
+    detail: 'No proxy env vars or git config proxy configured.',
+    logs
+  };
+};
+
+/**
+ * Check XDG config paths.
+ * @param ctx CLI context.
+ * @param verbose Whether to record logs.
+ * @returns Doctor check result.
+ */
+const checkXdgConfig = async (ctx: Context, verbose: boolean): Promise<DoctorCheck> => {
+  const logs = createLogger(verbose);
+  try {
+    const paths = resolveUserConfigPaths(ctx.env);
+    log(logs, 'output', `root: ${paths.root}`);
+    log(logs, 'output', `activeHub: ${paths.activeHub}`);
+    log(logs, 'output', `hubs: ${paths.hubs}`);
+    const exists = await ctx.fs.exists(paths.root);
+    log(logs, 'output', `exists: ${exists ? 'true' : 'false'}`);
+    if (!exists) {
+      return {
+        name: 'xdg-config',
+        status: 'warn',
+        detail: `User config dir ${paths.root} does not exist yet (will be created on first hub add).`,
+        logs
+      };
+    }
+    return {
+      name: 'xdg-config',
+      status: 'ok',
+      detail: `User config: ${paths.root}`,
+      logs
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log(logs, 'error', msg);
+    return {
+      name: 'xdg-config',
+      status: 'fail',
+      detail: msg,
+      logs
+    };
+  }
+};
+
+/**
+ * Check active hub.
+ * @param ctx CLI context.
+ * @param verbose Whether to record logs.
+ * @returns Doctor check result.
+ */
+const checkActiveHub = async (ctx: Context, verbose: boolean): Promise<DoctorCheck> => {
+  const logs = createLogger(verbose);
+  try {
+    const paths = resolveUserConfigPaths(ctx.env);
+    const legacyRoot = path.join(path.dirname(paths.root), 'prompt-registry');
+    const legacyPaths = {
+      root: legacyRoot,
+      activeHub: path.join(legacyRoot, 'active-hub.json'),
+      hubs: path.join(legacyRoot, 'hubs')
+    };
+
+    const candidates = [paths, legacyPaths];
+    for (const candidate of candidates) {
+      const exists = await ctx.fs.exists(candidate.root);
+      log(logs, 'output', `userConfigExists (${candidate.root}): ${exists ? 'true' : 'false'}`);
+      if (!exists) {
+        continue;
+      }
+      const active = new ActiveHubStore(candidate.activeHub, ctx.fs);
+      const id = await active.get();
+      log(logs, 'output', `activeHubId (${candidate.root}): ${id ?? '<null>'}`);
+      if (id === null) {
+        continue;
+      }
+      const store = new HubStore(candidate.hubs, ctx.fs);
+      const hubExists = await store.has(id);
+      log(logs, 'output', `hubConfigExists (${candidate.root}): ${hubExists ? 'true' : 'false'}`);
+      if (!hubExists) {
+        return {
+          name: 'active-hub',
+          status: 'fail',
+          detail: `Active hub "${id}" pointer is stale (config missing).`,
+          logs
+        };
+      }
+      return { name: 'active-hub', status: 'ok', detail: `Active hub: ${id}`, logs };
+    }
+
+    return { name: 'active-hub', status: 'warn', detail: 'No active hub. Run `hub use <id>`.', logs };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log(logs, 'error', msg);
+    return {
+      name: 'active-hub',
+      status: 'fail',
+      detail: msg,
+      logs
+    };
+  }
+};
+
+/**
+ * Check GitHub authentication.
+ * @param ctx CLI context.
+ * @param verbose Whether to record logs.
+ * @returns Doctor check result.
+ */
+const checkGitHubAuth = async (ctx: Context, verbose: boolean): Promise<DoctorCheck> => {
+  const logs = createLogger(verbose);
+  try {
+    const provider = defaultTokenProvider(ctx.env);
+    const token = await provider.getToken('api.github.com');
+    log(logs, 'output', `tokenResolved: ${token !== undefined && token.length > 0 ? 'true' : 'false'}`);
+    if (token !== undefined && token.length > 0) {
+      log(logs, 'output', `tokenLength: ${token.length}`);
+      return {
+        name: 'github-auth',
+        status: 'ok',
+        detail: `GitHub token resolved (${token.length} chars). Token is never logged.`,
+        logs
+      };
+    }
+    return {
+      name: 'github-auth',
+      status: 'warn',
+      detail: 'No GitHub token resolvable. Set GITHUB_TOKEN/GH_TOKEN or run `gh auth login`. '
+        + 'Public hubs work without auth (60 req/hour rate limit).',
+      logs
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log(logs, 'error', msg);
+    return {
+      name: 'github-auth',
+      status: 'fail',
+      detail: msg,
+      logs
+    };
+  }
+};
+
+/**
+ * Check the GitHub CLI (`gh`) availability and auth status.
+ * @param ctx CLI context.
+ * @param verbose Whether to record logs.
+ * @returns Doctor check result.
+ */
+const checkGitHubCli = (ctx: Context, verbose: boolean): Promise<DoctorCheck> => {
+  const logs = createLogger(verbose);
+  try {
+    const version = spawnSync('gh', ['--version'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 5000
+    });
+    log(logs, 'input', 'gh --version');
+    log(logs, 'output', `status: ${version.status ?? 'null'}`);
+    log(logs, 'output', `stdout: ${version.stdout.trim()}`);
+    if (version.status !== 0) {
+      return Promise.resolve({
+        name: 'github-cli',
+        status: 'warn',
+        detail: '`gh` CLI not found or not working. Install it from https://cli.github.com.',
+        logs
+      });
+    }
+    const status = spawnSync('gh', ['auth', 'status'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 5000
+    });
+    log(logs, 'input', 'gh auth status');
+    log(logs, 'output', `status: ${status.status ?? 'null'}`);
+    log(logs, 'output', `stdout: ${status.stdout.trim()}`);
+    log(logs, 'output', `stderr: ${status.stderr.trim()}`);
+    if (status.status !== 0) {
+      return Promise.resolve({
+        name: 'github-cli',
+        status: 'warn',
+        detail: '`gh` CLI is installed but not authenticated. Run `gh auth login`.',
+        logs
+      });
+    }
+    return Promise.resolve({
+      name: 'github-cli',
+      status: 'ok',
+      detail: '`gh` CLI installed and authenticated.',
+      logs
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log(logs, 'error', msg);
+    return Promise.resolve({
+      name: 'github-cli',
+      status: 'warn',
+      detail: `Could not verify gh CLI: ${msg}`,
+      logs
+    });
+  }
+};
+
+/**
+ * Check GitHub API reachability.
+ * @param ctx CLI context.
+ * @param verbose Whether to record logs.
+ * @returns Doctor check result.
+ */
+const checkApiReachable = async (ctx: Context, verbose: boolean): Promise<DoctorCheck> => {
+  const logs = createLogger(verbose);
+  // Use the lib's own HTTP client (so we test the same path users hit).
+  // Skip when running offline tests by setting AI_PRIMITIVES_HUB_SKIP_NETWORK=1.
+  if (ctx.env.AI_PRIMITIVES_HUB_SKIP_NETWORK === '1') {
+    log(logs, 'info', 'Skipped (AI_PRIMITIVES_HUB_SKIP_NETWORK=1).');
+    return {
+      name: 'github-api',
+      status: 'warn',
+      detail: 'Skipped (AI_PRIMITIVES_HUB_SKIP_NETWORK=1).',
+      logs
+    };
+  }
+  try {
+    log(logs, 'input', 'GET https://api.github.com/rate_limit');
+    const http = new NodeHttpClient();
+    const provider = defaultTokenProvider(ctx.env);
+    const token = await provider.getToken('api.github.com');
+    log(logs, 'output', `tokenPresent: ${token !== undefined && token.length > 0 ? 'true' : 'false'}`);
+    const headers: Record<string, string> = {};
+    if (token !== undefined && token.length > 0) {
+      headers.Authorization = `Bearer ${token}`;
+    }
+    const res = await http.fetch({ url: 'https://api.github.com/rate_limit', headers });
+    log(logs, 'output', `statusCode: ${String(res.statusCode)}`);
+    log(logs, 'output', `rateLimit: limit=${res.headers['x-ratelimit-limit'] ?? 'n/a'} remaining=${res.headers['x-ratelimit-remaining'] ?? 'n/a'}`);
+    if (res.statusCode >= 200 && res.statusCode < 300) {
+      return { name: 'github-api', status: 'ok', detail: 'api.github.com reachable.', logs };
+    }
+    return {
+      name: 'github-api',
+      status: 'warn',
+      detail: `api.github.com returned ${String(res.statusCode)}.`,
+      logs
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    const cause = err instanceof Error && err.cause instanceof Error ? err.cause.message : undefined;
+    log(logs, 'error', msg);
+    if (cause !== undefined) {
+      log(logs, 'error', `cause: ${cause}`);
+    }
+    const proxy = summarizeProxyEnv(ctx.env);
+    const hints: string[] = [];
+    if (!proxy.configured) {
+      hints.push('No proxy env vars set. If behind a corporate proxy, set HTTPS_PROXY (and optionally HTTP_PROXY/NO_PROXY).');
+    }
+    if (ctx.env.NODE_EXTRA_CA_CERTS === undefined) {
+      hints.push('If TLS errors occur behind a corporate proxy, set NODE_EXTRA_CA_CERTS to your custom CA bundle path.');
+    }
+    const detailParts = [`api.github.com unreachable: ${cause ?? msg}`];
+    if (hints.length > 0) {
+      detailParts.push(hints.join(' '));
+    }
+    return {
+      name: 'github-api',
+      status: 'warn',
+      detail: detailParts.join(' '),
+      logs
+    };
+  }
+};
+
+/** Status glyphs for text output. */
+const STATUS_GLYPHS: Record<DoctorCheck['status'], string> = {
+  ok: '[ OK ]',
+  warn: '[WARN]',
+  fail: '[FAIL]'
+};
+
+/**
+ * Render doctor result as text.
+ * @param result Doctor result.
+ * @returns Formatted text output.
+ */
+const renderDoctorText = (result: DoctorResult): string => {
+  const lines: string[] = ['ai-primitives-hub doctor'];
+  for (const c of result.checks) {
+    lines.push(`  ${STATUS_GLYPHS[c.status]} ${c.name}: ${c.detail}`);
+    if (result.verbose && c.logs !== undefined && c.logs.length > 0) {
+      for (const entry of c.logs) {
+        lines.push(`         ${entry.level}: ${entry.message}`);
+      }
+    }
+  }
+  lines.push(
+    '',
+    `summary: ${result.summary.ok} ok / ${result.summary.warn} warn / ${result.summary.fail} fail`
+  );
+  return `${lines.join('\n')}\n`;
+};
+
+/**
+ * Render diagnostics result as text.
+ * @param result Diagnostics result.
+ * @returns Formatted text output.
+ */
+const renderDiagnosticsText = (result: DiagnosticsResult): string => {
+  const lines: string[] = [
+    'ai-primitives-hub doctor diagnostics',
+    `  workspace: ${result.workspace}`,
+    `  ${result.ok ? '[ OK ]' : '[FAIL]'} ${result.summary}`,
+    ''
+  ];
+  for (const step of result.steps) {
+    lines.push(
+      `  ${step.exitCode === 0 ? '[ OK ]' : '[FAIL]'} ${step.name} (exit ${String(step.exitCode)}, ${String(step.durationMs)}ms)`
+    );
+    if (step.input !== undefined && Object.keys(step.input).length > 0) {
+      for (const [k, v] of Object.entries(step.input)) {
+        lines.push(`         input: ${k}=${JSON.stringify(v)}`);
+      }
+    }
+    if (step.output !== undefined && Object.keys(step.output).length > 0) {
+      for (const [k, v] of Object.entries(step.output)) {
+        lines.push(`         output: ${k}=${JSON.stringify(v)}`);
+      }
+    }
+    if (step.stdout.length > 0) {
+      lines.push(`         stdout: ${step.stdout.trim()}`);
+    }
+    if (step.stderr.length > 0) {
+      lines.push(`         stderr: ${step.stderr.trim()}`);
+    }
+  }
+  return `${lines.join('\n')}\n`;
+};

--- a/packages/cli/src/commands/explain.ts
+++ b/packages/cli/src/commands/explain.ts
@@ -1,0 +1,273 @@
+/**
+ * `ai-primitives-hub explain <code>`.
+ *
+ * Looks up a structured RegistryError code and prints a paragraph of
+ * documentation. The full code catalog is built incrementally; this
+ * delivers a stub that recognizes the 11 namespaces and a curated set
+ * of the codes commands actually emit. Codes that aren't yet
+ * documented produce a generic "namespace recognized, but no entry yet"
+ * message rather than failing — the catalog is filled out as new codes appear.
+ * @module commands/explain
+ */
+import {
+  Command,
+  type Context,
+  formatOutput,
+  Option,
+  type OutputFormat,
+  RegistryError,
+  renderError,
+} from '../framework';
+
+/**
+ * Known error namespaces. Must be kept in sync with `NAMESPACES` in
+ * `@ai-primitives-hub/core`'s `domain/registry-error.ts` (only the
+ * derived `RegistryErrorNamespace` *type* is exported publicly, not
+ * the runtime array, so this list is a deliberate, documented
+ * duplicate rather than an import).
+ */
+const KNOWN_NAMESPACES: ReadonlySet<string> = new Set([
+  'BUNDLE',
+  'INDEX',
+  'HUB',
+  'PRIMITIVE',
+  'CONFIG',
+  'NETWORK',
+  'AUTH',
+  'FS',
+  'PLUGIN',
+  'USAGE',
+  'INTERNAL'
+]);
+
+/**
+ * Explain data structure.
+ */
+interface ExplainData {
+  code: string;
+  namespace: string;
+  summary: string;
+  remediation: string;
+  docsUrl?: string | null;
+}
+
+/**
+ * Catalog entry for error code documentation.
+ */
+interface CatalogEntry {
+  summary: string;
+  remediation: string;
+  docsUrl?: string;
+}
+
+// Initial catalog. Every code emitted by commands gets an
+// entry; new codes added should be added here in the
+// same iteration that introduces them.
+/**
+ * Error code documentation catalog.
+ */
+const CATALOG: Record<string, CatalogEntry> = {
+  'FS.NOT_FOUND': {
+    summary: 'A required file or directory could not be found on disk.',
+    remediation: 'Check the path is correct, or run from a repo root that has the expected folder.'
+  },
+  'FS.WRITE_FAILED': {
+    summary: 'A target write failed (permissions, full disk, parent missing).',
+    remediation: 'Check write permissions on the target path.'
+  },
+  'FS.SCAFFOLD_FAILED': {
+    summary: 'Scaffolding a new primitive (skill/prompt/agent/etc.) from a template failed.',
+    remediation: 'Check the --path directory is writable and does not already contain a conflicting file.'
+  },
+  'FS.COLLECTION_UPDATE_FAILED': {
+    summary: 'A newly scaffolded primitive was created, but appending it to --collection <id> failed.',
+    remediation: 'Check the collection.yml file is valid YAML and run `ai-primitives-hub collection validate`.'
+  },
+  'BUNDLE.NOT_FOUND': {
+    summary: 'No bundle (collection or plugin) matched the requested identifier.',
+    remediation: 'Run `ai-primitives-hub collection list` to see available collections.'
+  },
+  'BUNDLE.INVALID_MANIFEST': {
+    summary: 'A collection or bundle manifest failed schema validation (missing required fields).',
+    remediation: 'Run `ai-primitives-hub collection validate` for a per-file diagnosis.'
+  },
+  'BUNDLE.INVALID_VERSION': {
+    summary: 'The collection.version field is not a valid semver string.',
+    remediation: 'Edit the collection.yml file and ensure `version:` matches MAJOR.MINOR.PATCH.'
+  },
+  'BUNDLE.ITEM_NOT_FOUND': {
+    summary: 'A collection item references a path that does not exist on disk.',
+    remediation: 'Check the `items[].path` entries and ensure each file exists relative to the repo root.'
+  },
+  'BUNDLE.TAG_EXISTS': {
+    summary: 'A manually-set collection.version already has a matching git tag.',
+    remediation: 'Bump the `version:` field in the collection.yml or remove the existing tag.'
+  },
+  'BUNDLE.MANIFEST_MISSING': {
+    summary: 'The bundle is missing `deployment-manifest.yml` at its root.',
+    remediation: 'Verify the bundle was built with `ai-primitives-hub bundle build`. The manifest must live at the bundle root, not in a subdir.'
+  },
+  'BUNDLE.MANIFEST_INVALID': {
+    summary: 'The deployment-manifest.yml is malformed (bad YAML, missing id/version/name).',
+    remediation: 'Open the manifest and ensure it is a YAML mapping with non-empty `id`, `version`, `name` fields.'
+  },
+  'BUNDLE.ID_MISMATCH': {
+    summary: 'The manifest id differs from the requested bundle id.',
+    remediation: 'Check the install command line; the bundle id and the manifest id must match.'
+  },
+  'BUNDLE.VERSION_MISMATCH': {
+    summary: 'The manifest version differs from the requested bundle version.',
+    remediation: 'Either install with --version matching the manifest, or `--version latest` to skip the check.'
+  },
+  'BUNDLE.EXTRACT_FAILED': {
+    summary: 'The bundle bytes could not be unpacked.',
+    remediation: 'Check that the downloaded zip is intact (no truncation), or re-build locally with `ai-primitives-hub bundle build`.'
+  },
+  'PRIMITIVE.ALREADY_EXISTS': {
+    summary: 'A skill folder with the requested name already exists.',
+    remediation: 'Choose a different --skill-name or remove the existing folder.'
+  },
+  'PRIMITIVE.INVALID_NAME': {
+    summary: 'The skill name failed the spec validation (e.g., contains whitespace).',
+    remediation: 'Use only lowercase letters, digits, and hyphens.'
+  },
+  'PRIMITIVE.CREATE_FAILED': {
+    summary: 'createSkill failed for an unspecified reason.',
+    remediation: 'Re-run with verbose output and check the surrounding logs.'
+  },
+  'HUB.NOT_FOUND': {
+    summary: 'No active hub, or the requested hub id is not the currently active one.',
+    remediation: 'Run `ai-primitives-hub hub add` to import a hub, then `hub use <id>` to activate it.'
+  },
+  'INDEX.NOT_FOUND': {
+    summary: 'No primitive index file exists yet at the expected path.',
+    remediation: 'Run `ai-primitives-hub index build` or `ai-primitives-hub index harvest` first.'
+  },
+  'NETWORK.DOWNLOAD_FAILED': {
+    summary: 'The bundle could not be downloaded from the resolved URL.',
+    remediation: 'Check connectivity and GitHub rate limits, and try `ai-primitives-hub doctor` for diagnostics.'
+  },
+  'CONFIG.SCHEMA_VERSION_UNSUPPORTED': {
+    summary: 'The config or lockfile carries a schemaVersion this build does not understand.',
+    remediation: 'Upgrade ai-primitives-hub, or roll back to a build matching the schema version on disk.'
+  },
+  'USAGE.MISSING_FLAG': {
+    summary: 'A required CLI flag or argument was not provided.',
+    remediation: 'Re-run with --help on the subcommand to see the required flags.'
+  },
+  'INTERNAL.UNEXPECTED': {
+    summary: 'An unexpected error escaped a command handler. This is a bug.',
+    remediation: 'Please report at https://github.com/AmadeusITGroup/ai-primitives-hub/issues with the stderr output.'
+  }
+};
+
+/**
+ * Emit error in appropriate format.
+ * @param ctx CLI context.
+ * @param output Output format.
+ * @param err Registry error.
+ */
+const emitError = (ctx: Context, output: OutputFormat, err: RegistryError): void => {
+  if (output === 'json' || output === 'yaml' || output === 'ndjson') {
+    formatOutput({
+      ctx,
+      command: 'explain',
+      output,
+      status: 'error',
+      data: null,
+      errors: [err.toJSON()]
+    });
+  } else {
+    renderError(err, ctx);
+  }
+};
+
+/**
+ * Render explain data as text.
+ * @param d Explain data.
+ * @returns Formatted text output.
+ */
+const renderText = (d: ExplainData): string => {
+  const lines: string[] = [`${d.code}`, `  ${d.summary}`, '', `Remediation: ${d.remediation}`];
+  if (d.docsUrl !== null && d.docsUrl !== undefined) {
+    lines.push(`Docs:        ${d.docsUrl}`);
+  }
+  return `${lines.join('\n')}\n`;
+};
+
+/**
+ * Explain command class. Accepts a positional argument for the error code.
+ */
+export class ExplainCommand extends Command {
+  public static readonly paths = [['explain']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Print documentation for a RegistryError code.',
+    category: 'Configure & Debug',
+    details: `
+      Usage: ai-primitives-hub explain <NAMESPACE.CODE> [options]
+
+      Options:
+        -o, --output <format>  Output format (text, json, yaml, ndjson)
+
+      Examples:
+        ai-primitives-hub explain BUNDLE.NOT_FOUND
+        ai-primitives-hub explain INDEX.NOT_FOUND
+    `
+  });
+
+  public code = Option.String();
+  public output = Option.String('-o', '--output') as OutputFormat | undefined;
+  public commandContext!: { ctx: Context };
+
+  public execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+    const fmt = this.output ?? 'text';
+
+    if (!this.code) {
+      const err = new RegistryError({
+        code: 'USAGE.MISSING_FLAG',
+        message: 'explain: missing error code',
+        hint: 'Usage: `ai-primitives-hub explain <NAMESPACE.CODE>` (e.g., BUNDLE.NOT_FOUND)'
+      });
+      emitError(ctx, fmt, err);
+      return Promise.resolve(1);
+    }
+    const dotIdx = this.code.indexOf('.');
+    const namespace = dotIdx === -1 ? this.code : this.code.slice(0, dotIdx);
+    if (!KNOWN_NAMESPACES.has(namespace)) {
+      const err = new RegistryError({
+        code: 'USAGE.MISSING_FLAG',
+        message: `unknown namespace: ${namespace}`,
+        hint: `Valid namespaces: ${[...KNOWN_NAMESPACES].toSorted((a, b) => a.localeCompare(b)).join(', ')}`
+      });
+      emitError(ctx, fmt, err);
+      return Promise.resolve(1);
+    }
+    const entry = CATALOG[this.code];
+    const data: ExplainData = entry === undefined
+      ? {
+        code: this.code,
+        namespace,
+        summary: `Code ${this.code} is in the recognized namespace ${namespace} but has no catalog entry yet.`,
+        remediation: 'The catalog is filled out as new codes appear. Search the source for `code: \'CODE_NAME\'` if you need the throw site.',
+        docsUrl: null
+      }
+      : {
+        code: this.code,
+        namespace,
+        summary: entry.summary,
+        remediation: entry.remediation,
+        docsUrl: entry.docsUrl ?? null
+      };
+    formatOutput({
+      ctx,
+      command: 'explain',
+      output: fmt,
+      status: 'ok',
+      data,
+      textRenderer: renderText
+    });
+    return Promise.resolve(0);
+  }
+}

--- a/packages/cli/src/commands/hook-create.ts
+++ b/packages/cli/src/commands/hook-create.ts
@@ -1,0 +1,165 @@
+/**
+ * `hook create` subcommand.
+ *
+ * Creates a new hook configuration file using templates.
+ *
+ * Usage:
+ *   ai-primitives-hub hook create format \
+ *     --type "format" \
+ *     --description "Formatting hook"
+ * @module commands/hook-create
+ */
+import * as path from 'node:path';
+import {
+  readCollection,
+  writeCollection,
+} from '@ai-primitives-hub/app';
+import {
+  generateSanitizedId,
+  TemplateContext,
+} from '@ai-primitives-hub/core';
+import type {
+  CollectionItem,
+} from '@ai-primitives-hub/core';
+import {
+  TEMPLATE_PATHS,
+  TemplateEngine,
+} from '@ai-primitives-hub/infra';
+import {
+  Command,
+  type Context,
+  formatOutput,
+  Option,
+  type OutputFormat,
+  RegistryError,
+  renderError,
+} from '../framework';
+
+/**
+ * Hook create command class.
+ */
+export class HookCreateCommand extends Command {
+  public static readonly paths = [['hook', 'create']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Create a new hook configuration file',
+    category: 'Primitive',
+    details: `
+      Usage: ai-primitives-hub hook create <name> [options]
+
+      Options:
+        --type <type>          Hook type (e.g., format, validate)
+        --description <text>   Hook description
+        --path <dir>           Output directory (default: hooks/)
+        -o, --output <format>  Output format (text, json, yaml, ndjson)
+
+      Examples:
+        ai-primitives-hub hook create format --type format
+        ai-primitives-hub hook create format --type format --description "Formatting hook"
+    `
+  });
+
+  public name = Option.String({ required: true });
+  public type = Option.String('--type');
+  public description = Option.String('--description');
+  public collection = Option.String('--collection');
+  public pathOption = Option.String('--path');
+  public output = Option.String('-o', '--output') as OutputFormat | undefined;
+  public commandContext!: { ctx: Context };
+
+  public async execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+    const fmt = (this.output ?? 'text');
+
+    try {
+      // Determine hook name
+      const hookName = generateSanitizedId(this.name);
+      const displayName = this.name;
+
+      // Build template context
+      const context: TemplateContext = {
+        projectName: hookName,
+        collectionId: hookName,
+        name: displayName,
+        type: this.type || 'generic',
+        description: this.description || `A ${displayName} hook`
+      };
+
+      // Determine output path
+      const outputPath = this.pathOption || 'hooks';
+      const targetPath = path.isAbsolute(outputPath) ? outputPath : path.join(ctx.cwd(), outputPath);
+
+      // Initialize template engine
+      const templateEngine = new TemplateEngine(TEMPLATE_PATHS.hook);
+
+      // Scaffold the hook
+      const result = await templateEngine.scaffoldProject(targetPath, context);
+
+      if (!result.success) {
+        const err = new RegistryError({
+          code: 'FS.SCAFFOLD_FAILED',
+          message: result.error || 'Scaffolding failed'
+        });
+        renderError(err, ctx);
+        return 1;
+      }
+
+      // Add to collection if specified
+      if (this.collection) {
+        const collectionId = this.collection;
+        const collectionFile = path.join(ctx.cwd(), 'collections', `${collectionId}.collection.yml`);
+
+        try {
+          const collection = readCollection(ctx.cwd(), collectionFile);
+
+          // Calculate repo-root relative path
+          const createdFile = result.createdFiles[0];
+          const relativePath = path.relative(ctx.cwd(), createdFile).replace(/\\/g, '/');
+
+          // Add item to collection
+          const newItem: CollectionItem = {
+            path: relativePath,
+            kind: 'hook',
+            name: displayName,
+            description: this.description
+          };
+
+          collection.items.push(newItem);
+          writeCollection(ctx.cwd(), collectionFile, collection);
+        } catch (error) {
+          const err = new RegistryError({
+            code: 'FS.COLLECTION_UPDATE_FAILED',
+            message: `Failed to add hook to collection: ${(error as Error).message}`
+          });
+          renderError(err, ctx);
+          return 1;
+        }
+      }
+
+      // Format output
+      formatOutput({
+        ctx,
+        command: 'hook create',
+        output: fmt,
+        status: 'ok',
+        data: {
+          name: hookName,
+          path: result.createdFiles[0],
+          createdFiles: result.createdFiles,
+          collection: this.collection
+        }
+      });
+      return 0;
+    } catch (error) {
+      const registryError = error instanceof RegistryError
+        ? error
+        : new RegistryError({
+          code: 'INTERNAL.UNEXPECTED',
+          message: (error as Error).message
+        });
+
+      renderError(registryError, ctx);
+      return 1;
+    }
+  }
+}

--- a/packages/cli/src/commands/hub.ts
+++ b/packages/cli/src/commands/hub.ts
@@ -1,0 +1,478 @@
+/**
+ * `hub` commands.
+ *
+ * Subcommands:
+ *   hub add <ref>         import a hub from a reference
+ *   hub list              list saved hubs
+ *   hub use [<id>|--clear]  set/clear the active hub
+ *   hub remove <id>       remove a hub
+ *   hub sync [<id>]       re-fetch a hub config (default: active)
+ *   hub create            scaffold a hub-config.yml skeleton
+ *   hub refresh           sync the active hub (shorthand)
+ *
+ * Our `HubManager` (`@ai-primitives-hub/app`) names two methods the
+ * reference branch's manager names differently: `useHub` here is
+ * `setActiveHub`, and `removeHub` here is `deleteHub`. There is also no
+ * `checkHub(hubId)` convenience — `hub list --check` instead calls
+ * `verifyHubAvailability(reference)` per listed hub (boolean only, no
+ * failure `reason` string).
+ */
+import * as path from 'node:path';
+import type {
+  HttpClient,
+  TokenProvider,
+} from '@ai-primitives-hub/core';
+import {
+  Command,
+  createHubManager,
+  Option,
+} from '../framework';
+import {
+  type Context,
+  formatOutput,
+  type OutputFormat,
+  RegistryError,
+  renderError,
+} from '../framework';
+
+/**
+ * Context passed to hub command execute methods.
+ */
+interface HubCommandContext {
+  ctx: Context;
+  http?: HttpClient;
+  tokens?: TokenProvider;
+}
+
+/**
+ * Base class for hub commands with shared context.
+ */
+abstract class BaseHubCommand extends Command {
+  /**
+   * Get the CLI context. This needs to be set by the CLI entry point.
+   */
+  public commandContext!: HubCommandContext;
+
+  public output = Option.String('-o,--output');
+}
+
+/**
+ * hub list - list saved hubs
+ */
+export class HubListCommand extends BaseHubCommand {
+  public static readonly paths = [['hub', 'list']];
+  public static readonly usage = Command.Usage({
+    description: 'List imported hubs and optionally check reachability.',
+    category: 'Hub & Discovery',
+    details: `
+      Usage: ai-primitives-hub hub list [options]
+
+      Options:
+        --check                 Probe reachability of each hub source
+        -o, --output <format>  Output format (text, json, yaml, ndjson)
+
+      Examples:
+        ai-primitives-hub hub list
+        ai-primitives-hub hub list --check
+    `
+  });
+
+  public check = Option.Boolean('--check');
+
+  public async execute() {
+    const { ctx, http, tokens } = this.commandContext;
+    const fmt = (this.output ?? 'text') as OutputFormat;
+    const mgr = createHubManager({ ctx, http, tokens });
+    const hubs = await mgr.listHubs();
+    const active = await mgr.getActiveHub();
+
+    let reachability: Record<string, { status: 'ok' | 'error' }> | undefined;
+    if (this.check) {
+      reachability = {};
+      const results = await Promise.all(hubs.map(async (h) => {
+        const ok = await mgr.verifyHubAvailability(h.reference);
+        return [h.id, { status: ok ? 'ok' as const : 'error' as const }] as const;
+      }));
+      for (const [id, r] of results) {
+        reachability[id] = r;
+      }
+    }
+
+    const enriched = reachability === undefined
+      ? hubs
+      : hubs.map((h) => ({ ...h, check: reachability[h.id] }));
+
+    formatOutput({
+      ctx, command: 'hub.list', output: fmt, status: 'ok',
+      data: { hubs: enriched, activeId: active?.id ?? null },
+      textRenderer: (d) => d.hubs.length === 0
+        ? 'No hubs imported. Run `ai-primitives-hub hub add <ref>` to import one.\n'
+        : d.hubs.map((h: { id: string; name: string; check?: { status: string } }) => {
+          const marker = h.id === d.activeId ? '*' : ' ';
+          let probe: string;
+          if (h.check === undefined) {
+            probe = '';
+          } else if (h.check.status === 'ok') {
+            probe = '  [reachable]';
+          } else {
+            probe = '  [unreachable]';
+          }
+          return `${marker} ${h.id}  ${h.name}${probe}\n`;
+        }).join('')
+    });
+    return 0;
+  }
+}
+
+/**
+ * hub add - import a hub from a reference
+ */
+export class HubAddCommand extends BaseHubCommand {
+  public static readonly paths = [['hub', 'add']];
+  public static readonly usage = Command.Usage({
+    description: 'Import a hub from a reference (GitHub repo, local path, or URL).',
+    category: 'Hub & Discovery',
+    details: `
+      Usage: ai-primitives-hub hub add --location <ref> [options]
+
+      Options:
+        --type <type>            Reference type: github (default), local, url
+        --location <ref>         GitHub owner/repo, local path, or URL
+        --ref <branch>           Git branch, tag, or commit (GitHub only)
+        --id <id>                Custom hub ID (defaults to repo name)
+        --no-sync                Skip syncing after import
+        --no-use                 Skip setting as active hub
+        -o, --output <format>     Output format (text, json, yaml, ndjson)
+
+      Examples:
+        ai-primitives-hub hub add --location amadeus/copilot-hub
+        ai-primitives-hub hub add --type local --location ./my-hub --id local-hub
+    `
+  });
+
+  public refType = Option.String('--type');
+  public refLocation = Option.String('--location');
+  public refRef = Option.String('--ref');
+  public hubId = Option.String('--id');
+  public noSync = Option.Boolean('--no-sync');
+  public noUse = Option.Boolean('--no-use');
+
+  public async execute() {
+    const { ctx, http, tokens } = this.commandContext;
+    const fmt = (this.output ?? 'text') as OutputFormat;
+    const mgr = createHubManager({ ctx, http, tokens });
+
+    if (!this.refLocation) {
+      renderError(new RegistryError({
+        code: 'USAGE.MISSING_FLAG',
+        message: 'hub add: --location <ref> is required',
+        hint: 'Examples: hub add --type github --location owner/repo --ref main'
+      }), ctx);
+      return 1;
+    }
+
+    const refType = (this.refType ?? 'github') as 'github' | 'local' | 'url';
+    let location = this.refLocation;
+    if (refType === 'local' && !path.isAbsolute(location)) {
+      location = path.resolve(ctx.cwd(), location);
+    }
+
+    const id = await mgr.importHub({
+      type: refType,
+      location,
+      ref: this.refRef
+    }, this.hubId);
+
+    // F-05: auto-use and auto-sync after import (unless flags disable)
+    if (!this.noUse) {
+      await mgr.setActiveHub(id);
+    }
+
+    if (!this.noSync) {
+      await mgr.syncHub(id);
+    }
+
+    formatOutput({
+      ctx, command: 'hub.add', output: fmt, status: 'ok',
+      data: { id, location, type: refType, used: !this.noUse, synced: !this.noSync },
+      textRenderer: (d) => {
+        const actions: string[] = [`Imported hub "${d.id}" from ${d.type}:${d.location}`];
+        if (d.used) {
+          actions.push('marked as active');
+        }
+        if (d.synced) {
+          actions.push('synced');
+        }
+        const suffix = d.used ? '' : `\nRun \`ai-primitives-hub hub use ${d.id}\` to activate it.`;
+        return `${actions.join(', ')}.${suffix}\n`;
+      }
+    });
+    return 0;
+  }
+}
+
+/**
+ * hub use - set/clear the active hub
+ */
+export class HubUseCommand extends BaseHubCommand {
+  public static readonly paths = [['hub', 'use']];
+  public static readonly usage = Command.Usage({
+    description: 'Set or clear the active hub.',
+    category: 'Hub & Discovery',
+    details: `
+      Usage: ai-primitives-hub hub use <hub-id>
+      Usage: ai-primitives-hub hub use --clear
+
+      Options:
+        --clear                  Clear the active hub
+        -o, --output <format>     Output format (text, json, yaml, ndjson)
+
+      Examples:
+        ai-primitives-hub hub use amadeus-copilot-hub
+        ai-primitives-hub hub use --clear
+    `
+  });
+
+  public clear = Option.Boolean('--clear');
+  public hubId = Option.String({ required: false });
+
+  public async execute() {
+    const { ctx, http, tokens } = this.commandContext;
+    const fmt = (this.output ?? 'text') as OutputFormat;
+    const mgr = createHubManager({ ctx, http, tokens });
+
+    if (this.clear) {
+      await mgr.setActiveHub(null);
+      formatOutput({
+        ctx, command: 'hub.use', output: fmt, status: 'ok',
+        data: { activeId: null },
+        textRenderer: () => 'Active hub cleared.\n'
+      });
+      return 0;
+    }
+
+    if (!this.hubId) {
+      renderError(new RegistryError({
+        code: 'USAGE.MISSING_FLAG',
+        message: 'hub use: provide a hub id or --clear',
+        hint: 'Run `ai-primitives-hub hub list` to see available hubs.'
+      }), ctx);
+      return 1;
+    }
+
+    await mgr.setActiveHub(this.hubId);
+    formatOutput({
+      ctx, command: 'hub.use', output: fmt, status: 'ok',
+      data: { activeId: this.hubId },
+      textRenderer: (d) => `Active hub: ${d.activeId}.\n`
+    });
+    return 0;
+  }
+}
+
+/**
+ * hub remove - remove a hub
+ */
+export class HubRemoveCommand extends BaseHubCommand {
+  public static readonly paths = [['hub', 'remove']];
+  public static readonly usage = Command.Usage({
+    description: 'Remove an imported hub.',
+    category: 'Hub & Discovery',
+    details: `
+      Usage: ai-primitives-hub hub remove <hub-id>
+
+      Options:
+        -o, --output <format>  Output format (text, json, yaml, ndjson)
+
+      Examples:
+        ai-primitives-hub hub remove old-hub
+    `
+  });
+
+  public hubId = Option.String({ required: false });
+
+  public async execute() {
+    const { ctx, http, tokens } = this.commandContext;
+    const fmt = (this.output ?? 'text') as OutputFormat;
+    const mgr = createHubManager({ ctx, http, tokens });
+
+    if (!this.hubId) {
+      renderError(new RegistryError({
+        code: 'USAGE.MISSING_FLAG',
+        message: 'hub remove: <hubId> is required',
+        hint: 'Run `ai-primitives-hub hub list` to see available hub IDs.'
+      }), ctx);
+      return 1;
+    }
+
+    await mgr.deleteHub(this.hubId);
+    formatOutput({
+      ctx, command: 'hub.remove', output: fmt, status: 'ok',
+      data: { id: this.hubId },
+      textRenderer: (d) => `Removed hub "${d.id}".\n`
+    });
+    return 0;
+  }
+}
+
+/**
+ * hub create - scaffold a hub-config.yml skeleton
+ */
+export class HubCreateCommand extends BaseHubCommand {
+  public static readonly paths = [['hub', 'create']];
+  public static readonly usage = Command.Usage({
+    description: 'Scaffold a hub-config.yml skeleton.',
+    category: 'Hub & Discovery',
+    details: `
+      Usage: ai-primitives-hub hub create --name <name> [--out <dir>] [--add-source <path>]
+
+      Options:
+        --name <name>        Hub display name.
+        --out <dir>          Output directory (default: cwd).
+        --add-source <path>  Pre-populate a local source in the config.
+
+      Examples:
+        $ ai-primitives-hub hub create --name "My Hub"
+        $ ai-primitives-hub hub create --name "Dev Hub" --out ./hubs/dev
+    `
+  });
+
+  public name = Option.String('--name');
+  public out = Option.String('--out');
+  public addSource = Option.String('--add-source');
+
+  public async execute() {
+    const { ctx } = this.commandContext;
+    const fmt = (this.output ?? 'text') as OutputFormat;
+
+    if (!this.name) {
+      renderError(new RegistryError({
+        code: 'USAGE.MISSING_FLAG',
+        message: 'hub create: --name <name> is required',
+        hint: 'Example: hub create --name "My Hub" --out ./my-hub'
+      }), ctx);
+      return 1;
+    }
+
+    const outDir = this.out ? path.resolve(ctx.cwd(), this.out) : ctx.cwd();
+    const configPath = path.join(outDir, 'hub-config.yml');
+    const now = new Date().toISOString();
+    const sourcesBlock = this.addSource
+      ? `  - id: local-source\n    type: local\n    url: ${path.resolve(ctx.cwd(), this.addSource)}\n`
+      : '  # - id: my-source\n  #   type: github\n  #   url: owner/repo\n';
+
+    const content = [
+      '# hub-config.yml — created by ai-primitives-hub hub create',
+      'version: "1.0.0"',
+      'metadata:',
+      `  name: "${this.name}"`,
+      '  description: ""',
+      '  maintainer: ""',
+      `  updatedAt: "${now}"`,
+      'sources:',
+      sourcesBlock,
+      'profiles: []'
+    ].join('\n') + '\n';
+
+    await ctx.fs.mkdir(outDir, { recursive: true });
+    await ctx.fs.writeFile(configPath, content);
+
+    formatOutput({
+      ctx, command: 'hub.create', output: fmt, status: 'ok',
+      data: { path: configPath, name: this.name, outDir },
+      textRenderer: (d) => `Created hub config: ${d.path}\n`
+        + `Edit it to add sources and profiles, then run:\n`
+        + `  ai-primitives-hub hub add --type local --location ${d.outDir}\n`
+    });
+    return 0;
+  }
+}
+
+/**
+ * hub sync - re-fetch a hub config
+ */
+export class HubSyncCommand extends BaseHubCommand {
+  public static readonly paths = [['hub', 'sync']];
+  public static readonly usage = Command.Usage({
+    description: 'Re-fetch and sync a hub config.',
+    category: 'Hub & Discovery',
+    details: `
+      Usage: ai-primitives-hub hub sync [<hub-id>]
+
+      Examples:
+        $ ai-primitives-hub hub sync          # sync active hub
+        $ ai-primitives-hub hub sync my-hub   # sync specific hub
+    `
+  });
+
+  public hubId = Option.String({ required: false });
+
+  public async execute() {
+    const { ctx, http, tokens } = this.commandContext;
+    const fmt = (this.output ?? 'text') as OutputFormat;
+    const mgr = createHubManager({ ctx, http, tokens });
+
+    let id = this.hubId;
+    if (!id) {
+      const active = await mgr.getActiveHub();
+      if (!active) {
+        renderError(new RegistryError({
+          code: 'USAGE.MISSING_FLAG',
+          message: 'hub sync: no <hubId> given and no active hub',
+          hint: 'Run `ai-primitives-hub hub use <id>` or pass the hub id directly.'
+        }), ctx);
+        return 1;
+      }
+      id = active.id;
+    }
+
+    await mgr.syncHub(id);
+    formatOutput({
+      ctx, command: 'hub.sync', output: fmt, status: 'ok',
+      data: { id },
+      textRenderer: (d) => `Synced hub "${d.id}".\n`
+    });
+    return 0;
+  }
+}
+
+/**
+ * hub refresh - sync the active hub (F-05 shorthand)
+ */
+export class HubRefreshCommand extends BaseHubCommand {
+  public static readonly paths = [['hub', 'refresh']];
+  public static readonly usage = Command.Usage({
+    description: 'Sync the active hub (shorthand for hub sync).',
+    category: 'Hub & Discovery',
+    details: `
+      Usage: ai-primitives-hub hub refresh
+
+      Examples:
+        $ ai-primitives-hub hub refresh   # same as: hub sync (active)
+    `
+  });
+
+  public async execute() {
+    const { ctx, http, tokens } = this.commandContext;
+    const fmt = (this.output ?? 'text') as OutputFormat;
+    const mgr = createHubManager({ ctx, http, tokens });
+
+    const active = await mgr.getActiveHub();
+    if (!active) {
+      renderError(new RegistryError({
+        code: 'HUB.NOT_FOUND',
+        message: 'hub refresh: no active hub',
+        hint: 'Run `ai-primitives-hub hub use <id>` first.'
+      }), ctx);
+      return 1;
+    }
+
+    await mgr.syncHub(active.id);
+    formatOutput({
+      ctx, command: 'hub.refresh', output: fmt, status: 'ok',
+      data: { id: active.id },
+      textRenderer: (d) => `Refreshed hub "${d.id}".\n`
+    });
+    return 0;
+  }
+}

--- a/packages/cli/src/commands/index-bench.ts
+++ b/packages/cli/src/commands/index-bench.ts
@@ -1,0 +1,99 @@
+/**
+ * `index bench` — search microbenchmark.
+ *
+ * Loads a gold-set JSON file (same shape as `index eval`) and runs
+ * each query N times against the loaded index, reporting per-query
+ * median/p95/max plus aggregate QPS.
+ * @module commands/index-bench
+ */
+import * as fs from 'node:fs';
+import {
+  defaultIndexFile,
+  loadIndex,
+} from '@ai-primitives-hub/infra';
+import {
+  type BenchCase,
+  renderBenchReportMarkdown,
+  runBench,
+} from '@ai-primitives-hub/infra';
+import {
+  Command,
+  type Context,
+  failWith,
+  formatOutput,
+  Option,
+  type OutputFormat,
+  RegistryError,
+} from '../framework';
+
+/**
+ * Index bench command class.
+ * Runs a search microbenchmark over a gold-set against an index.
+ */
+export class IndexBenchCommand extends Command {
+  public static readonly paths = [['index', 'bench']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Run a search microbenchmark over a gold-set against an index.',
+    category: 'Index & Search',
+    details: `
+      Usage: ai-primitives-hub index bench --gold <FILE> [options]
+
+      Examples:
+        ai-primitives-hub index bench --gold golden-queries.json
+        ai-primitives-hub index bench --gold golden-queries.json --index /tmp/index.json
+        ai-primitives-hub index bench --gold golden-queries.json --iterations 100
+    `
+  });
+
+  public gold = Option.String('--gold');
+  public index = Option.String('--index');
+  public iterations = Option.String('--iterations');
+  public output = Option.String('-o,--output');
+  public commandContext!: { ctx: Context };
+
+  public execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+
+    const fmt = (this.output ?? 'text') as OutputFormat;
+
+    if (!this.gold || this.gold.length === 0) {
+      return Promise.resolve(failWith(ctx, fmt, 'index.bench', new RegistryError({
+        code: 'USAGE.MISSING_FLAG',
+        message: 'index bench: --gold <FILE> is required'
+      })));
+    }
+
+    const indexPath = this.index ?? defaultIndexFile(ctx.env);
+    const iterations = this.iterations ? Number.parseInt(this.iterations, 10) : 50;
+
+    try {
+      const idx = loadIndex(indexPath);
+      const raw = fs.readFileSync(this.gold, 'utf8');
+      const parsed = JSON.parse(raw) as { cases: { id: string; query: BenchCase['query'] }[] };
+      const cases: BenchCase[] = parsed.cases.map((c) => ({ id: c.id, query: c.query }));
+      const report = runBench(idx, cases, iterations);
+      formatOutput({
+        ctx, command: 'index.bench', output: fmt, status: 'ok',
+        data: report,
+        textRenderer: (r) => renderBenchReportMarkdown(r)
+      });
+      return Promise.resolve(0);
+    } catch (cause) {
+      const msg = cause instanceof Error ? cause.message : String(cause);
+      const err = /ENOENT|no such file/i.test(msg)
+        ? new RegistryError({
+          code: 'INDEX.NOT_FOUND',
+          message: `index bench: missing file (${msg})`,
+          hint: 'Run `ai-primitives-hub index build` or `ai-primitives-hub index harvest` first.',
+          cause: cause instanceof Error ? cause : undefined
+        })
+        : new RegistryError({
+          code: 'INDEX.BENCH_FAILED',
+          message: `index bench failed: ${msg}`,
+          cause: cause instanceof Error ? cause : undefined
+        });
+      return Promise.resolve(failWith(ctx, fmt, 'index.bench', err));
+    }
+  }
+}

--- a/packages/cli/src/commands/index-build.ts
+++ b/packages/cli/src/commands/index-build.ts
@@ -1,0 +1,110 @@
+/**
+ * `index build` — build a primitive index from a local folder of
+ * bundles.
+ *
+ * Wraps `LocalFolderBundleProvider` + `PrimitiveIndex.buildFrom` and
+ * persists via `saveIndex`. Output goes through `formatOutput` so
+ * callers get a stable JSON envelope on `-o json`.
+ * @module commands/index-build
+ */
+import * as path from 'node:path';
+import type {
+  IndexStats,
+} from '@ai-primitives-hub/infra';
+import {
+  LocalFolderBundleProvider,
+  PrimitiveIndex,
+  saveIndex,
+} from '@ai-primitives-hub/infra';
+import {
+  Command,
+  type Context,
+  failWith,
+  formatOutput,
+  Option,
+  type OutputFormat,
+  RegistryError,
+} from '../framework';
+
+interface BuildResult {
+  outFile: string;
+  stats: IndexStats;
+}
+
+/**
+ * Index build command class.
+ * Builds a primitive index from a local folder of bundles.
+ */
+export class IndexBuildCommand extends Command {
+  public static readonly paths = [['index', 'build']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Build a primitive index from a local folder of bundles.',
+    category: 'Index & Search',
+    details: `
+      Usage: ai-primitives-hub index build --root <DIR> [options]
+
+      Options:
+        --root <dir>              Root directory containing bundles (required)
+        --out, --out-file <path>  Output index file path
+        --source-id <id>          Source ID for the index
+        -o, --output <format>     Output format (text, json, yaml, ndjson)
+
+      Examples:
+        ai-primitives-hub index build --root ./bundles
+        ai-primitives-hub index build --root ./bundles --out /tmp/index.json
+        ai-primitives-hub index build --root ./bundles --source-id my-source
+    `
+  });
+
+  public root = Option.String('--root');
+  public out = Option.String('--out,--out-file');
+  public sourceId = Option.String('--source-id');
+  public output = Option.String('-o,--output');
+  public commandContext!: { ctx: Context };
+
+  public async execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+
+    const fmt = (this.output ?? 'text') as OutputFormat;
+
+    if (!this.root || this.root.length === 0) {
+      return failWith(ctx, fmt, 'index.build', new RegistryError({
+        code: 'USAGE.MISSING_FLAG',
+        message: 'index build: --root <DIR> is required'
+      }));
+    }
+
+    try {
+      const outFile = this.out ?? path.join(this.root, 'primitive-index.json');
+      const provider = new LocalFolderBundleProvider({
+        root: this.root,
+        sourceId: this.sourceId
+      });
+      const idx = await PrimitiveIndex.buildFrom(provider, {
+        hubId: this.sourceId
+      });
+      saveIndex(idx, outFile);
+      const stats = idx.stats();
+      const data: BuildResult = { outFile, stats };
+      formatOutput({
+        ctx,
+        command: 'index.build',
+        output: fmt,
+        status: 'ok',
+        data,
+        textRenderer: (d) =>
+          `built ${String(d.stats.primitives)} primitives `
+          + `from ${String(d.stats.bundles)} bundles → ${d.outFile}\n`
+      });
+      return 0;
+    } catch (cause) {
+      const err = new RegistryError({
+        code: 'INDEX.BUILD_FAILED',
+        message: `index build failed: ${cause instanceof Error ? cause.message : String(cause)}`,
+        cause: cause instanceof Error ? cause : undefined
+      });
+      return failWith(ctx, fmt, 'index.build', err);
+    }
+  }
+}

--- a/packages/cli/src/commands/index-eval.ts
+++ b/packages/cli/src/commands/index-eval.ts
@@ -1,0 +1,101 @@
+/**
+ * `index eval` — pattern-based relevance eval.
+ *
+ * Loads a gold-set JSON file with `cases[]: PatternCase` and runs
+ * every query against the index, reporting must-match satisfaction
+ * per case + aggregated pass-rate. Exits non-zero when any case fails
+ * so CI can gate ranking quality.
+ * @module commands/index-eval
+ */
+import * as fs from 'node:fs';
+import {
+  defaultIndexFile,
+  loadIndex,
+} from '@ai-primitives-hub/infra';
+import {
+  type PatternCase,
+  type PatternReport,
+  renderPatternReportMarkdown,
+  runPatternEval,
+} from '@ai-primitives-hub/infra';
+import {
+  Command,
+  type Context,
+  failWith,
+  formatOutput,
+  Option,
+  type OutputFormat,
+  RegistryError,
+} from '../framework';
+
+/**
+ * Index eval command class.
+ * Runs pattern-based relevance eval against an index.
+ */
+export class IndexEvalCommand extends Command {
+  public static readonly paths = [['index', 'eval']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Run pattern-based relevance eval against an index.',
+    category: 'Index & Search',
+    details: `
+      Usage: ai-primitives-hub index eval --gold <FILE> [options]
+
+      Examples:
+        ai-primitives-hub index eval --gold golden-queries.json
+        ai-primitives-hub index eval --gold golden-queries.json --index /tmp/index.json
+    `
+  });
+
+  public gold = Option.String('--gold');
+  public index = Option.String('--index');
+  public output = Option.String('-o,--output');
+  public commandContext!: { ctx: Context };
+
+  public execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+
+    const fmt = (this.output ?? 'text') as OutputFormat;
+
+    if (!this.gold || this.gold.length === 0) {
+      return Promise.resolve(failWith(ctx, fmt, 'index.eval', new RegistryError({
+        code: 'USAGE.MISSING_FLAG',
+        message: 'index eval: --gold <FILE> is required'
+      })));
+    }
+
+    const indexPath = this.index ?? defaultIndexFile(ctx.env);
+
+    let report: PatternReport;
+    try {
+      const idx = loadIndex(indexPath);
+      const raw = fs.readFileSync(this.gold, 'utf8');
+      const parsed = JSON.parse(raw) as { cases: PatternCase[] };
+      report = runPatternEval(idx, parsed.cases);
+    } catch (cause) {
+      const msg = cause instanceof Error ? cause.message : String(cause);
+      const err = /ENOENT|no such file/i.test(msg)
+        ? new RegistryError({
+          code: 'INDEX.NOT_FOUND',
+          message: `index eval: missing file (${msg})`,
+          hint: 'Run `ai-primitives-hub index build` or `ai-primitives-hub index harvest` first.',
+          cause: cause instanceof Error ? cause : undefined
+        })
+        : new RegistryError({
+          code: 'INDEX.EVAL_FAILED',
+          message: `index eval failed: ${msg}`,
+          cause: cause instanceof Error ? cause : undefined
+        });
+      return Promise.resolve(failWith(ctx, fmt, 'index.eval', err));
+    }
+
+    formatOutput({
+      ctx, command: 'index.eval', output: fmt, status: 'ok',
+      data: report,
+      textRenderer: (r) => renderPatternReportMarkdown(r)
+    });
+
+    // Non-zero exit when any case failed so CI treats it as a fail.
+    return Promise.resolve(report.aggregate.failed > 0 ? 1 : 0);
+  }
+}

--- a/packages/cli/src/commands/index-export.ts
+++ b/packages/cli/src/commands/index-export.ts
@@ -1,0 +1,149 @@
+/**
+ * `index export` — export a shortlist as a hub profile YAML (and
+ * optionally a suggested collection YAML).
+ *
+ * Output goes through `formatOutput` so JSON callers get the canonical
+ * envelope with `profileFile` and (when `--suggest-collection`)
+ * `collectionFile` paths.
+ * @module commands/index-export
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  exportShortlistAsProfile,
+} from '@ai-primitives-hub/app';
+import {
+  defaultIndexFile,
+  loadIndex,
+} from '@ai-primitives-hub/infra';
+import {
+  dump as toYaml,
+} from 'js-yaml';
+import {
+  Command,
+  type Context,
+  failWith,
+  formatOutput,
+  Option,
+  type OutputFormat,
+  RegistryError,
+} from '../framework';
+
+interface ExportResult {
+  profileFile: string;
+  collectionFile?: string;
+  warnings: string[];
+}
+
+const buildIndexExportError = (cause: unknown, indexPath: string): RegistryError => {
+  const msg = cause instanceof Error ? cause.message : String(cause);
+  return /ENOENT|no such file/i.test(msg)
+    ? new RegistryError({
+      code: 'INDEX.NOT_FOUND',
+      message: `index not found: ${indexPath}`,
+      hint: 'Run `ai-primitives-hub index build` or `ai-primitives-hub index harvest` first.',
+      cause: cause instanceof Error ? cause : undefined
+    })
+    : new RegistryError({
+      code: 'INDEX.EXPORT_FAILED',
+      message: `index export failed: ${msg}`,
+      hint: 'Please check the error message and try again.',
+      cause: cause instanceof Error ? cause : undefined
+    });
+};
+
+/**
+ * Index export command class.
+ * Exports a shortlist as a hub profile YAML.
+ */
+export class IndexExportCommand extends Command {
+  public static readonly paths = [['index', 'export']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Export a shortlist as a hub profile YAML.',
+    category: 'Index & Search',
+    details: `
+      Usage: ai-primitives-hub index export --shortlist <SHORTLIST_ID> --profile-id <ID> [options]
+
+      Examples:
+        ai-primitives-hub index export --shortlist my-list --profile-id custom-profile
+        ai-primitives-hub index export --shortlist my-list --profile-id custom-profile --out-dir ./exports
+        ai-primitives-hub index export --shortlist my-list --profile-id custom-profile --suggest-collection
+    `
+  });
+
+  public shortlist = Option.String('--shortlist');
+  public profileId = Option.String('--profile-id');
+  public outDir = Option.String('--out-dir');
+  public profileName = Option.String('--profile-name');
+  public description = Option.String('--description');
+  public icon = Option.String('--icon');
+  public suggestCollection = Option.Boolean('--suggest-collection');
+  public index = Option.String('--index');
+  public output = Option.String('-o,--output');
+  public commandContext!: { ctx: Context };
+
+  public execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+
+    const fmt = (this.output ?? 'text') as OutputFormat;
+
+    if (!this.shortlist || this.shortlist.length === 0) {
+      return Promise.resolve(failWith(ctx, fmt, 'index.export', new RegistryError({
+        code: 'USAGE.MISSING_FLAG',
+        message: 'index export: --shortlist <SHORTLIST_ID> is required'
+      })));
+    }
+    if (!this.profileId || this.profileId.length === 0) {
+      return Promise.resolve(failWith(ctx, fmt, 'index.export', new RegistryError({
+        code: 'USAGE.MISSING_FLAG',
+        message: 'index export: --profile-id <ID> is required'
+      })));
+    }
+
+    const indexPath = this.index ?? defaultIndexFile(ctx.env);
+
+    try {
+      const idx = loadIndex(indexPath);
+      const sl = idx.getShortlist(this.shortlist);
+      if (sl === undefined) {
+        return Promise.resolve(failWith(ctx, fmt, 'index.export', new RegistryError({
+          code: 'INDEX.SHORTLIST_NOT_FOUND',
+          message: `index export: unknown shortlist "${this.shortlist}"`
+        })));
+      }
+      const result = exportShortlistAsProfile(idx, sl, {
+        profileId: this.profileId,
+        profileName: this.profileName,
+        description: this.description,
+        icon: this.icon,
+        suggestCollection: this.suggestCollection
+      });
+      const outDir = this.outDir ?? '.';
+      fs.mkdirSync(outDir, { recursive: true });
+      const profileFile = path.join(outDir, `${this.profileId}.profile.yml`);
+      fs.writeFileSync(profileFile, toYaml(result.profile), 'utf8');
+      const data: ExportResult = {
+        profileFile,
+        warnings: result.warnings
+      };
+      if (result.suggestedCollection !== undefined) {
+        const collectionFile = path.join(outDir, `${result.suggestedCollection.id}.collection.yml`);
+        fs.writeFileSync(collectionFile, toYaml(result.suggestedCollection), 'utf8');
+        data.collectionFile = collectionFile;
+      }
+      formatOutput({
+        ctx, command: 'index.export', output: fmt, status: 'ok',
+        data,
+        warnings: result.warnings,
+        textRenderer: (d) =>
+          `wrote ${d.profileFile}`
+          + (d.collectionFile === undefined ? '' : `\nwrote ${d.collectionFile}`)
+          + '\n'
+      });
+      return Promise.resolve(0);
+    } catch (cause) {
+      return Promise.resolve(failWith(ctx, fmt, 'index.export', buildIndexExportError(cause, indexPath)));
+    }
+  }
+}

--- a/packages/cli/src/commands/index-harvest.ts
+++ b/packages/cli/src/commands/index-harvest.ts
@@ -1,0 +1,219 @@
+/**
+ * `index harvest` — fetch hub-config + walk every source + write a
+ * primitive index.
+ *
+ * Heavy lifting lives in `harvestHub` (`@ai-primitives-hub/infra`'s
+ * `harvest/hub-harvester.ts`); this command only adapts options + emits
+ * the canonical envelope.
+ * @module commands/index-harvest
+ */
+import * as path from 'node:path';
+import {
+  resolveUserConfigPaths,
+} from '@ai-primitives-hub/app';
+import {
+  ActiveHubStore,
+  harvestHub as defaultHarvestHub,
+  type HubHarvestPipelineOptions,
+  type HubHarvestPipelineResult,
+  HubStore,
+} from '@ai-primitives-hub/infra';
+import {
+  Command,
+  type Context,
+  failWith,
+  formatOutput,
+  Option,
+  type OutputFormat,
+  RegistryError,
+} from '../framework';
+
+/**
+ * Populate hub source fields on `cmd` from the currently active hub
+ * when the user hasn't provided them explicitly.
+ *
+ * Falls back to the legacy `prompt-registry` config directory so the
+ * `ai-primitives-hub` CLI can reuse an active hub configured by the
+ * `gh prompt-registry` extension.
+ * @param cmd IndexHarvestCommand instance (mutated).
+ * @param cmd.hubRepo
+ * @param cmd.hubBranch
+ * @param cmd.hubConfigFile
+ * @param ctx CLI context.
+ */
+async function autoDetectHubFromActive(
+  cmd: { hubRepo?: string; hubBranch?: string; hubConfigFile?: string },
+  ctx: Context
+): Promise<void> {
+  try {
+    const userPaths = resolveUserConfigPaths(ctx.env);
+
+    // Legacy fallback: `gh prompt-registry` stores active hubs under
+    // `~/.config/prompt-registry`; reuse them when the new CLI has no active hub.
+    const legacyRoot = path.join(path.dirname(userPaths.root), 'prompt-registry');
+    const candidates = [
+      { activeHub: userPaths.activeHub, hubs: userPaths.hubs },
+      { activeHub: path.join(legacyRoot, 'active-hub.json'), hubs: path.join(legacyRoot, 'hubs') }
+    ];
+
+    for (const candidate of candidates) {
+      const activeId = await new ActiveHubStore(candidate.activeHub, ctx.fs).get();
+      if (activeId === null) {
+        continue;
+      }
+      const saved = await new HubStore(candidate.hubs, ctx.fs).load(activeId);
+      const hubConfigFile = path.join(candidate.hubs, `${activeId}.yml`);
+      applyHubRef(cmd, saved.reference, hubConfigFile);
+      return;
+    }
+  } catch {
+    // If detection fails for any reason, fall through to the explicit error below.
+  }
+}
+
+/**
+ * Apply a loaded hub reference to the command's hub source fields.
+ * @param cmd Command instance (mutated).
+ * @param cmd.hubRepo Output GitHub owner/repo.
+ * @param cmd.hubBranch Output Git ref.
+ * @param cmd.hubConfigFile Output local/URL config file path.
+ * @param hubRef Loaded hub reference.
+ * @param hubRef.type Hub source type.
+ * @param hubRef.location Hub location or owner/repo.
+ * @param hubRef.ref Optional Git ref.
+ * @param hubConfigFile Absolute path to the locally cached hub config YAML.
+ */
+function applyHubRef(
+  cmd: { hubRepo?: string; hubBranch?: string; hubConfigFile?: string },
+  hubRef: { type: 'github' | 'local' | 'url'; location: string; ref?: string },
+  hubConfigFile: string
+): void {
+  if (hubRef.type === 'github') {
+    cmd.hubRepo = hubRef.location;
+    if (hubRef.ref) {
+      cmd.hubBranch = hubRef.ref;
+    }
+  }
+  cmd.hubConfigFile = hubConfigFile;
+}
+
+const buildHarvestError = (cause: unknown): RegistryError => new RegistryError({
+  code: 'INDEX.HARVEST_FAILED',
+  message: `index harvest failed: ${cause instanceof Error ? cause.message : String(cause)}`,
+  cause: cause instanceof Error ? cause : undefined
+});
+
+const isHubRefMissing = (noHubConfig: boolean, hubConfigFile: string | undefined, hubRepo: string | undefined): boolean =>
+  !noHubConfig && !hubConfigFile && (!hubRepo || hubRepo.length === 0);
+
+/**
+ * Index harvest command class.
+ * Fetches hub-config, walks every source, and writes a primitive index.
+ */
+export class IndexHarvestCommand extends Command {
+  public static readonly paths = [['index', 'harvest']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Fetch hub-config, walk every source, and write a primitive index.',
+    category: 'Index & Search',
+    details: `
+      Usage: ai-primitives-hub index harvest [options]
+
+      Examples:
+        ai-primitives-hub index harvest --hub-repo OWNER/REPO
+        ai-primitives-hub index harvest --hub-config-file hub-config.yml
+        ai-primitives-hub index harvest --no-hub-config --extra-source 'local:/path/to/bundles'
+    `
+  });
+
+  public hubRepo = Option.String('--hub-repo');
+  public hubBranch = Option.String('--hub-branch');
+  public hubConfigFile = Option.String('--hub-config-file');
+  public noHubConfig = Option.Boolean('--no-hub-config');
+  public cacheDir = Option.String('--cache-dir');
+  public progressFile = Option.String('--progress-file');
+  public outFile = Option.String('--out-file');
+  public concurrency = Option.String('--concurrency');
+  public tokenEnv = Option.String('--token-env');
+  public sourcesInclude = Option.Array('--sources-include');
+  public sourcesExclude = Option.Array('--sources-exclude');
+  public extraSources = Option.Array('--extra-source');
+  public force = Option.Boolean('--force');
+  public dryRun = Option.Boolean('--dry-run');
+  public verbose = Option.Boolean('--verbose');
+  public output = Option.String('-o,--output');
+  public commandContext!: { ctx: Context };
+
+  public async execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+
+    const fmt = (this.output ?? 'text') as OutputFormat;
+    const noHubConfig = this.noHubConfig === true;
+
+    if (isHubRefMissing(noHubConfig, this.hubConfigFile, this.hubRepo)) {
+      await autoDetectHubFromActive(this, ctx);
+    }
+
+    const hubConfigFile = this.hubConfigFile;
+
+    if (isHubRefMissing(noHubConfig, hubConfigFile, this.hubRepo)) {
+      return failWith(ctx, fmt, 'index.harvest', new RegistryError({
+        code: 'USAGE.MISSING_FLAG',
+        message: 'index harvest: --hub-repo <OWNER/REPO> is required (or use --no-hub-config / --hub-config-file)',
+        hint: 'Run `ai-primitives-hub hub add <ref>` and `hub use <id>` to configure an active hub, or pass --hub-repo directly.'
+      }));
+    }
+
+    const explicitToken = this.tokenEnv === undefined
+      ? undefined
+      : ctx.env[this.tokenEnv];
+
+    const pipelineOpts: HubHarvestPipelineOptions = {
+      hubRepo: this.hubRepo,
+      hubBranch: this.hubBranch,
+      hubConfigFile: this.hubConfigFile,
+      noHubConfig: this.noHubConfig,
+      cacheDir: this.cacheDir,
+      progressFile: this.progressFile,
+      outFile: this.outFile,
+      concurrency: this.concurrency ? Number.parseInt(this.concurrency, 10) : undefined,
+      explicitToken,
+      sourcesInclude: this.sourcesInclude,
+      sourcesExclude: this.sourcesExclude,
+      extraSources: this.extraSources,
+      force: this.force,
+      dryRun: this.dryRun,
+      onEvent: this.verbose === true
+        ? (ev): void => {
+          ctx.stderr.write(`[${ev.kind}] ${JSON.stringify(ev)}\n`);
+        }
+        : undefined,
+      onLog: (msg): void => {
+        ctx.stderr.write(`[index harvest] ${msg}\n`);
+      }
+    };
+
+    const runner = defaultHarvestHub;
+    let result: HubHarvestPipelineResult;
+
+    try {
+      result = await runner(pipelineOpts, ctx.env);
+    } catch (cause) {
+      return failWith(ctx, fmt, 'index.harvest', buildHarvestError(cause));
+    }
+
+    formatOutput({
+      ctx, command: 'index.harvest', output: fmt, status: 'ok',
+      data: result,
+      textRenderer: (r) =>
+        `done=${String(r.totals.done)} `
+        + `error=${String(r.totals.error)} `
+        + `skip=${String(r.totals.skip)} `
+        + `primitives=${String(r.totals.primitives)} `
+        + `wallMs=${String(r.totals.wallMs)} `
+        + `totalMs=${String(r.totals.totalMs)}\n`
+    });
+
+    return result.totals.error > 0 ? 1 : 0;
+  }
+}

--- a/packages/cli/src/commands/index-report.ts
+++ b/packages/cli/src/commands/index-report.ts
@@ -1,0 +1,132 @@
+/**
+ * `index report` — render a human-readable harvest report from a
+ * JSONL progress log.
+ *
+ * JSON mode emits a `{ summary, cacheStats?, bundles }` payload; text
+ * mode renders a markdown header + per-bundle table.
+ * @module commands/index-report
+ */
+import * as path from 'node:path';
+import {
+  BlobCache,
+  defaultHubCacheDir,
+  defaultProgressFile,
+} from '@ai-primitives-hub/infra';
+import {
+  type BundleState,
+  HarvestProgressLog,
+  type ProgressSummary,
+} from '@ai-primitives-hub/infra';
+import {
+  Command,
+  type Context,
+  failWith,
+  formatOutput,
+  Option,
+  type OutputFormat,
+  RegistryError,
+} from '../framework';
+
+interface ReportData {
+  summary: ProgressSummary;
+  cacheStats?: { entries: number; bytes: number };
+  bundles: BundleState[];
+}
+
+const renderReportMarkdown = (progressFile: string, d: ReportData): string => {
+  const lines: string[] = [
+    '# Primitive Index — Hub harvest report',
+    '',
+    `- Progress file: \`${progressFile}\``,
+    `- Done: **${String(d.summary.done)}**  Skip: **${String(d.summary.skip)}**  Error: **${String(d.summary.error)}**`,
+    `- Primitives (done): **${String(d.summary.primitives)}**  Wall ms: **${String(d.summary.wallMs)}**`
+  ];
+  if (d.cacheStats !== undefined) {
+    lines.push(
+      `- Blob cache: **${String(d.cacheStats.entries)}** entries, `
+      + `**${(d.cacheStats.bytes / 1024).toFixed(1)} KiB**`
+    );
+  }
+  lines.push(
+    '',
+    '| Source | Bundle | Status | Commit sha | Primitives | ms | Note |',
+    '|--------|--------|--------|-----------|------------|----|------|'
+  );
+  for (const r of d.bundles) {
+    const note = r.status === 'error' ? r.error ?? '' : r.reason ?? '';
+    const escapedNote = note.split('|').join(String.raw`\|`);
+    lines.push(
+      `| ${r.sourceId} | ${r.bundleId} | ${r.status} | ${r.commitSha.slice(0, 10)}`
+      + ` | ${r.primitives === undefined ? '—' : String(r.primitives)}`
+      + ` | ${r.ms === undefined ? '—' : String(r.ms)}`
+      + ` | ${escapedNote} |`
+    );
+  }
+  return lines.join('\n') + '\n';
+};
+
+/**
+ * Index report command class.
+ * Renders a hub-harvest report from a progress log.
+ */
+export class IndexReportCommand extends Command {
+  public static readonly paths = [['index', 'report']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Render a hub-harvest report from a progress log.',
+    category: 'Index & Search',
+    details: `
+      Usage: ai-primitives-hub index report [options]
+
+      Examples:
+        ai-primitives-hub index report --hub-repo OWNER/REPO
+        ai-primitives-hub index report --progress-file /tmp/progress.jsonl
+        ai-primitives-hub index report --cache-dir /tmp/cache
+    `
+  });
+
+  public hubRepo = Option.String('--hub-repo');
+  public progressFile = Option.String('--progress-file');
+  public cacheDir = Option.String('--cache-dir');
+  public output = Option.String('-o,--output');
+  public commandContext!: { ctx: Context };
+
+  public async execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+
+    const fmt = (this.output ?? 'text') as OutputFormat;
+    const progressFile = this.progressFile ?? defaultProgressFile(this.hubRepo, ctx.env);
+    const cacheDir = this.cacheDir ?? defaultHubCacheDir(this.hubRepo, ctx.env);
+
+    try {
+      const log = await HarvestProgressLog.open(progressFile);
+      const state = log.projectState();
+      const summary = log.summary();
+      await log.close();
+      const bundles = [...state.values()]
+        .toSorted((a, b) => a.sourceId.localeCompare(b.sourceId));
+      const data: ReportData = { summary, bundles };
+      if (cacheDir.length > 0) {
+        try {
+          const cache = new BlobCache(path.join(cacheDir, 'blobs'));
+          data.cacheStats = await cache.stats();
+        } catch {
+          // Missing cache dir is fine — leave cacheStats undefined.
+        }
+      }
+      formatOutput({
+        ctx, command: 'index.report', output: fmt, status: 'ok',
+        data,
+        textRenderer: (d) => renderReportMarkdown(progressFile, d)
+      });
+      return 0;
+    } catch (cause) {
+      const err = new RegistryError({
+        code: 'INDEX.REPORT_FAILED',
+        message: `index report failed: ${cause instanceof Error ? cause.message : String(cause)}`,
+        cause: cause instanceof Error ? cause : undefined
+      });
+      return failWith(ctx, fmt, 'index.report', err);
+    }
+  }
+}

--- a/packages/cli/src/commands/index-search.ts
+++ b/packages/cli/src/commands/index-search.ts
@@ -1,0 +1,318 @@
+/**
+ * `index search` — search a primitive index.
+ *
+ * Semantics: BM25 + facets, deterministic ranking. Output goes through
+ * `formatOutput` so JSON callers get the canonical envelope and text
+ * callers get a readable listing.
+ *
+ * Default index path is `<XDG cache>/primitive-index.json`; override
+ * with `--index <FILE>`.
+ * @module commands/index-search
+ */
+import {
+  generateSourceId,
+} from '@ai-primitives-hub/core';
+import type {
+  HttpClient,
+  RegistrySource,
+  Target,
+  TokenProvider,
+} from '@ai-primitives-hub/core';
+import {
+  defaultIndexFile,
+  defaultTokenProvider,
+  loadIndex,
+  NodeHttpClient,
+  readTargets,
+} from '@ai-primitives-hub/infra';
+import type {
+  PrimitiveKind,
+  SearchQuery,
+  SearchResult,
+} from '@ai-primitives-hub/infra';
+import inquirer from 'inquirer';
+import {
+  Command,
+  type Context,
+  createHubManager,
+  failWith,
+  formatOutput,
+  Option,
+  type OutputFormat,
+  readTargetsSafely,
+  RegistryError,
+} from '../framework';
+import {
+  installBundleWithSource,
+} from './install';
+
+type SearchCandidate = { bundleId: string; version: string; source: RegistrySource };
+
+function buildSearchCandidates(sources: RegistrySource[], hits: SearchResult['hits']): SearchCandidate[] {
+  const sourceById = new Map<string, RegistrySource>();
+  for (const src of sources) {
+    sourceById.set(generateSourceId(src.type, src.url), src);
+    sourceById.set(src.id, src);
+  }
+  const seen = new Set<string>();
+  const result: SearchCandidate[] = [];
+  for (const hit of hits) {
+    const b = hit.primitive.bundle;
+    if (seen.has(b.bundleId)) {
+      continue;
+    }
+    seen.add(b.bundleId);
+    const src = sourceById.get(b.sourceId);
+    if (src !== undefined) {
+      result.push({ bundleId: b.bundleId, version: b.bundleVersion, source: src });
+    }
+  }
+  return result;
+}
+
+async function selectBundleIds(candidates: SearchCandidate[], interactive: boolean, ctx: Context): Promise<string[] | null> {
+  if (!interactive) {
+    return candidates.map((c) => c.bundleId);
+  }
+  const choices = candidates.map((c) => ({
+    name: `${c.bundleId}@${c.version}  (${c.source.name})`,
+    value: c.bundleId,
+    short: c.bundleId
+  }));
+  const answer = await inquirer.prompt<{ selectedIds: string[] }>([
+    {
+      type: 'checkbox',
+      name: 'selectedIds',
+      message: 'Select bundles to install:',
+      choices,
+      validate: (input: string[]) => input.length > 0 || 'Select at least one bundle'
+    }
+  ]);
+  if (answer.selectedIds.length === 0) {
+    ctx.stdout.write('No bundles selected.\n');
+    return null;
+  }
+  return answer.selectedIds;
+}
+
+async function installSelectedBundles(
+  selectedIds: string[],
+  candidates: SearchCandidate[],
+  target: Target,
+  ctx: Context,
+  http: HttpClient,
+  tokens: TokenProvider,
+  fmt: OutputFormat
+): Promise<number> {
+  let installed = 0;
+  for (const bundleId of selectedIds) {
+    const c = candidates.find((x) => x.bundleId === bundleId);
+    if (c === undefined) {
+      continue;
+    }
+    try {
+      const code = await installBundleWithSource(bundleId, c.source, target, ctx, http, tokens, fmt);
+      if (code === 0) {
+        installed++;
+      }
+    } catch (err) {
+      ctx.stderr.write(`Failed to install ${bundleId}: ${err instanceof Error ? err.message : String(err)}\n`);
+    }
+  }
+  ctx.stdout.write(`Installed ${installed}/${selectedIds.length} bundle(s)\n`);
+  return installed === selectedIds.length ? 0 : 1;
+}
+
+async function searchAndInstall(
+  result: SearchResult,
+  opts: { installTarget?: string; interactive?: boolean; http?: HttpClient; tokens?: TokenProvider },
+  ctx: Context,
+  fmt: OutputFormat
+): Promise<number> {
+  const http = opts.http ?? new NodeHttpClient();
+  const tokens = opts.tokens ?? defaultTokenProvider(ctx.env);
+  const mgr = createHubManager({ ctx, http, tokens });
+  const active = await mgr.getActiveHub();
+  if (active === null) {
+    ctx.stderr.write('No active hub found. Run `ai-primitives-hub hub use <id>` first.\n');
+    return 1;
+  }
+
+  const candidates = buildSearchCandidates(active.config.sources, result.hits);
+
+  if (candidates.length === 0) {
+    ctx.stdout.write('No bundles from the active hub matched the search results.\n');
+    return 0;
+  }
+
+  const selectedIds = await selectBundleIds(candidates, opts.interactive ?? false, ctx);
+  if (selectedIds === null) {
+    return 0;
+  }
+
+  const targets = await readTargetsSafely(readTargets({ cwd: ctx.cwd(), fs: ctx.fs }));
+  let target: Target | undefined;
+  if (opts.installTarget && opts.installTarget.length > 0) {
+    target = targets.find((t) => t.name === opts.installTarget);
+  } else if (targets.length === 1) {
+    target = targets[0];
+  } else if (targets.length > 1 && opts.interactive) {
+    const { chosenTarget } = await inquirer.prompt<{ chosenTarget: string }>([
+      { type: 'list', name: 'chosenTarget', message: 'Select target:', choices: targets.map((t) => ({ name: `${t.name} (${t.type})`, value: t.name })) }
+    ]);
+    target = targets.find((t) => t.name === chosenTarget);
+  } else if (targets.length > 1) {
+    ctx.stderr.write('Multiple targets configured. Use --install-target <name> to specify one.\n');
+    return 1;
+  }
+
+  if (target === undefined) {
+    ctx.stderr.write('No target found. Run `ai-primitives-hub target add` first.\n');
+    return 1;
+  }
+
+  ctx.stdout.write(`\nInstalling ${selectedIds.length} bundle(s) to target "${target.name}"\n`);
+  if (opts.interactive) {
+    const { proceed } = await inquirer.prompt<{ proceed: boolean }>([
+      { type: 'confirm', name: 'proceed', message: 'Proceed with installation?', default: true }
+    ]);
+    if (!proceed) {
+      ctx.stdout.write('Installation cancelled.\n');
+      return 0;
+    }
+  }
+
+  return installSelectedBundles(selectedIds, candidates, target, ctx, http, tokens, fmt);
+}
+
+const classifyError = (cause: unknown, indexPath: string): RegistryError => {
+  if (cause instanceof RegistryError) {
+    return cause;
+  }
+  const msg = cause instanceof Error ? cause.message : String(cause);
+  // Missing-file is the most common operator error and deserves a
+  // dedicated code so scripts can branch on it.
+  if (/ENOENT|no such file/i.test(msg)) {
+    return new RegistryError({
+      code: 'INDEX.NOT_FOUND',
+      message: `index not found: ${indexPath}`,
+      hint: 'Run `ai-primitives-hub index build` or `ai-primitives-hub index harvest` first.',
+      cause: cause instanceof Error ? cause : undefined
+    });
+  }
+  return new RegistryError({
+    code: 'INDEX.LOAD_FAILED',
+    message: `failed to load index ${indexPath}: ${msg}`,
+    cause: cause instanceof Error ? cause : undefined
+  });
+};
+
+const renderSearchText = (r: SearchResult): string => {
+  const lines: string[] = [`total: ${String(r.total)}  took: ${String(r.tookMs)}ms`];
+  for (const hit of r.hits) {
+    const p = hit.primitive;
+    lines.push(
+      `${hit.score.toFixed(3)}  [${p.kind}] ${p.title}`
+      + `  (${p.bundle.sourceId}/${p.bundle.bundleId})  ${p.id}`
+    );
+    if (p.description.length > 0) {
+      lines.push(`      ${p.description}`);
+    }
+  }
+  return lines.join('\n') + '\n';
+};
+
+/**
+ * Index search command class.
+ * Supports free-text query and facet filters.
+ */
+export class IndexSearchCommand extends Command {
+  public static readonly paths = [['index', 'search'], ['search']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Search a primitive index by free text + facets.',
+    category: 'Index & Search',
+    details: `
+      Usage: ai-primitives-hub index search [options] [query]
+
+      Options:
+        --query <text>           Search query text
+        --index <path>           Path to index file
+        --kinds <kinds>          Filter by primitive kind (comma-separated)
+        --sources <sources>       Filter by source IDs (comma-separated)
+        --bundles <bundles>      Filter by bundle IDs (comma-separated)
+        --tags <tags>            Filter by tags (comma-separated)
+        --installed-only          Show only installed primitives
+        --limit <n>              Limit number of results
+        --offset <n>             Skip first n results
+        --explain                 Show search scoring explanation
+        --install                Install matching primitives
+        --interactive            Interactive mode for installation
+        --install-target <name>  Target name for installation
+        -o, --output <format>    Output format (text, json, yaml, ndjson)
+
+      Examples:
+        ai-primitives-hub index search "docker"
+        ai-primitives-hub index search --query "docker" --kinds skill
+        ai-primitives-hub index search --sources github --limit 10
+    `
+  });
+
+  public query = Option.String('--query');
+  public index = Option.String('--index');
+  public output = Option.String('-o,--output');
+  public kinds = Option.Array('--kinds');
+  public sources = Option.Array('--sources');
+  public bundles = Option.Array('--bundles');
+  public tags = Option.Array('--tags');
+  public installedOnly = Option.Boolean('--installed-only');
+  public limit = Option.String('--limit');
+  public offset = Option.String('--offset');
+  public explain = Option.Boolean('--explain');
+  public install = Option.Boolean('--install', false);
+  public interactive = Option.Boolean('--interactive', false);
+  public installTarget = Option.String('--install-target');
+  public commandContext!: { ctx: Context };
+
+  public async execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+
+    const fmt = (this.output ?? 'text') as OutputFormat;
+    const indexPath = this.index ?? defaultIndexFile(ctx.env);
+
+    try {
+      const idx = loadIndex(indexPath);
+      const query: SearchQuery = {
+        q: this.query,
+        kinds: this.kinds as PrimitiveKind[],
+        sources: this.sources,
+        bundles: this.bundles,
+        tags: this.tags,
+        installedOnly: this.installedOnly,
+        limit: this.limit ? Number.parseInt(this.limit, 10) : undefined,
+        offset: this.offset ? Number.parseInt(this.offset, 10) : undefined,
+        explain: this.explain
+      };
+      const result = idx.search(query);
+      formatOutput({
+        ctx,
+        command: 'index.search',
+        output: fmt,
+        status: 'ok',
+        data: result,
+        textRenderer: (r) => renderSearchText(r)
+      });
+      if (this.install && result.hits.length > 0) {
+        return await searchAndInstall(
+          result,
+          { installTarget: this.installTarget, interactive: this.interactive },
+          ctx,
+          fmt
+        );
+      }
+      return 0;
+    } catch (cause) {
+      return failWith(ctx, fmt, 'index.search', classifyError(cause, indexPath));
+    }
+  }
+}

--- a/packages/cli/src/commands/index-shortlist.ts
+++ b/packages/cli/src/commands/index-shortlist.ts
@@ -1,0 +1,274 @@
+/**
+ * `index shortlist` — manage shortlists in a primitive index.
+ * Subcommands: `new | add | remove | list`.
+ *
+ * Each call loads the index, mutates it, and writes it back atomically
+ * (`saveIndex` creates parent dirs).
+ * @module commands/index-shortlist
+ */
+import type {
+  Shortlist,
+} from '@ai-primitives-hub/infra';
+import {
+  defaultIndexFile,
+  loadIndex,
+  saveIndex,
+} from '@ai-primitives-hub/infra';
+import {
+  Command,
+  type Context,
+  failWith,
+  formatOutput,
+  Option,
+  type OutputFormat,
+  RegistryError,
+} from '../framework';
+
+const classifyError = (cause: unknown, indexPath: string): RegistryError => {
+  if (cause instanceof RegistryError) {
+    return cause;
+  }
+  const msg = cause instanceof Error ? cause.message : String(cause);
+  if (/ENOENT|no such file/i.test(msg)) {
+    return new RegistryError({
+      code: 'INDEX.NOT_FOUND',
+      message: `index not found: ${indexPath}`,
+      hint: 'Run `ai-primitives-hub index build` or `ai-primitives-hub index harvest` first.',
+      cause: cause instanceof Error ? cause : undefined
+    });
+  }
+  return new RegistryError({
+    code: 'INDEX.LOAD_FAILED',
+    message: `index shortlist: ${msg}`,
+    cause: cause instanceof Error ? cause : undefined
+  });
+};
+
+const renderShortlistList = (shortlists: Shortlist[]): string =>
+  shortlists.length === 0
+    ? 'No shortlists.\n'
+    : shortlists.map((sl) =>
+      `${sl.id}\t${sl.name}\t${String(sl.primitiveIds.length)} items\n`
+    ).join('');
+
+/**
+ * Index shortlist new command class.
+ * Creates a new shortlist.
+ */
+export class IndexShortlistNewCommand extends Command {
+  public static readonly paths = [['index', 'shortlist', 'new']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Create a new shortlist.',
+    category: 'Index & Search',
+    details: `
+      Usage: ai-primitives-hub index shortlist new --name <NAME> [options]
+
+      Examples:
+        ai-primitives-hub index shortlist new --name "My Selection"
+        ai-primitives-hub index shortlist new --name "My Selection" --description "Custom selection"
+    `
+  });
+
+  public name = Option.String('--name');
+  public description = Option.String('--description');
+  public index = Option.String('--index');
+  public output = Option.String('-o,--output');
+  public commandContext!: { ctx: Context };
+
+  public execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+
+    const fmt = (this.output ?? 'text') as OutputFormat;
+    const indexPath = this.index ?? defaultIndexFile(ctx.env);
+
+    try {
+      const idx = loadIndex(indexPath);
+      if (!this.name || this.name.length === 0) {
+        return Promise.resolve(failWith(ctx, fmt, 'index.shortlist', new RegistryError({
+          code: 'USAGE.MISSING_FLAG',
+          message: 'index shortlist new: --name <NAME> is required'
+        })));
+      }
+      const sl = idx.createShortlist(this.name, this.description);
+      saveIndex(idx, indexPath);
+      formatOutput({
+        ctx, command: 'index.shortlist', output: fmt, status: 'ok',
+        data: { shortlist: sl },
+        textRenderer: (d) => `Created shortlist "${d.shortlist.id}" (${d.shortlist.name}).\n`
+      });
+      return Promise.resolve(0);
+    } catch (cause) {
+      return Promise.resolve(failWith(ctx, fmt, 'index.shortlist', classifyError(cause, indexPath)));
+    }
+  }
+}
+
+/**
+ * Index shortlist add command class.
+ * Adds a primitive to a shortlist.
+ */
+export class IndexShortlistAddCommand extends Command {
+  public static readonly paths = [['index', 'shortlist', 'add']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Add a primitive to a shortlist.',
+    category: 'Index & Search',
+    details: `
+      Usage: ai-primitives-hub index shortlist add --id <SHORTLIST_ID> --primitive <PRIMITIVE_ID> [options]
+
+      Examples:
+        ai-primitives-hub index shortlist add --id my-list --primitive primitive-id
+    `
+  });
+
+  public id = Option.String('--id');
+  public primitive = Option.String('--primitive');
+  public index = Option.String('--index');
+  public output = Option.String('-o,--output');
+  public commandContext!: { ctx: Context };
+
+  public execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+
+    const fmt = (this.output ?? 'text') as OutputFormat;
+    const indexPath = this.index ?? defaultIndexFile(ctx.env);
+
+    try {
+      const idx = loadIndex(indexPath);
+      const id = this.id ?? '';
+      const pid = this.primitive ?? '';
+      if (id.length === 0 || pid.length === 0) {
+        return Promise.resolve(failWith(ctx, fmt, 'index.shortlist', new RegistryError({
+          code: 'USAGE.MISSING_FLAG',
+          message: 'index shortlist add: --id <SHORTLIST_ID> and --primitive <PRIMITIVE_ID> are required'
+        })));
+      }
+      let sl: Shortlist;
+      try {
+        sl = idx.addToShortlist(id, pid);
+      } catch (cause) {
+        return Promise.resolve(failWith(ctx, fmt, 'index.shortlist', new RegistryError({
+          code: 'INDEX.SHORTLIST_NOT_FOUND',
+          message: `index shortlist add: ${(cause as Error).message}`,
+          cause: cause instanceof Error ? cause : undefined
+        })));
+      }
+      saveIndex(idx, indexPath);
+      formatOutput({
+        ctx, command: 'index.shortlist', output: fmt, status: 'ok',
+        data: { shortlist: sl },
+        textRenderer: (d) => `Added ${pid} to shortlist ${d.shortlist.id}.\n`
+      });
+      return Promise.resolve(0);
+    } catch (cause) {
+      return Promise.resolve(failWith(ctx, fmt, 'index.shortlist', classifyError(cause, indexPath)));
+    }
+  }
+}
+
+/**
+ * Index shortlist remove command class.
+ * Removes a primitive from a shortlist.
+ */
+export class IndexShortlistRemoveCommand extends Command {
+  public static readonly paths = [['index', 'shortlist', 'remove']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Remove a primitive from a shortlist.',
+    category: 'Index & Search',
+    details: `
+      Usage: ai-primitives-hub index shortlist remove --id <SHORTLIST_ID> --primitive <PRIMITIVE_ID> [options]
+
+      Examples:
+        ai-primitives-hub index shortlist remove --id my-list --primitive primitive-id
+    `
+  });
+
+  public id = Option.String('--id');
+  public primitive = Option.String('--primitive');
+  public index = Option.String('--index');
+  public output = Option.String('-o,--output');
+  public commandContext!: { ctx: Context };
+
+  public execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+
+    const fmt = (this.output ?? 'text') as OutputFormat;
+    const indexPath = this.index ?? defaultIndexFile(ctx.env);
+
+    try {
+      const idx = loadIndex(indexPath);
+      const id = this.id ?? '';
+      const pid = this.primitive ?? '';
+      if (id.length === 0 || pid.length === 0) {
+        return Promise.resolve(failWith(ctx, fmt, 'index.shortlist', new RegistryError({
+          code: 'USAGE.MISSING_FLAG',
+          message: 'index shortlist remove: --id and --primitive are required'
+        })));
+      }
+      let sl: Shortlist;
+      try {
+        sl = idx.removeFromShortlist(id, pid);
+      } catch (cause) {
+        return Promise.resolve(failWith(ctx, fmt, 'index.shortlist', new RegistryError({
+          code: 'INDEX.SHORTLIST_NOT_FOUND',
+          message: `index shortlist remove: ${(cause as Error).message}`,
+          cause: cause instanceof Error ? cause : undefined
+        })));
+      }
+      saveIndex(idx, indexPath);
+      formatOutput({
+        ctx, command: 'index.shortlist', output: fmt, status: 'ok',
+        data: { shortlist: sl },
+        textRenderer: (d) => `Removed ${pid} from shortlist ${d.shortlist.id}.\n`
+      });
+      return Promise.resolve(0);
+    } catch (cause) {
+      return Promise.resolve(failWith(ctx, fmt, 'index.shortlist', classifyError(cause, indexPath)));
+    }
+  }
+}
+
+/**
+ * Index shortlist list command class.
+ * Lists all shortlists.
+ */
+export class IndexShortlistListCommand extends Command {
+  public static readonly paths = [['index', 'shortlist', 'list']];
+
+  public static readonly usage = Command.Usage({
+    description: 'List all shortlists.',
+    category: 'Index & Search',
+    details: `
+      Usage: ai-primitives-hub index shortlist list [options]
+
+      Examples:
+        ai-primitives-hub index shortlist list
+    `
+  });
+
+  public index = Option.String('--index');
+  public output = Option.String('-o,--output');
+  public commandContext!: { ctx: Context };
+
+  public execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+
+    const fmt = (this.output ?? 'text') as OutputFormat;
+    const indexPath = this.index ?? defaultIndexFile(ctx.env);
+
+    try {
+      const idx = loadIndex(indexPath);
+      const shortlists = idx.listShortlists();
+      formatOutput({
+        ctx, command: 'index.shortlist', output: fmt, status: 'ok',
+        data: { shortlists },
+        textRenderer: (d) => renderShortlistList(d.shortlists)
+      });
+      return Promise.resolve(0);
+    } catch (cause) {
+      return Promise.resolve(failWith(ctx, fmt, 'index.shortlist', classifyError(cause, indexPath)));
+    }
+  }
+}

--- a/packages/cli/src/commands/index-stats.ts
+++ b/packages/cli/src/commands/index-stats.ts
@@ -1,0 +1,90 @@
+/**
+ * `index stats` — summary stats for a primitive index.
+ *
+ * Output goes through `formatOutput` so `-o json|yaml|ndjson` all
+ * produce the canonical envelope.
+ * @module commands/index-stats
+ */
+import type {
+  IndexStats,
+} from '@ai-primitives-hub/infra';
+import {
+  defaultIndexFile,
+  loadIndex,
+} from '@ai-primitives-hub/infra';
+import {
+  Command,
+  type Context,
+  failWith,
+  formatOutput,
+  Option,
+  type OutputFormat,
+  RegistryError,
+} from '../framework';
+
+/**
+ * Index stats command class.
+ */
+export class IndexStatsCommand extends Command {
+  public static readonly paths = [['index', 'stats']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Show summary statistics for a primitive index.',
+    category: 'Index & Search',
+    details: `
+      Usage: ai-primitives-hub index stats [options]
+
+      Options:
+        -o, --output <format>  Output format (text, json, yaml, ndjson)
+        --index <path>         Path to index JSON (default: XDG cache/primitive-index.json)
+    `
+  });
+
+  public output = Option.String('-o,--output');
+  public indexFile = Option.String('--index');
+  public commandContext!: { ctx: Context };
+
+  public execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+    const fmt = (this.output ?? 'text') as OutputFormat;
+    const indexPath = this.indexFile ?? defaultIndexFile(ctx.env);
+    try {
+      const idx = loadIndex(indexPath);
+      const stats = idx.stats();
+      formatOutput({
+        ctx,
+        command: 'index.stats',
+        output: fmt,
+        status: 'ok',
+        data: stats,
+        textRenderer: (s) => renderStatsText(s)
+      });
+      return Promise.resolve(0);
+    } catch (cause) {
+      const msg = cause instanceof Error ? cause.message : String(cause);
+      const err = /ENOENT|no such file/i.test(msg)
+        ? new RegistryError({
+          code: 'INDEX.NOT_FOUND',
+          message: `index not found: ${indexPath}`,
+          hint: 'Run `ai-primitives-hub index build` or `ai-primitives-hub index harvest` first.',
+          cause: cause instanceof Error ? cause : undefined
+        })
+        : new RegistryError({
+          code: 'INDEX.LOAD_FAILED',
+          message: `failed to load index ${indexPath}: ${msg}`,
+          cause: cause instanceof Error ? cause : undefined
+        });
+      return Promise.resolve(failWith(ctx, fmt, 'index.stats', err));
+    }
+  }
+}
+
+const renderStatsText = (s: IndexStats): string =>
+  [
+    `primitives: ${String(s.primitives)}`,
+    `bundles: ${String(s.bundles)}`,
+    `shortlists: ${String(s.shortlists)}`,
+    `byKind: ${JSON.stringify(s.byKind)}`,
+    `bySource: ${JSON.stringify(s.bySource)}`,
+    `builtAt: ${s.builtAt}`
+  ].join('\n') + '\n';

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,0 +1,617 @@
+/**
+ * `ai-primitives-hub init` — zero-friction project bootstrap.
+ *
+ * Creates a target and optionally imports a hub in a single step,
+ * replacing the multi-command manual sequence a new user previously needed.
+ *
+ * Interactive wizard mode: prompts for IDE, target, and hub connection.
+ * Non-interactive mode: accepts flags for all values so it works well in CI.
+ *
+ * Usage:
+ *   ai-primitives-hub init
+ *   ai-primitives-hub init --target-name copilot --target-type copilot-cli --hub owner/repo --yes
+ *
+ * Curates default hubs (e.g. Amadeus, Prompt Registry Community Hub) in the
+ * hub selector alongside "Local directory" and "Skip for now". Non-interactive
+ * mode (the `--yes` / CI path) is unaffected and fully at parity with the reference.
+ */
+import * as path from 'node:path';
+import {
+  emptyLockfile,
+  getLockfilePathForMode,
+  resolveUserConfigPaths,
+  writeLockfile,
+} from '@ai-primitives-hub/app';
+import type {
+  HttpClient,
+  TargetType,
+  TokenProvider,
+} from '@ai-primitives-hub/core';
+import {
+  TARGET_TYPES,
+} from '@ai-primitives-hub/core';
+import {
+  addTarget,
+  addTargetToPath,
+  findProjectConfigPath,
+  getEnabledDefaultHubs,
+  readTargets,
+  writeTargets,
+} from '@ai-primitives-hub/infra';
+import inquirer from 'inquirer';
+import {
+  Command,
+  type CommandDefinition,
+  type Context,
+  createHubManager,
+  defineCommand,
+  formatOutput,
+  Option,
+  type OutputFormat,
+  RegistryError,
+  renderError,
+} from '../framework';
+
+type TargetScope = 'user' | 'repository';
+type HubType = 'github' | 'local' | 'url';
+
+const DEFAULT_TARGET_NAME = 'copilot';
+const DEFAULT_TARGET_TYPE: TargetType = 'copilot-cli';
+
+/**
+ * Get human-readable display name for a target type.
+ * @param type Target type.
+ * @returns Display name.
+ */
+function getTargetTypeDisplayName(type: TargetType): string {
+  const displayNames: Record<TargetType, string> = {
+    vscode: 'Visual Studio Code',
+    'vscode-insiders': 'Visual Studio Code Insiders',
+    'copilot-cli': 'GitHub Copilot CLI',
+    kiro: 'Kiro IDE',
+    windsurf: 'Windsurf Editor',
+    'claude-code': 'Anthropic Claude Code'
+  };
+  return displayNames[type];
+}
+
+/**
+ * Build hub choices for the wizard.
+ * Amadeus is always placed first.
+ * @returns Array of hub choices.
+ */
+function buildHubChoices(): { name: string; value: string }[] {
+  const defaultHubs = getEnabledDefaultHubs();
+  const hubChoices: { name: string; value: string }[] = [];
+
+  // Separate Amadeus from other hubs.
+  const amadeusHub = defaultHubs.find((h) => h.name === 'Amadeus');
+  const otherHubs = defaultHubs.filter((h) => h.name !== 'Amadeus');
+
+  // Build choices with Amadeus first.
+  if (amadeusHub) {
+    hubChoices.push({
+      name: `${amadeusHub.icon} ${amadeusHub.name}${amadeusHub.recommended ? ' ⭐' : ''}`,
+      value: amadeusHub.name
+    });
+  }
+
+  for (const hub of otherHubs) {
+    hubChoices.push({
+      name: `${hub.icon} ${hub.name}${hub.recommended ? ' ⭐' : ''}`,
+      value: hub.name
+    });
+  }
+
+  return hubChoices;
+}
+
+/** Options for the init command (programmatic API + test seam). */
+export interface InitOptions {
+  /** Output format (default: text). */
+  output?: string;
+  /** Target name (default: 'copilot'). */
+  targetName?: string;
+  /** Target type (default: 'copilot-cli'). */
+  targetType?: string;
+  /** Target scope (default: 'user'). */
+  scope?: TargetScope;
+  /** Hub location ref (e.g. owner/repo or file:./hub-config.yml). */
+  hub?: string;
+  /** Hub type override (default: auto-detect from ref). */
+  hubType?: HubType;
+  /** Skip confirmation prompt. */
+  yes?: boolean;
+  /** Verbose output with file paths and verification commands. */
+  verbose?: boolean;
+  /** HTTP client seam for testing. */
+  http?: HttpClient;
+  /** Token provider seam for testing. */
+  tokens?: TokenProvider;
+}
+
+/**
+ * Build the `init` command (defineCommand variant for test compatibility).
+ * @param opts Command options.
+ * @returns CommandDefinition.
+ */
+export const createInitCommand = (
+  opts: InitOptions = {}
+): CommandDefinition =>
+  defineCommand({
+    path: ['init'],
+    description: 'Bootstrap a project: add a target and optionally import a hub.',
+    category: 'Getting Started',
+    run: async ({ ctx }: { ctx: Context }): Promise<number> => {
+      return runInit(ctx, opts);
+    }
+  });
+
+/**
+ * Init command class (clipanion variant).
+ */
+export class InitCommand extends Command {
+  public static readonly paths = [['init']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Bootstrap a project: add a target and optionally import a hub.',
+    category: 'Getting Started',
+    details: `
+      Usage: ai-primitives-hub init [options]
+
+      Creates a target in ai-primitives-hub.yml and optionally imports a hub,
+      replacing the manual multi-step setup sequence.
+
+      Examples:
+        ai-primitives-hub init
+        ai-primitives-hub init --target-name my-copilot --target-type copilot-cli --yes
+        ai-primitives-hub init --hub owner/repo --yes
+        ai-primitives-hub init --hub file:./hub-config.yml --hub-type local --yes
+    `
+  });
+
+  public targetName = Option.String('--target-name');
+  public targetType = Option.String('--target-type');
+  public scope = Option.String('--scope');
+  public hub = Option.String('--hub');
+  public hubType = Option.String('--hub-type');
+  public yes = Option.Boolean('-y,--yes', false);
+  public output = Option.String('-o,--output');
+  public verbose = Option.Boolean('-v,--verbose', false);
+  public commandContext!: { ctx: Context; http?: HttpClient; tokens?: TokenProvider };
+
+  public async execute(): Promise<number> {
+    const { ctx, http, tokens } = this.commandContext;
+    return runInit(ctx, {
+      output: (this.output ?? 'text'),
+      targetName: this.targetName,
+      targetType: this.targetType,
+      scope: this.scope as TargetScope | undefined,
+      hub: this.hub,
+      hubType: this.hubType as HubType | undefined,
+      yes: this.yes,
+      verbose: this.verbose,
+      http,
+      tokens
+    });
+  }
+}
+
+/**
+ * Run interactive wizard to collect init options.
+ * @param ctx CLI context.
+ * @param _opts Init options.
+ * @returns Wizard answers.
+ */
+async function runInteractiveWizard(ctx: Context, _opts: InitOptions): Promise<{
+  targetType: TargetType;
+  targetName: string;
+  targetScope: TargetScope;
+  hubRef?: string;
+  hubType?: HubType;
+  hubRefParam?: string;
+}> {
+  interface WizardAnswers {
+    ide: string;
+    scope?: TargetScope;
+    connectHub: boolean;
+    hubChoice?: string;
+    hubPath?: string;
+    useExistingTarget?: boolean;
+    newTargetName?: string;
+  }
+
+  const defaultHubs = getEnabledDefaultHubs();
+  const hubChoices = buildHubChoices();
+  const baseChoices = hubChoices.length > 0
+    ? hubChoices
+    : [{ name: 'Local directory', value: 'local' }];
+
+  const allHubChoices = [
+    ...baseChoices,
+    { name: 'Local directory', value: 'local' },
+    { name: 'Skip for now', value: 'skip' }
+  ];
+
+  const answers = await inquirer.prompt<WizardAnswers>([
+    {
+      type: 'list',
+      name: 'ide',
+      message: 'What IDE are you using?',
+      choices: TARGET_TYPES.map((type) => ({
+        name: getTargetTypeDisplayName(type),
+        value: type
+      })),
+      default: 'copilot-cli'
+    },
+    {
+      type: 'list',
+      name: 'scope',
+      message: 'Installation scope:',
+      choices: [
+        { name: 'User scope (installed in home directory)', value: 'user' },
+        { name: 'Project scope (installed in current project)', value: 'repository' }
+      ],
+      default: 'user'
+    },
+    {
+      type: 'confirm',
+      name: 'connectHub',
+      message: 'Connect to a hub? (recommended)',
+      default: true
+    },
+    {
+      type: 'list',
+      name: 'hubChoice',
+      message: 'Select hub:',
+      choices: allHubChoices,
+      default: baseChoices[0].value,
+      when: (a: { connectHub: boolean }) => a.connectHub
+    },
+    {
+      type: 'input',
+      name: 'hubPath',
+      message: 'Enter local hub path:',
+      default: './hub-config.yml',
+      when: (a: { hubChoice: string }) => a.hubChoice === 'local'
+    }
+  ]);
+
+  const targetType = answers.ide as TargetType;
+  let targetName = DEFAULT_TARGET_NAME;
+  const targetScope = answers.scope ?? 'user';
+
+  const currentTargets = await readTargets({ cwd: ctx.cwd(), fs: ctx.fs });
+  const targetExists = currentTargets.some((t) => t.name === targetName);
+
+  if (targetExists) {
+    const targetAnswers = await inquirer.prompt<WizardAnswers>([
+      {
+        type: 'confirm',
+        name: 'useExistingTarget',
+        message: `Target "${targetName}" already exists. Use it anyway?`,
+        default: true
+      },
+      {
+        type: 'input',
+        name: 'newTargetName',
+        message: 'Enter a different target name:',
+        default: 'copilot-2',
+        when: (a: { useExistingTarget: boolean }) => !a.useExistingTarget
+      }
+    ]);
+
+    if (!targetAnswers.useExistingTarget) {
+      targetName = targetAnswers.newTargetName || targetName;
+    }
+  }
+
+  let hubRef: string | undefined;
+  let hubType: HubType | undefined;
+  let hubRefParam: string | undefined;
+
+  if (answers.hubChoice === 'local' && answers.hubPath) {
+    hubRef = `file:${answers.hubPath}`;
+    hubType = 'local';
+  } else if (answers.hubChoice && answers.hubChoice !== 'skip') {
+    const hub = defaultHubs.find((h) => h.name === answers.hubChoice);
+    if (hub) {
+      hubRef = hub.reference.location;
+      hubType = hub.reference.type;
+      hubRefParam = hub.reference.ref;
+    }
+  }
+
+  return { targetType, targetName, targetScope, hubRef, hubType, hubRefParam };
+}
+
+/**
+ * Create or reuse target.
+ * @param ctx CLI context.
+ * @param targetName Target name.
+ * @param targetType Target type.
+ * @param targetScope Target scope.
+ * @param explicitPath Absolute path to the targets file; bypasses the upward walk when set.
+ * @returns Target file path and creation status.
+ */
+async function createOrReuseTarget(
+  ctx: Context,
+  targetName: string,
+  targetType: TargetType,
+  targetScope: 'user' | 'repository',
+  explicitPath?: string
+): Promise<{ file: string; created?: boolean; updated?: boolean }> {
+  const storeOpts = { cwd: ctx.cwd(), fs: ctx.fs };
+
+  if (explicitPath !== undefined) {
+    const result = await addTargetToPath(
+      explicitPath,
+      { name: targetName, type: targetType, scope: targetScope },
+      ctx.fs
+    );
+    return result;
+  }
+
+  const currentTargets = await readTargets(storeOpts);
+  const existing = currentTargets.find((t) => t.name === targetName);
+
+  if (existing !== undefined) {
+    if ((existing.type as string) !== (targetType as string) || existing.scope !== targetScope) {
+      const next = currentTargets.map((t) =>
+        t.name === targetName ? { ...t, type: targetType, scope: targetScope } : t
+      );
+      const writeResult = await writeTargets(storeOpts, next);
+      return { ...writeResult, updated: true };
+    }
+    const { file } = await findProjectConfigPath(storeOpts);
+    return { file, created: false };
+  }
+
+  return await addTarget(
+    storeOpts,
+    { name: targetName, type: targetType, scope: targetScope }
+  );
+}
+
+/**
+ * Import and sync hub.
+ * @param ctx CLI context.
+ * @param hubRef Hub reference location.
+ * @param hubType Hub reference type.
+ * @param hubRefParam Hub reference branch or tag.
+ * @param opts Init options.
+ * @returns Hub ID or null.
+ */
+async function importAndSyncHub(
+  ctx: Context,
+  hubRef: string,
+  hubType: HubType | undefined,
+  hubRefParam: string | undefined,
+  opts: InitOptions
+): Promise<string | null> {
+  const mgr = createHubManager({ ctx, http: opts.http, tokens: opts.tokens });
+  const refType = hubType ?? opts.hubType ?? inferHubType(hubRef);
+  const location = refType === 'local' && !path.isAbsolute(hubRef)
+    ? path.resolve(ctx.cwd(), hubRef)
+    : hubRef;
+
+  const hubId = await mgr.importHub({ type: refType, location, ref: hubRefParam });
+  await mgr.syncHub(hubId);
+  return hubId;
+}
+
+function describeTargetStep(name: string, type: string, file: string, created: boolean, updated: boolean): string {
+  if (created) {
+    return `target "${name}" (${type}) → ${file}`;
+  }
+  if (updated) {
+    return `target "${name}" updated to type "${type}"`;
+  }
+  return `target "${name}" already exists`;
+}
+
+/**
+ * Build text renderer output for init command.
+ * @param data Init result data.
+ * @param data.steps Initialization steps.
+ * @param data.target Target configuration.
+ * @param data.target.file
+ * @param data.target.name
+ * @param data.target.type
+ * @param data.hub Hub configuration.
+ * @param verbose Verbose flag.
+ * @returns Formatted text output.
+ */
+function buildInitOutput(data: { steps: string[]; target: { file: string; name: string; type: string }; hub: { id: string } | null }, verbose: boolean): string {
+  const lines = ['Initialized ai-primitives-hub project:\n'];
+  for (const step of data.steps) {
+    lines.push(`  ✓ ${step}\n`);
+  }
+
+  if (verbose) {
+    lines.push('\nConfiguration:\n', `  Config file: ${data.target.file}\n`, `  Target name: ${data.target.name}\n`, `  Target type: ${data.target.type}\n`);
+    if (data.hub !== null) {
+      lines.push(`  Hub ID: ${data.hub.id}\n`);
+    }
+    lines.push('\nVerification commands:\n', '  ai-primitives-hub status\n', '  ai-primitives-hub target list\n');
+    if (data.hub !== null) {
+      lines.push('  ai-primitives-hub hub list\n', '  ai-primitives-hub profile list\n');
+    }
+  }
+
+  if (data.hub === null) {
+    lines.push(
+      '\nNext steps:\n',
+      '  1. ai-primitives-hub hub add <owner/repo> --yes\n',
+      '  2. ai-primitives-hub profile activate <profileId>\n'
+    );
+  } else {
+    if (verbose) {
+      lines.push('\nAvailable profiles:\n', '  Run: ai-primitives-hub profile list\n');
+    }
+    lines.push('\nNext step:\n', '  ai-primitives-hub profile activate <profileId>\n');
+  }
+  return lines.join('');
+}
+
+function classifyInitError(cause: unknown): RegistryError {
+  if (cause instanceof RegistryError) {
+    return cause;
+  }
+  const msg = cause instanceof Error ? cause.message : String(cause);
+  const err = cause instanceof Error ? cause : undefined;
+  if (msg.includes('hub-config.yml not found at')) {
+    return new RegistryError({
+      code: 'HUB.ACCESS_DENIED',
+      message: `Cannot access hub: ${msg}`,
+      hint: 'Run `gh auth status` to check which account is active. Use `gh auth switch` to select an account with access, or choose a different hub.',
+      cause: err
+    });
+  }
+  const isAuthError = msg.includes('401')
+    || msg.includes('403')
+    || msg.toLowerCase().includes('unauthorized')
+    || msg.toLowerCase().includes('forbidden')
+    || msg.toLowerCase().includes('authentication failed');
+  if (isAuthError) {
+    return new RegistryError({
+      code: 'AUTH.ERROR',
+      message: `Failed to connect to hub: ${msg}`,
+      hint: 'Check your GitHub authentication with `gh auth status` or `gh auth login`',
+      cause: err
+    });
+  }
+  return new RegistryError({
+    code: 'INTERNAL.UNEXPECTED',
+    message: `Failed to initialize project: ${msg}`,
+    hint: 'Run `ai-primitives-hub doctor` for diagnostics',
+    cause: err
+  });
+}
+
+/**
+ * Core init logic shared by both command variants.
+ * @param ctx CLI context.
+ * @param opts Init options.
+ * @returns Exit code.
+ */
+async function runInit(ctx: Context, opts: InitOptions): Promise<number> {
+  const fmt = (opts.output ?? 'text') as OutputFormat;
+  const isInteractive = !opts.yes && process.stdout.isTTY;
+
+  const userPaths = resolveUserConfigPaths(ctx.env);
+  let targetName = opts.targetName ?? DEFAULT_TARGET_NAME;
+  let targetType = (opts.targetType ?? DEFAULT_TARGET_TYPE) as TargetType;
+  let targetScope = (opts.scope as TargetScope) ?? 'user';
+  let hubRef = opts.hub;
+  let hubType: HubType | undefined = opts.hubType;
+
+  let hubRefParam: string | undefined;
+  if (isInteractive) {
+    const wizardResult = await runInteractiveWizard(ctx, opts);
+    targetType = wizardResult.targetType;
+    targetName = wizardResult.targetName;
+    targetScope = wizardResult.targetScope;
+    hubRef = wizardResult.hubRef;
+    hubType = wizardResult.hubType;
+    hubRefParam = wizardResult.hubRefParam;
+  }
+
+  if (!TARGET_TYPES.includes(targetType)) {
+    return failWith(ctx, fmt, new RegistryError({
+      code: 'USAGE.MISSING_FLAG',
+      message: `init: unknown --target-type "${targetType}"`,
+      hint: `Known types: ${[...TARGET_TYPES].toSorted((a, b) => a.localeCompare(b)).join(', ')}`
+    }));
+  }
+
+  try {
+    const configPath = targetScope === 'user' ? userPaths.userTargets : undefined;
+    const result = await createOrReuseTarget(ctx, targetName, targetType, targetScope, configPath);
+    const updated = result.updated === true;
+    const steps: string[] = [
+      describeTargetStep(targetName, targetType, result.file, result.created ?? false, updated)
+    ];
+
+    // Lockfile is repository-scope only (see `stores/json-lockfile-store.ts`'s
+    // module doc) — the extension has never tracked user/workspace-scope
+    // installs via a lockfile, so nothing is pre-created for those scopes.
+    if (targetScope === 'repository') {
+      const lockfilePath = getLockfilePathForMode(ctx.cwd(), 'commit');
+      if (!(await ctx.fs.exists(lockfilePath))) {
+        await writeLockfile(lockfilePath, emptyLockfile('ai-primitives-hub-cli'), ctx.fs);
+        steps.push(`lockfile initialized: ${path.basename(lockfilePath)}`);
+      }
+    }
+
+    let hubId: string | null = null;
+    if (hubRef !== undefined && hubRef.length > 0) {
+      hubId = await importAndSyncHub(ctx, hubRef, hubType, hubRefParam, opts);
+      steps.push(`hub "${hubId}" imported and synced`);
+    }
+
+    const data = {
+      target: {
+        name: targetName,
+        type: targetType,
+        file: result.file,
+        created: result.created ?? false
+      },
+      hub: hubId === null ? null : { id: hubId },
+      steps
+    };
+
+    formatOutput({
+      ctx,
+      command: 'init',
+      output: fmt,
+      status: 'ok',
+      data,
+      textRenderer: (d) => buildInitOutput(d, opts.verbose ?? false)
+    });
+    return 0;
+  } catch (cause) {
+    return failWith(ctx, fmt, classifyInitError(cause));
+  }
+}
+
+/**
+ * Infer hub reference type from the location string.
+ * - Starts with `file:` or is an absolute path → local
+ * - Starts with `http` → url
+ * - Otherwise → github (owner/repo)
+ * @param location Hub reference string.
+ * @returns Inferred reference type.
+ */
+function inferHubType(location: string): HubType {
+  if (location.startsWith('file:') || path.isAbsolute(location)) {
+    return 'local';
+  }
+  if (location.startsWith('http://') || location.startsWith('https://')) {
+    return 'url';
+  }
+  return 'github';
+}
+
+/**
+ * Emit error in appropriate format.
+ * @param ctx CLI context.
+ * @param output Output format.
+ * @param err Registry error.
+ * @returns Exit code 1.
+ */
+function failWith(ctx: Context, output: OutputFormat, err: RegistryError): number {
+  if (output === 'json' || output === 'yaml' || output === 'ndjson') {
+    formatOutput({
+      ctx,
+      command: 'init',
+      output,
+      status: 'error',
+      data: null,
+      errors: [err.toJSON()]
+    });
+  } else {
+    renderError(err, ctx);
+  }
+  return 1;
+}

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -1,0 +1,1379 @@
+/**
+ * `install` — install a bundle into a configured target.
+ *
+ * Final shape:
+ *   ai-primitives-hub install <bundle>            (imperative)
+ *   ai-primitives-hub install --lockfile <path>   (declarative from a lockfile)
+ *
+ * Lockfile integration uses `app`'s dict-based `Lockfile` (extension-compatible
+ * schema, `bundles: Record<bundleId, LockfileBundleEntry>`) rather than the
+ * reference branch's array-of-entries schema. There is no per-entry `target`
+ * field — repository scope always writes to `.github/` regardless of target,
+ * and user-scope installs get their own lockfile file
+ * (`resolveUserConfigPaths(env).userLockfile`) rather than the project-root one.
+ * `SourceDispatcher`/`GitHubBundleResolver` take a shared `GitHubApi` client
+ * (built from `http`+`tokens` via `GitHubApiClient`) instead of separate
+ * `http`/`tokens` fields.
+ */
+import * as path from 'node:path';
+import {
+  checksumFiles,
+  emptyLockfile,
+  FileTreeTargetWriter,
+  type Lockfile,
+  type LockfileBundleEntry,
+  type LockfileSourceEntry,
+  readLockfile,
+  resolveUserConfigPaths,
+  type TargetWriter,
+  TransformerRegistry,
+  upsertBundleEntry,
+  upsertSource,
+  writeLockfile,
+} from '@ai-primitives-hub/app';
+import type {
+  BundleResolver,
+  HttpClient,
+  RegistrySource,
+  Target,
+  TokenProvider,
+} from '@ai-primitives-hub/core';
+import {
+  parseBundleSpec,
+  validateManifest,
+} from '@ai-primitives-hub/core';
+import {
+  ActiveHubStore,
+  AwesomeCopilotBundleResolver,
+  defaultTokenProvider,
+  FileSystemLayoutConfigLoader,
+  GitHubApiClient,
+  GitHubBundleResolver,
+  HttpsBundleDownloader,
+  HubStore,
+  NodeHttpClient,
+  readLocalBundle,
+  readTargets,
+  type RepositoryCommitMode,
+  RepositoryScopeWriter,
+  RepositoryScopeWriterAdapter,
+  resolveUserConfigDir,
+  SourceDispatcher,
+  TargetStateStore,
+  ZipBundleExtractor,
+} from '@ai-primitives-hub/infra';
+import inquirer from 'inquirer';
+import {
+  Command,
+  createHubManager,
+  failWith,
+  findProjectLockfile,
+  loadTargets,
+  lockfilePathForTarget,
+  Option,
+  requireActiveHubOrFail,
+} from '../framework';
+import {
+  type CommandDefinition,
+  type Context,
+  defineCommand,
+  formatOutput,
+  type OutputFormat,
+  readTargetsSafely,
+  RegistryError,
+  resolveTarget,
+  resolveTargetName,
+  validateInputs,
+} from '../framework';
+
+/**
+ * Extract repo slug from a GitHub URL.
+ * @param url GitHub URL (e.g., "https://github.com/owner/repo" or "owner/repo").
+ * @returns Repo slug (e.g., "owner/repo").
+ */
+function extractRepoSlug(url: string): string {
+  if (url.startsWith('https://github.com/')) {
+    return url.replace('https://github.com/', '');
+  }
+  return url;
+}
+
+/**
+ * Build a `GitHubApi` client shared by every GitHub-backed resolver in
+ * a single command invocation.
+ * @param http HTTP client.
+ * @param tokens Token provider.
+ * @returns GitHubApiClient instance.
+ */
+export function githubApiFor(http: HttpClient, tokens: TokenProvider): GitHubApiClient {
+  return new GitHubApiClient(http, { tokenProvider: tokens });
+}
+
+/**
+ * Install command options.
+ */
+export interface InstallOptions {
+  output?: OutputFormat;
+  /** Bundle id to install (imperative mode). */
+  bundle?: string;
+  /** Lockfile path (declarative mode). */
+  lockfile?: string;
+  /** Target name (resolved against `targets[]` in config). */
+  target?: string;
+  /**
+   * Path to an already-built bundle directory. When set, the install
+   * command bypasses resolve/download/extract and reads files from
+   * the directory directly. Useful for dev workflows where the
+   * user just ran `ai-primitives-hub bundle build`.
+   */
+  from?: string;
+  /** Dry-run: validate + plan the install but write nothing. */
+  dryRun?: boolean;
+  /**
+   * Comma-separated allowlist of target names this run is permitted
+   * to write to. Defense-in-depth for CI; refuses any --target outside
+   * the set even if the target is configured.
+   */
+  allowTarget?: string;
+  /**
+   * Optional source slug for the remote install path. When `<bundle>` is given without
+   * `--from`, this resolves the bundle via `GitHubBundleResolver`.
+   * Format: `owner/repo`. If omitted, the bundleSpec must carry
+   * a sourceId of the same form (e.g. `install owner/repo:foo`).
+   */
+  source?: string;
+  /**
+   * Interactive mode: prompts user to select bundles from a list.
+   */
+  interactive?: boolean;
+  /**
+   * Dependency-injection seam for tests. Production callers leave this
+   * undefined; the install command then constructs a `NodeHttpClient`. Tests pass a
+   * recording HTTP client to avoid real sockets.
+   */
+  http?: HttpClient;
+  /**
+   * Dependency-injection seam for tests. Production callers leave this
+   * undefined; the install command then constructs `defaultTokenProvider(ctx.env)`.
+   */
+  tokens?: TokenProvider;
+  /**
+   * Installation scope (user or repository).
+   * Overrides target's scope if specified.
+   */
+  scope?: 'user' | 'repository';
+  /**
+   * Commit mode for repository scope.
+   * Only applies when scope=repository.
+   */
+  commitMode?: RepositoryCommitMode;
+  /**
+   * Source configuration for resolver selection.
+   * If provided, SourceDispatcher will select the appropriate resolver.
+   */
+  sourceConfig?: RegistrySource;
+  /**
+   * Verbose mode: show detailed progress and error messages.
+   */
+  verbose?: boolean;
+}
+
+/**
+ * Command context for install/uninstall commands.
+ */
+interface CommandContext {
+  ctx: Context;
+  http?: HttpClient;
+  tokens?: TokenProvider;
+}
+
+/**
+ * Base class for install/uninstall commands.
+ */
+abstract class BaseInstallCommand extends Command {
+  public commandContext: CommandContext = { ctx: null as unknown as Context };
+  public output?: OutputFormat;
+}
+
+/**
+ * Native clipanion class command for install.
+ */
+export class InstallCommand extends BaseInstallCommand {
+  public static readonly paths = [['install']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Install bundles to a configured target.',
+    category: 'Install & Manage',
+    details: `
+      Usage: ai-primitives-hub install [options]
+
+      Options:
+        --from <path>           Path to an already-built bundle directory
+        --lockfile <path>       Path to a lockfile for declarative installation
+        --target <name>         Target name to install to
+        --source <hub-id>       Hub ID to list bundles from (use with --interactive for selection)
+        --interactive           Interactive mode: select bundles from a list
+        --dry-run               Validate and plan without writing
+        --scope <scope>         Installation scope (user or repository)
+        --commit-mode <mode>    Commit mode for repository scope
+        --verbose               Show detailed progress and error messages
+        -o, --output <format>  Output format (text, json, yaml, ndjson)
+
+      Examples:
+        ai-primitives-hub install --from <path> --target my-vscode
+        ai-primitives-hub install --lockfile prompt-registry.lock.json --target my-vscode
+        ai-primitives-hub install --source amadeus-hub --interactive --target my-vscode
+    `
+  });
+
+  public output = Option.String('-o', '--output') as OutputFormat | undefined;
+  public from = Option.String('--from');
+  public lockfile = Option.String('--lockfile');
+  public target = Option.String('--target');
+  public source = Option.String('--source');
+  public interactive = Option.Boolean('--interactive', false);
+  public dryRun = Option.Boolean('--dry-run');
+  public scope = Option.String('--scope');
+  public commitMode = Option.String('--commit-mode');
+  public verbose = Option.Boolean('--verbose', false);
+  public allowTarget = Option.String('--allow-target');
+  public bundle = Option.String({ required: false }); // Optional positional argument
+
+  public async execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+    const http = this.commandContext.http ?? new NodeHttpClient();
+    const tokens = this.commandContext.tokens ?? defaultTokenProvider(ctx.env);
+    const fmt = (this.output ?? 'text');
+
+    const opts: InstallOptions = {
+      output: fmt,
+      bundle: this.bundle,
+      lockfile: this.lockfile,
+      target: this.target,
+      from: this.from,
+      dryRun: this.dryRun,
+      source: this.source,
+      interactive: this.interactive,
+      allowTarget: this.allowTarget,
+      http,
+      tokens,
+      scope: this.scope as 'user' | 'repository' | undefined,
+      commitMode: this.commitMode as RepositoryCommitMode | undefined,
+      verbose: this.verbose
+    };
+
+    await detectInstallContext(opts, ctx);
+
+    const { bundle: noBundle, lockfile: noLockfile } = validateInputs(opts, { flags: ['bundle', 'lockfile'] });
+    if (noBundle && noLockfile && !opts.from && !opts.source) {
+      return failWith(ctx, fmt, 'install', new RegistryError({
+        code: 'USAGE.MISSING_FLAG',
+        message: 'install: provide either <bundle-id> (imperative), --lockfile <path> (declarative), --from <path> (local directory), or --source <hub-id> (list bundles)',
+        hint: 'Examples:\n'
+          + '  ai-primitives-hub install --from <path> --target my-vscode\n'
+          + '  ai-primitives-hub install --lockfile prompt-registry.lock.json\n'
+          + '  ai-primitives-hub install --source amadeus-hub --target my-vscode'
+      }));
+    }
+
+    try {
+      const targetName = await resolveTargetName(opts.target, 'install', ctx, () => readTargets({ cwd: ctx.cwd(), fs: ctx.fs }));
+      checkAllowTarget(targetName, opts);
+      const target = await resolveTarget(targetName, 'install', ctx, () => readTargets({ cwd: ctx.cwd(), fs: ctx.fs }));
+
+      const mode = determineInstallMode(opts);
+      if (mode === undefined) {
+        return await performRemoteInstall(opts, target, ctx, fmt);
+      }
+
+      return await executeInstallMode(mode, opts, target, ctx, fmt);
+    } catch (err) {
+      if (err instanceof RegistryError) {
+        return failWith(ctx, fmt, 'install', err);
+      }
+      throw err;
+    }
+  }
+}
+
+/**
+ * Determine the installation mode based on options.
+ * @param opts Install options.
+ * @returns Installation mode.
+ */
+function determineInstallMode(opts: InstallOptions): 'local' | 'lockfile' | 'remote' | 'interactive' | 'list' | undefined {
+  const { bundle: noBundle } = validateInputs(opts, { flags: ['bundle', 'lockfile'] });
+
+  if (opts.source !== undefined && opts.source.length > 0 && noBundle) {
+    return opts.interactive ? 'interactive' : 'list';
+  }
+  if (opts.from !== undefined && opts.from.length > 0) {
+    return 'local';
+  }
+  if (opts.lockfile !== undefined && opts.lockfile.length > 0) {
+    return 'lockfile';
+  }
+  return 'remote';
+}
+
+async function autoDetectHubSource(opts: InstallOptions, ctx: Context, userPaths: ReturnType<typeof resolveUserConfigPaths>): Promise<void> {
+  if (!(await ctx.fs.exists(userPaths.root))) {
+    return;
+  }
+  const activeStore = new ActiveHubStore(userPaths.activeHub, ctx.fs);
+  const hubId = await activeStore.get();
+  if (hubId === null) {
+    return;
+  }
+  const store = new HubStore(userPaths.hubs, ctx.fs);
+  if (await store.has(hubId)) {
+    opts.source = hubId;
+    opts.interactive = true;
+  }
+}
+
+/**
+ * Detect install context from the project environment.
+ * Fills in `opts.lockfile`, `opts.source`, `opts.interactive`, and `opts.target`
+ * when they can be inferred without user input.
+ * @param opts Install options (mutated in-place).
+ * @param ctx CLI context.
+ */
+async function detectInstallContext(opts: InstallOptions, ctx: Context): Promise<void> {
+  const { bundle: noBundle, lockfile: noLockfile } = validateInputs(opts, { flags: ['bundle', 'lockfile'] });
+  const noExplicitSource = !opts.source || opts.source.length === 0;
+  const noMode = noBundle && noLockfile && !opts.from && noExplicitSource;
+
+  const userPaths = resolveUserConfigPaths(ctx.env);
+
+  if (noMode && !opts.interactive) {
+    const found = await findProjectLockfile(ctx);
+    if (found !== null) {
+      opts.lockfile = found;
+    }
+  }
+
+  if (noMode && (!opts.lockfile || opts.lockfile.length === 0)) {
+    try {
+      await autoDetectHubSource(opts, ctx, userPaths);
+    } catch {
+      // Ignore errors; proceed without auto-detected hub
+    }
+  }
+
+  if (!opts.target || opts.target.length === 0) {
+    const targets = await readTargetsSafely(
+      loadTargets(ctx)
+    );
+    if (targets.length === 1) {
+      opts.target = targets[0].name;
+    }
+  }
+}
+
+/**
+ * Execute installation based on determined mode.
+ * @param mode Installation mode.
+ * @param opts Install options.
+ * @param target Target configuration.
+ * @param ctx CLI context.
+ * @param fmt Output format.
+ * @returns Exit code.
+ */
+async function executeInstallMode(
+  mode: string,
+  opts: InstallOptions,
+  target: Target,
+  ctx: Context,
+  fmt: OutputFormat
+): Promise<number> {
+  switch (mode) {
+    case 'interactive': {
+      return await interactiveBundleSelection(opts, target, ctx, fmt);
+    }
+    case 'list': {
+      return await listSourceBundles(opts, ctx, fmt);
+    }
+    case 'local': {
+      return await performLocalInstall(opts, target, ctx, fmt);
+    }
+    case 'lockfile': {
+      return await performLockfileInstall(opts, target, ctx, fmt);
+    }
+    default: {
+      return await performRemoteInstall(opts, target, ctx, fmt);
+    }
+  }
+}
+
+/**
+ * Create a writer factory that routes to the appropriate
+ * writer based on target scope.
+ * - user scope → FileTreeTargetWriter
+ * - repository scope → RepositoryScopeWriter
+ * @param ctx CLI context.
+ * @param opts Install options.
+ * @returns Writer factory function.
+ */
+export const createWriterFactory = (
+  ctx: Context,
+  opts: InstallOptions
+): (target: Target) => TargetWriter => {
+  // Create transformer registry and hierarchical layout loader once per command.
+  const transformerRegistry = TransformerRegistry.withBuiltIns();
+  const layoutLoader = new FileSystemLayoutConfigLoader({
+    cwd: ctx.cwd(),
+    fs: ctx.fs,
+    userConfigDir: resolveUserConfigDir(ctx.env)
+  });
+
+  return (target: Target): TargetWriter => {
+    // Use CLI flags to override target scope if specified
+    const scope = opts.scope ?? target.scope;
+    const commitMode = opts.commitMode ?? target.commitMode ?? 'commit';
+    const workspaceRoot = target.rootPath ?? ctx.cwd();
+
+    if (scope === 'repository') {
+      const writer = new RepositoryScopeWriter({
+        fs: ctx.fs,
+        workspaceRoot,
+        commitMode
+      });
+      return new RepositoryScopeWriterAdapter(writer);
+    }
+    // Default to FileTreeTargetWriter for user scope
+    const transformer = transformerRegistry.getTransformer(target.type);
+    return new FileTreeTargetWriter({
+      fs: ctx.fs,
+      env: ctx.env,
+      transformer,
+      layoutLoader
+    });
+  };
+};
+
+/**
+ * List bundles from a hub source.
+ * @param opts Install options.
+ * @param ctx CLI context.
+ * @param fmt Output format.
+ * @returns Exit code.
+ */
+async function listSourceBundles(
+  opts: InstallOptions,
+  ctx: Context,
+  fmt: OutputFormat
+): Promise<number> {
+  const hubId = opts.source as string;
+
+  try {
+    const mgr = createHubManager({ ctx });
+
+    await mgr.syncHub(hubId);
+    const active = await requireActiveHubOrFail(mgr, hubId, 'install', ctx, fmt);
+    if (typeof active === 'number') {
+      return active;
+    }
+
+    const bundles = active.config.profiles.flatMap((p: { bundles: { id: string; version: string; source: string }[] }) => p.bundles);
+    formatOutput({
+      ctx,
+      command: 'install',
+      output: fmt,
+      status: 'ok',
+      data: {
+        hubId,
+        bundles: bundles.map((b: { id: string; version: string; source: string }) => ({ id: b.id, version: b.version, source: b.source }))
+      },
+      textRenderer: (d) => `Available bundles in hub "${d.hubId}":\n`
+        + d.bundles.map((b: { id: string; version: string; source: string }) => `  ${b.id}@${b.version} (source: ${b.source})`).join('\n')
+        + '\n\nInstall with: ai-primitives-hub install <bundle-id> --source <hub-id> --target <target>\n'
+    });
+    return 0;
+  } catch (err) {
+    if (err instanceof RegistryError) {
+      return failWith(ctx, fmt, 'install', err);
+    }
+    return failWith(ctx, fmt, 'install', new RegistryError({
+      code: 'HUB.LOAD_FAILED',
+      message: `Failed to load hub "${hubId}": ${err instanceof Error ? err.message : String(err)}`,
+      cause: err instanceof Error ? err : undefined
+    }));
+  }
+}
+
+function buildInstallError(err: unknown): RegistryError {
+  return new RegistryError({
+    code: 'INSTALL.ERROR',
+    message: err instanceof Error ? err.message : String(err),
+    hint: 'Check the hub configuration and try again.'
+  });
+}
+
+/**
+ * Interactive bundle selection and installation.
+ * @param opts Install options.
+ * @param target Target configuration.
+ * @param ctx CLI context.
+ * @param fmt Output format.
+ * @returns Exit code.
+ */
+async function interactiveBundleSelection(
+  opts: InstallOptions,
+  target: Target,
+  ctx: Context,
+  fmt: OutputFormat
+): Promise<number> {
+  const hubId = opts.source as string;
+
+  try {
+    const mgr = createHubManager({ ctx });
+    await mgr.syncHub(hubId);
+    const active = await requireActiveHubOrFail(mgr, hubId, 'install', ctx, fmt);
+    if (typeof active === 'number') {
+      return active;
+    }
+
+    const sourceMap = buildSourceMap(active.config.sources);
+    const bundles = deduplicateBundles(active.config.profiles);
+    const bundleChoices = buildBundleChoices(bundles);
+    const selectedBundles = await promptBundleSelection(bundleChoices, bundles);
+
+    if (selectedBundles.length === 0) {
+      return 0;
+    }
+
+    await previewInstallation(selectedBundles, target.name, ctx);
+    const confirmed = await confirmInstallation(ctx);
+    if (!confirmed) {
+      return 0;
+    }
+
+    const installedCount = await installSelectedBundles(selectedBundles, sourceMap, opts, target, ctx, fmt);
+
+    formatOutput({
+      ctx,
+      command: 'install',
+      output: fmt,
+      status: 'ok',
+      data: { installed: installedCount, total: selectedBundles.length },
+      textRenderer: (d) => `Installed ${d.installed}/${d.total} bundles\n`
+    });
+    return 0;
+  } catch (err) {
+    return failWith(ctx, fmt, 'install', buildInstallError(err));
+  }
+}
+
+function buildSourceMap(sources: RegistrySource[]): Map<string, RegistrySource> {
+  const sourceMap = new Map<string, RegistrySource>();
+  for (const source of sources) {
+    sourceMap.set(source.id, source);
+    sourceMap.set(source.name, source);
+  }
+  return sourceMap;
+}
+
+function deduplicateBundles(profiles: { bundles: { id: string; version: string; source: string }[] }[]): { id: string; version: string; source: string }[] {
+  const allBundles = profiles.flatMap((p) => p.bundles);
+  const seenBundleKeys = new Set<string>();
+  return allBundles.filter((b) => {
+    const key = `${b.id}::${b.source}`;
+    if (seenBundleKeys.has(key)) {
+      return false;
+    }
+    seenBundleKeys.add(key);
+    return true;
+  });
+}
+
+function buildBundleChoices(bundles: { id: string; version: string; source: string }[]): { name: string; value: string; short: string }[] {
+  return bundles.map((b) => ({
+    name: `${b.id}@${b.version} (source: ${b.source})`,
+    value: b.id,
+    short: b.id
+  }));
+}
+
+async function promptBundleSelection(
+  bundleChoices: { name: string; value: string; short: string }[],
+  bundles: { id: string }[]
+): Promise<{ id: string; version: string; source: string }[]> {
+  const answers = await inquirer.prompt([
+    {
+      type: 'checkbox',
+      name: 'selectedBundles',
+      message: 'Select bundles to install:',
+      choices: bundleChoices,
+      validate: (input: string[]) => input.length > 0 || 'Please select at least one bundle'
+    }
+  ]);
+
+  const selectedBundleIds = answers.selectedBundles as string[];
+  return bundles.filter((b) => selectedBundleIds.includes(b.id)) as { id: string; version: string; source: string }[];
+}
+
+async function previewInstallation(bundles: { id: string; version: string; source: string }[], targetName: string, ctx: Context): Promise<void> {
+  ctx.stdout.write(`\nPreview: Installing ${bundles.length} bundle${bundles.length === 1 ? '' : 's'} to target "${targetName}"\n`);
+  for (const b of bundles) {
+    ctx.stdout.write(`  - ${b.id}@${b.version} (source: ${b.source})\n`);
+  }
+}
+
+async function confirmInstallation(ctx: Context): Promise<boolean> {
+  const confirm = await inquirer.prompt([
+    {
+      type: 'confirm',
+      name: 'proceed',
+      message: 'Proceed with installation?',
+      default: true
+    }
+  ]);
+
+  if (!confirm.proceed) {
+    ctx.stdout.write('Installation cancelled.\n');
+    return false;
+  }
+  return true;
+}
+
+async function installSelectedBundles(
+  bundles: { id: string; version: string; source: string }[],
+  sourceMap: Map<string, RegistrySource>,
+  opts: InstallOptions,
+  target: Target,
+  ctx: Context,
+  fmt: OutputFormat
+): Promise<number> {
+  let installedCount = 0;
+  for (const bundle of bundles) {
+    const source = sourceMap.get(bundle.source);
+    if (!source) {
+      ctx.stderr.write(`Failed to install ${bundle.id}@${bundle.version}: source "${bundle.source}" not found in hub\n`);
+      continue;
+    }
+    const bundleOpts = { ...opts, bundle: bundle.id, source: source.url, sourceConfig: source };
+    try {
+      const result = await performRemoteInstall(bundleOpts, target, ctx, fmt);
+      if (result === 0) {
+        installedCount++;
+      }
+    } catch (err) {
+      ctx.stderr.write(`Failed to install ${bundle.id}@${bundle.version}: ${err instanceof Error ? err.message : String(err)}\n`);
+    }
+  }
+  return installedCount;
+}
+
+/**
+ * Check if target is in allowlist.
+ * @param targetName Target name.
+ * @param opts Install options.
+ */
+function checkAllowTarget(targetName: string, opts: InstallOptions): void {
+  if (opts.allowTarget === undefined || opts.allowTarget.length === 0) {
+    return;
+  }
+  const allowSet = new Set(
+    opts.allowTarget.split(',').map((s) => s.trim()).filter((s) => s.length > 0)
+  );
+  if (!allowSet.has(targetName)) {
+    throw new RegistryError({
+      code: 'USAGE.MISSING_FLAG',
+      message: `install: target "${targetName}" is not in --allow-target=${opts.allowTarget}`,
+      hint: 'Add it to --allow-target or unset the flag to allow any configured target.',
+      context: { target: targetName, allowTarget: opts.allowTarget }
+    });
+  }
+}
+
+/**
+ * Perform local install from directory.
+ * @param opts Install options.
+ * @param target Target configuration.
+ * @param ctx CLI context.
+ * @param fmt Output format.
+ * @returns Exit code.
+ */
+async function performLocalInstall(
+  opts: InstallOptions,
+  target: Target,
+  ctx: Context,
+  fmt: OutputFormat
+): Promise<number> {
+  try {
+    const files = await readLocalBundle(opts.from as string, ctx.fs);
+    const manifest = validateManifest(files, {
+      expectedId: opts.bundle ?? '',
+      expectedVersion: undefined
+    });
+    if (opts.dryRun === true) {
+      formatOutput({
+        ctx,
+        command: 'install',
+        output: fmt,
+        status: 'ok',
+        data: {
+          dryRun: true,
+          target: target.name,
+          bundle: { id: manifest.id, version: manifest.version },
+          files: [...files.keys()]
+        },
+        textRenderer: (d) => `Dry run: would install ${d.bundle.id}@${d.bundle.version} `
+          + `(${d.files.length} file${d.files.length === 1 ? '' : 's'}) into target "${d.target}".\n`
+      });
+      return 0;
+    }
+    const writerFactory = createWriterFactory(ctx, opts);
+    const writer = writerFactory(target);
+    const result = await writer.write(target, files);
+
+    const scope = opts.scope ?? target.scope;
+    const commitMode = opts.commitMode ?? target.commitMode ?? 'commit';
+    const lockPath = lockfilePathForTarget(ctx, target, commitMode);
+    const existing = await readLockfile(lockPath, ctx.fs) ?? emptyLockfile('ai-primitives-hub-cli');
+    const localSourceId = `local-${path.basename(opts.from as string)}`;
+    const entry: LockfileBundleEntry = {
+      version: manifest.version,
+      sourceId: localSourceId,
+      sourceType: 'local',
+      installedAt: new Date().toISOString(),
+      files: checksumFiles(files)
+    };
+    if (scope === 'repository') {
+      entry.commitMode = commitMode;
+    }
+    let nextLock = upsertBundleEntry(existing, manifest.id, entry);
+    nextLock = upsertSource(nextLock, localSourceId, {
+      type: 'local',
+      url: path.resolve(ctx.cwd(), opts.from as string)
+    });
+    await writeLockfile(lockPath, nextLock, ctx.fs);
+
+    await updateTargetState(ctx, target.name, manifest.id, manifest.version);
+
+    formatOutput({
+      ctx,
+      command: 'install',
+      output: fmt,
+      status: 'ok',
+      data: {
+        target: target.name,
+        bundle: { id: manifest.id, version: manifest.version },
+        written: result.written,
+        skipped: result.skipped,
+        lockfile: lockPath
+      },
+      textRenderer: (d) => `Installed ${d.bundle.id}@${d.bundle.version} into target "${d.target}" `
+        + `(${d.written.length} written, ${d.skipped.length} skipped). `
+        + `Updated ${d.lockfile}.\n`
+    });
+    return 0;
+  } catch (cause) {
+    const raw = (cause as { code?: string }).code;
+    const code = raw !== undefined && /^(BUNDLE|FS|NETWORK|USAGE|CONFIG)\.[A-Z0-9_]+$/.test(raw)
+      ? raw
+      : 'INTERNAL.UNEXPECTED';
+    throw new RegistryError({
+      code,
+      message: `install: ${(cause as Error).message}`,
+      hint: 'Run `ai-primitives-hub doctor` for environment diagnostics.',
+      context: { from: opts.from },
+      cause: cause instanceof Error ? cause : undefined
+    });
+  }
+}
+
+/**
+ * Perform lockfile-based install.
+ * @param opts Install options.
+ * @param target Target configuration.
+ * @param ctx CLI context.
+ * @param fmt Output format.
+ * @returns Exit code.
+ */
+async function performLockfileInstall(
+  opts: InstallOptions,
+  target: Target,
+  ctx: Context,
+  fmt: OutputFormat
+): Promise<number> {
+  const lockfile = opts.lockfile as string;
+  const lockPath = path.isAbsolute(lockfile)
+    ? lockfile
+    : path.join(ctx.cwd(), lockfile);
+  const lock = await readLockfile(lockPath, ctx.fs) ?? emptyLockfile('ai-primitives-hub-cli');
+  const bundleIds = Object.keys(lock.bundles);
+  const http = opts.http ?? new NodeHttpClient();
+  const tokens = opts.tokens ?? defaultTokenProvider(ctx.env);
+  const writerFactory = createWriterFactory(ctx, opts);
+  const writer = writerFactory(target);
+
+  const { replayed, failures } = await replayLockfileEntries({
+    bundleIds,
+    lock,
+    http,
+    tokens,
+    writer,
+    target,
+    ctx,
+    verbose: opts.verbose ?? false
+  });
+
+  if (replayed.length > 0) {
+    await updateTargetStateFromLockfile(ctx, target.name, lock, replayed);
+  }
+
+  const status = failures.length === 0 ? 'ok' : 'warning';
+  formatOutput({
+    ctx,
+    command: 'install',
+    output: fmt,
+    status,
+    data: {
+      lockfile: lockPath,
+      target: target.name,
+      replayPlanned: bundleIds.length,
+      replayed,
+      failures
+    },
+    warnings: failures.length > 0
+      ? failures.map((f) => `${f.bundleId}: ${f.reason}`)
+      : undefined,
+    textRenderer: (d) => {
+      let suffix: string;
+      if (d.failures.length === 0) {
+        suffix = '.\n';
+      } else {
+        const plural = d.failures.length === 1 ? '' : 's';
+        suffix = `; ${d.failures.length} failure${plural}:\n`
+          + d.failures.map((f) => `  - ${f.bundleId}: ${f.reason}\n`).join('');
+      }
+      return `Replay: ${d.replayed.length}/${d.replayPlanned} bundles installed `
+        + `into target "${d.target}"` + suffix;
+    }
+  });
+  return failures.length === 0 ? 0 : 1;
+}
+
+/**
+ * Perform remote install from GitHub.
+ * @param opts Install options.
+ * @param target Target configuration.
+ * @param ctx CLI context.
+ * @param fmt Output format.
+ * @returns Exit code.
+ */
+async function performRemoteInstall(
+  opts: InstallOptions,
+  target: Target,
+  ctx: Context,
+  fmt: OutputFormat
+): Promise<number> {
+  try {
+    const spec = parseBundleSpec(opts.bundle as string);
+    const repoSlug = opts.source ?? spec.sourceId;
+    if (repoSlug === undefined || repoSlug.length === 0) {
+      throw new RegistryError({
+        code: 'USAGE.MISSING_FLAG',
+        message: 'install: a remote install needs --source <owner/repo> (or `install owner/repo:<bundleId>`).',
+        hint: 'Examples:\n'
+          + '  ai-primitives-hub install foo --source owner/repo --target my-vscode\n'
+          + '  ai-primitives-hub install owner/repo:foo --target my-vscode\n'
+          + '  ai-primitives-hub install foo --from <localDir> --target my-vscode'
+      });
+    }
+    const http = opts.http ?? new NodeHttpClient();
+    const tokens = opts.tokens ?? defaultTokenProvider(ctx.env);
+    const githubApi = githubApiFor(http, tokens);
+
+    // Use SourceDispatcher to select the appropriate resolver based on source config
+    let resolver: BundleResolver;
+    if (opts.sourceConfig) {
+      const dispatcher = new SourceDispatcher({ githubApi, fs: ctx.fs });
+      const selectedResolver = dispatcher.resolverFor(opts.sourceConfig);
+      resolver = selectedResolver ?? new GitHubBundleResolver({ repoSlug, githubApi });
+    } else {
+      // Default to GitHub resolver when no source config is provided
+      resolver = new GitHubBundleResolver({ repoSlug, githubApi });
+    }
+
+    const downloader = new HttpsBundleDownloader(http, tokens);
+    const extractor = new ZipBundleExtractor();
+
+    const installable = await resolver.resolve(spec);
+    if (installable === null) {
+      throw new RegistryError({
+        code: 'BUNDLE.NOT_FOUND',
+        message: `install: ${spec.bundleId} not found at ${repoSlug}`,
+        hint: 'Check the source slug and that a release with the requested version + asset (bundle.zip) exists.',
+        context: { spec, repoSlug }
+      });
+    }
+    const dl = await downloader.download(installable);
+    const files = await extractor.extract(dl.bytes);
+    const manifest = validateManifest(files, {
+      expectedId: opts.sourceConfig === undefined ? spec.bundleId : undefined,
+      expectedVersion: spec.bundleVersion === 'latest' ? undefined : spec.bundleVersion
+    });
+    if (opts.dryRun === true) {
+      formatOutput({
+        ctx,
+        command: 'install',
+        output: fmt,
+        status: 'ok',
+        data: {
+          dryRun: true,
+          target: target.name,
+          bundle: { id: manifest.id, version: manifest.version },
+          source: { type: 'github', repo: repoSlug, downloadUrl: installable.downloadUrl },
+          sha256: dl.sha256,
+          files: [...files.keys()]
+        },
+        textRenderer: (d) => `Dry run: would install ${d.bundle.id}@${d.bundle.version} `
+          + `from ${d.source.repo} (${d.files.length} file${d.files.length === 1 ? '' : 's'}) `
+          + `into target "${d.target}".\n`
+      });
+      return 0;
+    }
+    const transformerRegistry = TransformerRegistry.withBuiltIns();
+    const transformer = transformerRegistry.getTransformer(target.type);
+    const writer = new FileTreeTargetWriter({ fs: ctx.fs, env: ctx.env, transformer });
+    const result = await writer.write(target, files);
+    const scope = opts.scope ?? target.scope;
+    const commitMode = opts.commitMode ?? target.commitMode ?? 'commit';
+    const lockPath = lockfilePathForTarget(ctx, target, commitMode);
+    const existing = await readLockfile(lockPath, ctx.fs) ?? emptyLockfile('ai-primitives-hub-cli');
+    const entry: LockfileBundleEntry = {
+      version: manifest.version,
+      sourceId: installable.ref.sourceId,
+      sourceType: installable.ref.sourceType,
+      checksum: dl.sha256,
+      installedAt: new Date().toISOString(),
+      files: checksumFiles(files)
+    };
+    if (scope === 'repository') {
+      entry.commitMode = commitMode;
+    }
+    let nextLock = upsertBundleEntry(existing, manifest.id, entry);
+    const collectionsPath = opts.sourceConfig?.config?.collectionsPath;
+    nextLock = upsertSource(nextLock, installable.ref.sourceId, {
+      type: 'github',
+      url: `https://github.com/${repoSlug}`,
+      ...(collectionsPath ? { collectionsPath } : {})
+    });
+    await writeLockfile(lockPath, nextLock, ctx.fs);
+
+    formatOutput({
+      ctx,
+      command: 'install',
+      output: fmt,
+      status: 'ok',
+      data: {
+        target: target.name,
+        bundle: { id: manifest.id, version: manifest.version },
+        source: { type: 'github', repo: repoSlug, sourceId: installable.ref.sourceId },
+        sha256: dl.sha256,
+        written: result.written,
+        skipped: result.skipped,
+        lockfile: lockPath
+      },
+      textRenderer: (d) => `Installed ${d.bundle.id}@${d.bundle.version} from ${d.source.repo} `
+        + `into target "${d.target}" (${d.written.length} written, ${d.skipped.length} skipped). `
+        + `Updated ${d.lockfile}.\n`
+    });
+    return 0;
+  } catch (cause) {
+    if (cause instanceof RegistryError) {
+      throw cause;
+    }
+    const raw = (cause as { code?: string }).code;
+    const code = raw !== undefined && /^(BUNDLE|FS|NETWORK|USAGE|CONFIG)\.[A-Z0-9_]+$/.test(raw)
+      ? raw
+      : 'NETWORK.DOWNLOAD_FAILED';
+    throw new RegistryError({
+      code,
+      message: `install: ${(cause as Error).message}`,
+      hint: 'Run `ai-primitives-hub doctor` for environment diagnostics, or use `--from <localDir>` to install a pre-built bundle.',
+      context: {
+        mode: 'imperative-remote',
+        bundle: opts.bundle,
+        source: opts.source,
+        target: opts.target
+      },
+      cause: cause instanceof Error ? cause : undefined
+    });
+  }
+}
+
+/**
+ * Update target state with installed bundle.
+ * @param ctx CLI context.
+ * @param targetName Target name.
+ * @param bundleId Bundle ID.
+ * @param version Bundle version.
+ */
+async function updateTargetState(ctx: Context, targetName: string, bundleId: string, version: string): Promise<void> {
+  const stateStore = new TargetStateStore({
+    fs: ctx.fs,
+    statePath: path.join(ctx.cwd(), '.ai-primitives-hub', 'target-state.json')
+  });
+  const existingState = await stateStore.load(targetName);
+  const newBundles = existingState?.lastInstalledBundles ?? [];
+  const bundleIndex = newBundles.findIndex((b) => b.bundleId === bundleId);
+  const bundleState = { bundleId, version, installedAt: new Date().toISOString() };
+  if (bundleIndex === -1) {
+    newBundles.push(bundleState);
+  } else {
+    newBundles[bundleIndex] = bundleState;
+  }
+  await stateStore.save({
+    targetName,
+    lastInstalledBundles: newBundles,
+    lastUsedAt: new Date().toISOString()
+  });
+}
+
+/**
+ * Update target state from lockfile entries.
+ * @param ctx CLI context.
+ * @param targetName Target name.
+ * @param lock Lockfile.
+ * @param replayed Replayed bundle IDs.
+ */
+async function updateTargetStateFromLockfile(ctx: Context, targetName: string, lock: Lockfile, replayed: string[]): Promise<void> {
+  const stateStore = new TargetStateStore({
+    fs: ctx.fs,
+    statePath: path.join(ctx.cwd(), '.ai-primitives-hub', 'target-state.json')
+  });
+  const existingState = await stateStore.load(targetName);
+  const newBundles = existingState?.lastInstalledBundles ?? [];
+  for (const bundleId of replayed) {
+    const entry = lock.bundles[bundleId];
+    if (entry === undefined) {
+      continue;
+    }
+    const bundleIndex = newBundles.findIndex((b) => b.bundleId === bundleId);
+    const bundleState = { bundleId, version: entry.version, installedAt: entry.installedAt };
+    if (bundleIndex === -1) {
+      newBundles.push(bundleState);
+    } else {
+      newBundles[bundleIndex] = bundleState;
+    }
+  }
+  await stateStore.save({
+    targetName,
+    lastInstalledBundles: newBundles,
+    lastUsedAt: new Date().toISOString()
+  });
+}
+
+/**
+ * Install a single bundle given an explicit source configuration.
+ * Shared by `install --interactive` and `index search --install`.
+ * @param bundleId Bundle ID to install.
+ * @param sourceConfig Source configuration (hub source).
+ * @param target Target to write into.
+ * @param ctx CLI context.
+ * @param http HTTP client.
+ * @param tokens Token provider.
+ * @param fmt Output format.
+ * @returns Exit code.
+ */
+export async function installBundleWithSource(
+  bundleId: string,
+  sourceConfig: RegistrySource,
+  target: Target,
+  ctx: Context,
+  http: HttpClient,
+  tokens: TokenProvider,
+  fmt: OutputFormat = 'text'
+): Promise<number> {
+  const opts: InstallOptions = {
+    bundle: bundleId,
+    source: extractRepoSlug(sourceConfig.url),
+    sourceConfig,
+    http,
+    tokens
+  };
+  return performRemoteInstall(opts, target, ctx, fmt);
+}
+
+/**
+ * Build the `install` command (factory function for backward compatibility).
+ * @param opts - Command options.
+ * @returns CommandDefinition wired to the framework adapter.
+ */
+export const createInstallCommand = (
+  opts: InstallOptions = {}
+): CommandDefinition =>
+  defineCommand({
+    path: ['install'],
+    description: 'Install bundles to a configured target.',
+    category: 'Install & Manage',
+    run: async ({ ctx }: { ctx: Context }): Promise<number> => {
+      const fmt = opts.output ?? 'text';
+      const { bundle: noBundle, lockfile: noLockfile } = validateInputs(opts, { flags: ['bundle', 'lockfile'] });
+      if (noBundle && noLockfile) {
+        return failWith(ctx, fmt, 'install', new RegistryError({
+          code: 'USAGE.MISSING_FLAG',
+          message: 'install: provide either <bundle-id> (imperative) or --lockfile <path> (declarative)',
+          hint: 'Examples:\n'
+            + '  ai-primitives-hub install <bundle-id>\n'
+            + '  ai-primitives-hub install --lockfile prompt-registry.lock.json'
+        }));
+      }
+
+      try {
+        const targetName = await resolveTargetName(opts.target, 'install', ctx, () => readTargets({ cwd: ctx.cwd(), fs: ctx.fs }));
+        checkAllowTarget(targetName, opts);
+        const target = await resolveTarget(targetName, 'install', ctx, () => readTargets({ cwd: ctx.cwd(), fs: ctx.fs }));
+
+        if (opts.from !== undefined && opts.from.length > 0) {
+          return await performLocalInstall(opts, target, ctx, fmt);
+        }
+
+        if (opts.lockfile !== undefined && opts.lockfile.length > 0) {
+          return await performLockfileInstall(opts, target, ctx, fmt);
+        }
+
+        return await performRemoteInstall(opts, target, ctx, fmt);
+      } catch (err) {
+        if (err instanceof RegistryError) {
+          return failWith(ctx, fmt, 'install', err);
+        }
+        throw err;
+      }
+    }
+  });
+
+/**
+ * Replay lockfile entries for installation.
+ */
+interface ReplayLockfileEntriesOptions {
+  bundleIds: string[];
+  lock: Lockfile;
+  http: HttpClient;
+  tokens: TokenProvider;
+  writer: TargetWriter;
+  target: Target;
+  ctx: Context;
+  verbose: boolean;
+}
+
+async function replayLockfileEntries(
+  opts: ReplayLockfileEntriesOptions
+): Promise<{ replayed: string[]; failures: { bundleId: string; reason: string }[] }> {
+  const { bundleIds, lock, http, tokens, writer, target, ctx, verbose } = opts;
+  const replayed: string[] = [];
+  const failures: { bundleId: string; reason: string }[] = [];
+
+  if (verbose) {
+    ctx.stdout.write(`[verbose] Planning to replay ${bundleIds.length} bundles\n`);
+  }
+
+  for (const bundleId of bundleIds) {
+    const entry = lock.bundles[bundleId];
+    const result = await replaySingleEntry({
+      bundleId,
+      entry,
+      sources: lock.sources,
+      http,
+      tokens,
+      writer,
+      target,
+      ctx,
+      verbose
+    });
+    if (result.success) {
+      replayed.push(bundleId);
+    } else {
+      failures.push({ bundleId, reason: result.reason });
+    }
+  }
+
+  return { replayed, failures };
+}
+
+interface ReplaySingleEntryOptions {
+  bundleId: string;
+  entry: LockfileBundleEntry;
+  sources: Record<string, LockfileSourceEntry>;
+  http: HttpClient;
+  tokens: TokenProvider;
+  writer: TargetWriter;
+  target: Target;
+  ctx: Context;
+  verbose: boolean;
+}
+
+async function replaySingleEntry(
+  opts: ReplaySingleEntryOptions
+): Promise<{ success: boolean; reason: string }> {
+  const { bundleId, entry, sources, http, tokens, writer, target, ctx, verbose } = opts;
+  const src = sources[entry.sourceId];
+  if (src === undefined) {
+    return handleMissingSource(bundleId, entry, verbose, ctx);
+  }
+
+  try {
+    const files = await fetchFilesForSource(src, bundleId, entry, http, tokens, ctx, verbose);
+    if (files === null) {
+      return handleFetchFailure(bundleId, src, verbose, ctx);
+    }
+    await validateAndWrite(files, bundleId, entry, writer, target, ctx, verbose);
+    return { success: true, reason: '' };
+  } catch (cause) {
+    return handleInstallError(bundleId, cause, verbose, ctx);
+  }
+}
+
+async function validateAndWrite(
+  files: Map<string, Uint8Array>,
+  bundleId: string,
+  entry: LockfileBundleEntry,
+  writer: TargetWriter,
+  target: Target,
+  ctx: Context,
+  verbose: boolean
+): Promise<void> {
+  validateManifest(files, {
+    expectedId: bundleId,
+    expectedVersion: entry.version
+  });
+  await writer.write(target, files);
+  if (verbose) {
+    ctx.stdout.write(`[verbose] Successfully installed ${bundleId}\n`);
+  }
+}
+
+function handleMissingSource(
+  bundleId: string,
+  entry: LockfileBundleEntry,
+  verbose: boolean,
+  ctx: Context
+): { success: boolean; reason: string } {
+  const reason = `source ${entry.sourceId} missing from lockfile.sources`;
+  if (verbose) {
+    ctx.stdout.write(`[verbose] Skipping ${bundleId}: ${reason}\n`);
+  }
+  return { success: false, reason };
+}
+
+function handleFetchFailure(
+  bundleId: string,
+  src: LockfileSourceEntry,
+  verbose: boolean,
+  ctx: Context
+): { success: boolean; reason: string } {
+  const reason = `failed to fetch files from ${src.type} source`;
+  if (verbose) {
+    ctx.stdout.write(`[verbose] Skipping ${bundleId}: ${reason}\n`);
+  }
+  return { success: false, reason };
+}
+
+function handleInstallError(
+  bundleId: string,
+  cause: unknown,
+  verbose: boolean,
+  ctx: Context
+): { success: boolean; reason: string } {
+  const reason = (cause as Error).message;
+  if (verbose) {
+    ctx.stdout.write(`[verbose] Failed to install ${bundleId}: ${reason}\n`);
+  }
+  return { success: false, reason };
+}
+
+/**
+ * Fetch a bundle's extracted files from a lockfile source entry —
+ * dispatches on `src.type` (`local`, or `github`/AwesomeCopilot via
+ * `entry.sourceId`'s prefix) and resolves/downloads/extracts
+ * accordingly. Shared by lockfile replay (`replaySingleEntry`) and
+ * `profile.ts`'s bundle activation loop.
+ * @param src Lockfile source entry describing where to fetch from.
+ * @param bundleId Bundle id to fetch.
+ * @param entry Lockfile bundle entry — only `.version`/`.sourceId` are read.
+ * @param http HTTP client.
+ * @param tokens Token provider.
+ * @param ctx CLI context.
+ * @param verbose Whether to write `[verbose]` progress lines to stdout.
+ * @returns The extracted files, or `null` if the bundle couldn't be resolved/fetched.
+ */
+export async function fetchFilesForSource(
+  src: LockfileSourceEntry,
+  bundleId: string,
+  entry: LockfileBundleEntry,
+  http: HttpClient,
+  tokens: TokenProvider,
+  ctx: Context,
+  verbose: boolean
+): Promise<Map<string, Uint8Array> | null> {
+  if (src.type === 'local') {
+    if (verbose) {
+      ctx.stdout.write(`[verbose] Reading local bundle from ${src.url}\n`);
+    }
+    const files = await readLocalBundle(src.url, ctx.fs);
+    return new Map(files);
+  }
+  if (src.type === 'github') {
+    const githubApi = githubApiFor(http, tokens);
+    // Check if this is an awesome-copilot source (detected by sourceId prefix)
+    const isAwesomeCopilot = bundleId.startsWith('awesome-copilot-') || entry.sourceId.startsWith('awesome-copilot-');
+    const repoSlug = src.url.replace(/^https?:\/\/github\.com\//, '');
+    if (verbose) {
+      ctx.stdout.write(`[verbose] Resolving ${bundleId}@${entry.version} from ${repoSlug} (${isAwesomeCopilot ? 'awesome-copilot' : 'github'})\n`);
+    }
+
+    if (isAwesomeCopilot) {
+      const acResolver = new AwesomeCopilotBundleResolver({
+        repoSlug,
+        githubApi,
+        collectionsPath: src.collectionsPath
+      });
+      const acInstallable = await acResolver.resolve({ bundleId, bundleVersion: entry.version });
+      if (acInstallable?.inlineBytes === undefined) {
+        if (verbose) {
+          ctx.stdout.write(`[verbose] AwesomeCopilot resolver returned null or no inline bytes for ${bundleId}@${entry.version}\n`);
+        }
+        return null;
+      }
+      if (verbose) {
+        ctx.stdout.write(`[verbose] Using inline bundle from AwesomeCopilot resolver\n`);
+      }
+      const acFiles = await new ZipBundleExtractor().extract(acInstallable.inlineBytes);
+      return new Map(acFiles);
+    }
+
+    // Use GitHub resolver for regular github sources
+    const resolver = new GitHubBundleResolver({ repoSlug, githubApi });
+    const downloader = new HttpsBundleDownloader(http, tokens);
+    const installable = await resolver.resolve({ bundleId, bundleVersion: entry.version });
+    if (installable === null) {
+      if (verbose) {
+        ctx.stdout.write(`[verbose] Resolver returned null for ${bundleId}@${entry.version}\n`);
+      }
+      return null;
+    }
+    if (verbose) {
+      ctx.stdout.write(`[verbose] Downloading from ${installable.downloadUrl}\n`);
+    }
+    const dl = await downloader.download(installable);
+    if (entry.checksum !== undefined && dl.sha256 !== entry.checksum) {
+      if (verbose) {
+        ctx.stdout.write(`[verbose] SHA256 mismatch: expected ${entry.checksum}, got ${dl.sha256}\n`);
+      }
+      return null;
+    }
+    if (verbose) {
+      ctx.stdout.write(`[verbose] Extracting bundle\n`);
+    }
+    const files = await new ZipBundleExtractor().extract(dl.bytes);
+    return new Map(files);
+  }
+  if (verbose) {
+    ctx.stdout.write(`[verbose] Unsupported source type: ${src.type}\n`);
+  }
+  return null;
+}

--- a/packages/cli/src/commands/instruction-create.ts
+++ b/packages/cli/src/commands/instruction-create.ts
@@ -1,0 +1,161 @@
+/**
+ * `instruction create` subcommand.
+ *
+ * Creates a new instruction file with proper structure using templates.
+ *
+ * Usage:
+ *   ai-primitives-hub instruction create style \
+ *     --description "Code style guidelines"
+ * @module commands/instruction-create
+ */
+import * as path from 'node:path';
+import {
+  readCollection,
+  writeCollection,
+} from '@ai-primitives-hub/app';
+import {
+  generateSanitizedId,
+  TemplateContext,
+} from '@ai-primitives-hub/core';
+import type {
+  CollectionItem,
+} from '@ai-primitives-hub/core';
+import {
+  TEMPLATE_PATHS,
+  TemplateEngine,
+} from '@ai-primitives-hub/infra';
+import {
+  Command,
+  type Context,
+  formatOutput,
+  Option,
+  type OutputFormat,
+  RegistryError,
+  renderError,
+} from '../framework';
+
+/**
+ * Instruction create command class.
+ */
+export class InstructionCreateCommand extends Command {
+  public static readonly paths = [['instruction', 'create']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Create a new instruction file',
+    category: 'Primitive',
+    details: `
+      Usage: ai-primitives-hub instruction create <name> [options]
+
+      Options:
+        --description <text>   Instruction description
+        --path <dir>           Output directory (default: instructions/)
+        -o, --output <format>  Output format (text, json, yaml, ndjson)
+
+      Examples:
+        ai-primitives-hub instruction create style
+        ai-primitives-hub instruction create style --description "Code style guidelines"
+    `
+  });
+
+  public name = Option.String({ required: true });
+  public description = Option.String('--description');
+  public collection = Option.String('--collection');
+  public pathOption = Option.String('--path');
+  public output = Option.String('-o', '--output') as OutputFormat | undefined;
+  public commandContext!: { ctx: Context };
+
+  public async execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+    const fmt = (this.output ?? 'text');
+
+    try {
+      // Determine instruction name
+      const instructionName = generateSanitizedId(this.name);
+      const displayName = this.name;
+
+      // Build template context
+      const context: TemplateContext = {
+        projectName: instructionName,
+        collectionId: instructionName,
+        name: displayName,
+        description: this.description || `A ${displayName} instruction`
+      };
+
+      // Determine output path
+      const outputPath = this.pathOption || 'instructions';
+      const targetPath = path.isAbsolute(outputPath) ? outputPath : path.join(ctx.cwd(), outputPath);
+
+      // Initialize template engine
+      const templateEngine = new TemplateEngine(TEMPLATE_PATHS.instruction);
+
+      // Scaffold the instruction
+      const result = await templateEngine.scaffoldProject(targetPath, context);
+
+      if (!result.success) {
+        const err = new RegistryError({
+          code: 'FS.SCAFFOLD_FAILED',
+          message: result.error || 'Scaffolding failed'
+        });
+        renderError(err, ctx);
+        return 1;
+      }
+
+      // Add to collection if specified
+      if (this.collection) {
+        const collectionId = this.collection;
+        const collectionFile = path.join(ctx.cwd(), 'collections', `${collectionId}.collection.yml`);
+
+        try {
+          const collection = readCollection(ctx.cwd(), collectionFile);
+
+          // Calculate repo-root relative path
+          const createdFile = result.createdFiles[0];
+          const relativePath = path.relative(ctx.cwd(), createdFile).replace(/\\/g, '/');
+
+          // Add item to collection
+          const newItem: CollectionItem = {
+            path: relativePath,
+            kind: 'instruction',
+            name: displayName,
+            description: this.description
+          };
+
+          collection.items.push(newItem);
+          writeCollection(ctx.cwd(), collectionFile, collection);
+        } catch (error) {
+          const err = new RegistryError({
+            code: 'FS.COLLECTION_UPDATE_FAILED',
+            message: `Failed to add instruction to collection: ${(error as Error).message}`
+          });
+          renderError(err, ctx);
+          return 1;
+        }
+      }
+
+      // Format output
+      formatOutput({
+        ctx,
+        command: 'instruction create',
+        output: fmt,
+        status: 'ok',
+        data: {
+          name: instructionName,
+          path: result.createdFiles[0],
+          createdFiles: result.createdFiles,
+          collection: this.collection
+        }
+      });
+      return 0;
+    } catch (error) {
+      const registryError = error instanceof RegistryError
+        ? error
+        : new RegistryError({
+          code: 'INTERNAL.UNEXPECTED',
+          message: (error as Error).message
+        });
+
+      renderError(registryError, ctx);
+      return 1;
+    }
+  }
+}

--- a/packages/cli/src/commands/plugin-create.ts
+++ b/packages/cli/src/commands/plugin-create.ts
@@ -1,0 +1,167 @@
+/**
+ * `plugin create` subcommand.
+ *
+ * Creates a new plugin directory with plugin.json using templates.
+ *
+ * Usage:
+ *   ai-primitives-hub plugin create my-plugin \
+ *     --description "My custom plugin"
+ * @module commands/plugin-create
+ */
+import * as path from 'node:path';
+import {
+  readCollection,
+  writeCollection,
+} from '@ai-primitives-hub/app';
+import {
+  generateSanitizedId,
+  TemplateContext,
+} from '@ai-primitives-hub/core';
+import type {
+  CollectionItem,
+} from '@ai-primitives-hub/core';
+import {
+  TEMPLATE_PATHS,
+  TemplateEngine,
+} from '@ai-primitives-hub/infra';
+import {
+  Command,
+  type Context,
+  formatOutput,
+  Option,
+  type OutputFormat,
+  RegistryError,
+  renderError,
+} from '../framework';
+
+/**
+ * Plugin create command class.
+ */
+export class PluginCreateCommand extends Command {
+  public static readonly paths = [['plugin', 'create']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Create a new plugin directory',
+    category: 'Primitive',
+    details: `
+      Usage: ai-primitives-hub plugin create <name> [options]
+
+      Options:
+        --description <text>   Plugin description
+        --version <version>   Plugin version (default: 1.0.0)
+        --author <name>        Author name
+        --path <dir>           Output directory (default: plugins/)
+        -o, --output <format>  Output format (text, json, yaml, ndjson)
+
+      Examples:
+        ai-primitives-hub plugin create my-plugin
+        ai-primitives-hub plugin create my-plugin --description "My custom plugin"
+    `
+  });
+
+  public name = Option.String({ required: true });
+  public description = Option.String('--description');
+  public version = Option.String('--version');
+  public author = Option.String('--author');
+  public collection = Option.String('--collection');
+  public pathOption = Option.String('--path');
+  public output = Option.String('-o', '--output') as OutputFormat | undefined;
+  public commandContext!: { ctx: Context };
+
+  public async execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+    const fmt = (this.output ?? 'text');
+
+    try {
+      // Determine plugin name
+      const pluginName = generateSanitizedId(this.name);
+      const displayName = this.name;
+
+      // Build template context
+      const context: TemplateContext = {
+        projectName: pluginName,
+        collectionId: pluginName,
+        name: displayName,
+        description: this.description || `A ${displayName} plugin`,
+        version: this.version || '1.0.0',
+        author: this.author || process.env.USER || 'Your Name'
+      };
+
+      // Determine output path
+      const outputPath = this.pathOption || 'plugins';
+      const targetPath = path.isAbsolute(outputPath) ? outputPath : path.join(ctx.cwd(), outputPath);
+
+      // Initialize template engine
+      const templateEngine = new TemplateEngine(TEMPLATE_PATHS.plugin);
+
+      // Scaffold the plugin
+      const result = await templateEngine.scaffoldProject(targetPath, context);
+
+      if (!result.success) {
+        const err = new RegistryError({
+          code: 'FS.SCAFFOLD_FAILED',
+          message: result.error || 'Scaffolding failed'
+        });
+        renderError(err, ctx);
+        return 1;
+      }
+
+      // Add to collection if specified
+      if (this.collection) {
+        const collectionId = this.collection;
+        const collectionFile = path.join(ctx.cwd(), 'collections', `${collectionId}.collection.yml`);
+
+        try {
+          const collection = readCollection(ctx.cwd(), collectionFile);
+
+          // Calculate repo-root relative path
+          const createdFile = result.createdFiles[0];
+          const relativePath = path.relative(ctx.cwd(), createdFile).replace(/\\/g, '/');
+
+          // Add item to collection
+          const newItem: CollectionItem = {
+            path: relativePath,
+            kind: 'plugin',
+            name: displayName,
+            description: this.description
+          };
+
+          collection.items.push(newItem);
+          writeCollection(ctx.cwd(), collectionFile, collection);
+        } catch (error) {
+          const err = new RegistryError({
+            code: 'FS.COLLECTION_UPDATE_FAILED',
+            message: `Failed to add plugin to collection: ${(error as Error).message}`
+          });
+          renderError(err, ctx);
+          return 1;
+        }
+      }
+
+      // Format output
+      formatOutput({
+        ctx,
+        command: 'plugin create',
+        output: fmt,
+        status: 'ok',
+        data: {
+          name: pluginName,
+          path: result.createdFiles[0],
+          createdFiles: result.createdFiles,
+          collection: this.collection
+        }
+      });
+      return 0;
+    } catch (error) {
+      const registryError = error instanceof RegistryError
+        ? error
+        : new RegistryError({
+          code: 'INTERNAL.UNEXPECTED',
+          message: (error as Error).message
+        });
+
+      renderError(registryError, ctx);
+      return 1;
+    }
+  }
+}

--- a/packages/cli/src/commands/plugins-list.ts
+++ b/packages/cli/src/commands/plugins-list.ts
@@ -1,0 +1,184 @@
+/**
+ * `plugins list` subcommand.
+ *
+ * Discovers `ai-primitives-hub-<name>` executables on `$PATH` per
+ * the kubectl/gh model. Each match becomes a plugin
+ * candidate; dashes in the filename map to nested subcommands at
+ * dispatch time (not implemented in this iteration).
+ *
+ * This iteration ships discovery only — invocation is deferred to a later
+ * iteration when the dispatcher knows how to spawn matched plugins.
+ *
+ * The lookup walks every directory in PATH and reports the first
+ * match for each plugin name, mirroring how the shell's PATH search
+ * works. Conflicts are flagged as warnings.
+ * @module commands/plugins-list
+ */
+import * as path from 'node:path';
+import {
+  Command,
+  type Context,
+  formatOutput,
+  Option,
+  type OutputFormat,
+  renderTable,
+} from '../framework';
+
+/**
+ * Discovered plugin record.
+ */
+interface PluginRecord {
+  name: string;
+  source: string;
+  conflicts: string[];
+}
+
+const PLUGIN_PREFIX = 'ai-primitives-hub-';
+
+/**
+ * Scan every directory in PATH for plugin executables.
+ * @param pathVar Raw PATH environment variable value.
+ * @param ctx CLI context.
+ * @returns Map of plugin name to record (first match wins; later matches recorded as conflicts).
+ */
+const scanPathForPlugins = async (pathVar: string, ctx: Context): Promise<Map<string, PluginRecord>> => {
+  const dirs = pathVar.split(path.delimiter).filter((d) => d.length > 0);
+  const plugins = new Map<string, PluginRecord>();
+  for (const dir of dirs) {
+    await scanDirectoryForPlugins(dir, ctx, plugins);
+  }
+  return plugins;
+};
+
+/**
+ * Scan a single directory for plugin executables.
+ * @param dir Directory to scan.
+ * @param ctx CLI context.
+ * @param plugins Map to accumulate discovered plugins into.
+ */
+const scanDirectoryForPlugins = async (
+  dir: string,
+  ctx: Context,
+  plugins: Map<string, PluginRecord>
+): Promise<void> => {
+  if (!(await ctx.fs.exists(dir))) {
+    return;
+  }
+  const entries = await getDirectoryEntries(dir, ctx);
+  if (entries === undefined) {
+    return;
+  }
+  for (const filename of entries) {
+    processPluginFile(filename, dir, plugins);
+  }
+};
+
+/**
+ * Read directory entries, tolerating unreadable directories.
+ * @param dir Directory to read.
+ * @param ctx CLI context.
+ * @returns Entry filenames, or undefined if the directory could not be read.
+ */
+const getDirectoryEntries = async (dir: string, ctx: Context): Promise<string[] | undefined> => {
+  try {
+    return await ctx.fs.readDir(dir);
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Record a candidate plugin file if its name matches the plugin prefix.
+ * @param filename Filename to check.
+ * @param dir Directory the filename is in.
+ * @param plugins Map to accumulate discovered plugins into.
+ */
+const processPluginFile = (filename: string, dir: string, plugins: Map<string, PluginRecord>): void => {
+  if (!filename.startsWith(PLUGIN_PREFIX)) {
+    return;
+  }
+  const name = filename.slice(PLUGIN_PREFIX.length);
+  const fullPath = path.join(dir, filename);
+  const existing = plugins.get(name);
+  if (existing === undefined) {
+    plugins.set(name, { name, source: fullPath, conflicts: [] });
+  } else {
+    existing.conflicts.push(fullPath);
+  }
+};
+
+/**
+ * Generate warnings for every shadowed (conflicting) plugin match.
+ * @param records Plugin records.
+ * @returns Warning messages.
+ */
+const generateConflictWarnings = (records: PluginRecord[]): string[] => {
+  const warnings: string[] = [];
+  for (const r of records) {
+    for (const c of r.conflicts) {
+      warnings.push(`plugin "${r.name}" shadowed: ${c} (in use: ${r.source})`);
+    }
+  }
+  return warnings;
+};
+
+/**
+ * Render plugins as text.
+ * @param records Plugin records.
+ * @returns Formatted text output.
+ */
+const renderText = (records: PluginRecord[]): string =>
+  renderTable<PluginRecord>({
+    columns: [
+      { header: 'NAME', get: (r) => r.name },
+      { header: 'SOURCE', get: (r) => r.source }
+    ],
+    rows: records,
+    emptyMessage: 'No plugins found on $PATH.\n  (Plugins are executables named `ai-primitives-hub-<name>` discoverable via PATH.)\n'
+  });
+
+/**
+ * Plugins list command class.
+ */
+export class PluginsListCommand extends Command {
+  public static readonly paths = [['plugins', 'list']];
+
+  public static readonly usage = Command.Usage({
+    description: 'List `ai-primitives-hub-<name>` plugins discovered on $PATH (kubectl-style).',
+    category: 'Configure & Debug',
+    details: `
+      Usage: ai-primitives-hub plugins list [options]
+
+      Discovers ai-primitives-hub-<name> executables on $PATH and reports conflicts.
+
+      Options:
+        -o, --output <format>  Output format (text, json, yaml, ndjson)
+
+      Examples:
+        ai-primitives-hub plugins list
+        ai-primitives-hub plugins list -o json
+    `
+  });
+
+  public output = Option.String('-o', '--output') as OutputFormat | undefined;
+  public commandContext!: { ctx: Context };
+
+  public async execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+    const fmt = this.output ?? 'text';
+    const pathVar = ctx.env.PATH ?? '';
+    const plugins = await scanPathForPlugins(pathVar, ctx);
+    const records = [...plugins.values()].toSorted((a, b) => a.name.localeCompare(b.name));
+    const warnings = generateConflictWarnings(records);
+    formatOutput({
+      ctx,
+      command: 'plugins.list',
+      output: fmt,
+      status: warnings.length > 0 ? 'warning' : 'ok',
+      data: records,
+      warnings,
+      textRenderer: renderText
+    });
+    return 0;
+  }
+}

--- a/packages/cli/src/commands/profile.ts
+++ b/packages/cli/src/commands/profile.ts
@@ -1,0 +1,1026 @@
+/**
+ * `profile` commands.
+ *
+ * Subcommands:
+ *   profile list [--hub <id>]
+ *   profile show <profileId>
+ *   profile activate <profileId> [--hub <id>] [--target <name>...]
+ *   profile deactivate
+ *   profile current
+ *   profile create <profileId> --name <name>
+ *   profile edit <profileId>
+ *   profile publish <profileId> --hub <id>
+ *
+ * Activation writes bundle files to every configured target (optionally
+ * filtered via `--target`), reusing the same fetch/write primitives as
+ * `install.ts` (`fetchFilesForSource`, `createWriterFactory`) and the same
+ * removal primitives as `uninstall.ts` (`runUserScopeUninstall`,
+ * `UninstallPipeline`) for deactivation. Unlike the reference branch, there
+ * is no per-entry `target` field or `useProfile` field on the lockfile
+ * (see `stores/json-lockfile-store.ts`'s module doc) — activation state
+ * (which hub/profile is active, and which bundles it synced) is tracked
+ * exclusively via `ProfileActivationStore`, and each target's own lockfile
+ * (resolved via `lockfilePathForTarget`) is updated per bundle exactly as
+ * a direct `install` would.
+ */
+import * as path from 'node:path';
+import {
+  checksumFiles,
+  emptyLockfile,
+  type HubManager,
+  type Lockfile,
+  type LockfileBundleEntry,
+  type LockfileSourceEntry,
+  readLockfile,
+  resolveUserConfigPaths,
+  type TargetWriter,
+  UninstallPipeline,
+  upsertBundleEntry,
+  upsertSource,
+  writeLockfile,
+} from '@ai-primitives-hub/app';
+import {
+  type HttpClient,
+  type HubProfile,
+  type HubProfileBundle,
+  type ProfileActivationState,
+  type RegistrySource,
+  type Target,
+  type TokenProvider,
+  validateManifest,
+} from '@ai-primitives-hub/core';
+import {
+  ProfileActivationStore,
+} from '@ai-primitives-hub/infra';
+import * as yaml from 'js-yaml';
+import {
+  Command,
+  createHttpClientAndTokens,
+  createHubManager,
+  failWith,
+  loadTargets,
+  lockfilePathForTarget,
+  Option,
+  requireActiveHubOrFail,
+} from '../framework';
+import {
+  type Context,
+  formatOutput,
+  type OutputFormat,
+  RegistryError,
+} from '../framework';
+import {
+  createWriterFactory,
+  fetchFilesForSource,
+} from './install';
+import {
+  createWriterFactory as createUninstallWriterFactory,
+  runUserScopeUninstall,
+} from './uninstall';
+
+/**
+ * Bundle of HubManager + activation store + HTTP/token deps, as
+ * returned by {@link buildHubMgr} and consumed by
+ * {@link runProfileActivation}.
+ */
+export interface BuiltHubMgr {
+  mgr: HubManager;
+  activations: ProfileActivationStore;
+  http: HttpClient;
+  tokens: TokenProvider;
+}
+
+/**
+ * Build HubManager and related instances.
+ * @param ctx CLI context.
+ * @param http HTTP client (optional test seam).
+ * @param tokens Token provider (optional test seam).
+ * @returns HubManager, activations store, HTTP client, and token provider.
+ */
+export const buildHubMgr = (ctx: Context, http?: HttpClient, tokens?: TokenProvider): BuiltHubMgr => {
+  const [httpClient, tokenProvider] = createHttpClientAndTokens(http, ctx, tokens);
+  const mgr = createHubManager({ ctx, http: httpClient, tokens: tokenProvider });
+  // Activation state lives under `<hubsDir>/profile-activations/` — the same
+  // base directory `HubStore` itself uses so `hub remove` can clean up any
+  // activation files left behind for a removed hub (see infra's
+  // `ProfileActivationStore` module doc).
+  const hubsDir = resolveUserConfigPaths(ctx.env).hubs;
+  return {
+    mgr,
+    activations: new ProfileActivationStore(hubsDir, ctx.fs),
+    http: httpClient,
+    tokens: tokenProvider
+  };
+};
+
+/**
+ * Resolve hub ID from options or active hub.
+ * @param mgr Hub manager.
+ * @param hubId Optional hub ID from options.
+ * @returns Hub ID.
+ */
+const resolveHubId = async (mgr: HubManager, hubId?: string): Promise<string> => {
+  if (hubId && typeof hubId === 'string') {
+    return hubId;
+  }
+  const active = await mgr.getActiveHub();
+  if (!active) {
+    throw new RegistryError({
+      code: 'HUB.NOT_FOUND',
+      message: 'no active hub',
+      hint: 'Run `ai-primitives-hub hub add` to import a hub, then `hub use <id>` to activate it.'
+    });
+  }
+  return active.id;
+};
+
+/**
+ * Context passed to profile command execute methods.
+ */
+interface ProfileCommandContext {
+  ctx: Context;
+  http?: HttpClient;
+  tokens?: TokenProvider;
+}
+
+/**
+ * Base class for profile commands with shared context.
+ */
+abstract class BaseProfileCommand extends Command {
+  /**
+   * Get the CLI context. This needs to be set by the CLI entry point.
+   */
+  public commandContext!: ProfileCommandContext;
+
+  public output = Option.String('-o,--output');
+  public hubId = Option.String('--hub');
+}
+
+/**
+ * profile list - list profiles in a hub
+ */
+export class ProfileListCommand extends BaseProfileCommand {
+  public static readonly paths = [['profile', 'list']];
+  public static readonly usage = Command.Usage({
+    description: 'List profiles in a hub.',
+    category: 'Hub & Discovery',
+    details: `
+      Usage: ai-primitives-hub profile list [options]
+
+      Options:
+        --hub <hub-id>           Hub ID to list profiles from
+        -o, --output <format>     Output format (text, json, yaml, ndjson)
+
+      Examples:
+        ai-primitives-hub profile list
+        ai-primitives-hub profile list --hub my-hub
+    `
+  });
+
+  public async execute() {
+    const { ctx, http, tokens } = this.commandContext;
+    const fmt = (this.output ?? 'text') as OutputFormat;
+    const built = buildHubMgr(ctx, http, tokens);
+    const mgr = built.mgr;
+
+    let hubId: string;
+    try {
+      hubId = await resolveHubId(mgr, this.hubId);
+    } catch (err) {
+      if (err instanceof RegistryError) {
+        return failWith(ctx, fmt, 'profile', err);
+      }
+      throw err;
+    }
+
+    const hubs = await mgr.listHubs();
+    if (!hubs.some((h) => h.id === hubId)) {
+      return failWith(ctx, fmt, 'profile', new RegistryError({
+        code: 'HUB.NOT_FOUND',
+        message: `profile list: hub "${hubId}" not found`,
+        hint: 'Run `ai-primitives-hub hub list` to see available hubs.'
+      }));
+    }
+    const all = await mgr.listSourcesAcrossAllHubs();
+    const sourceCount = all.filter((s) => s.hubId === hubId).length;
+    const active = await mgr.getActiveHub();
+    const profiles = active?.id === hubId
+      ? active.config.profiles.map((p) => ({
+        id: p.id, name: p.name, bundles: p.bundles.length
+      }))
+      : [];
+    formatOutput({
+      ctx, command: 'profile.list', output: fmt, status: 'ok',
+      data: { hubId, profiles, sourceCount },
+      textRenderer: (d) => d.profiles.length === 0
+        ? `No profiles in hub "${d.hubId}". Run \`ai-primitives-hub profile create <id> --name <name>\` to add one.\n`
+        : d.profiles.map((p) => `${p.id}  ${p.name} (${String(p.bundles)} bundle${p.bundles === 1 ? '' : 's'})\n`).join('')
+    });
+    return 0;
+  }
+}
+
+/**
+ * profile show - show profile details
+ */
+export class ProfileShowCommand extends BaseProfileCommand {
+  public static readonly paths = [['profile', 'show']];
+  public static readonly usage = Command.Usage({
+    description: 'Show details of a profile.',
+    category: 'Hub & Discovery',
+    details: `
+      Usage: ai-primitives-hub profile show <profile-id> [options]
+
+      Options:
+        --hub <hub-id>           Hub ID containing the profile
+        -o, --output <format>     Output format (text, json, yaml, ndjson)
+
+      Examples:
+        ai-primitives-hub profile show my-profile
+        ai-primitives-hub profile show my-profile --hub my-hub
+    `
+  });
+
+  public profileId = Option.String({ required: false });
+
+  public async execute() {
+    const { ctx, http, tokens } = this.commandContext;
+    const fmt = (this.output ?? 'text') as OutputFormat;
+    const built = buildHubMgr(ctx, http, tokens);
+    const mgr = built.mgr;
+
+    if (!this.profileId) {
+      return failWith(ctx, fmt, 'profile', new RegistryError({
+        code: 'USAGE.MISSING_FLAG',
+        message: 'profile show: <profileId> required'
+      }));
+    }
+
+    let hubId: string;
+    try {
+      hubId = await resolveHubId(mgr, this.hubId);
+    } catch (err) {
+      if (err instanceof RegistryError) {
+        return failWith(ctx, fmt, 'profile', err);
+      }
+      throw err;
+    }
+
+    const active = await requireActiveHubOrFail(mgr, hubId, 'profile.show', ctx, fmt);
+    if (typeof active === 'number') {
+      return active;
+    }
+    const profile = active.config.profiles.find((p) => p.id === this.profileId);
+    if (profile === undefined) {
+      return failWith(ctx, fmt, 'profile', new RegistryError({
+        code: 'BUNDLE.NOT_FOUND',
+        message: `profile show: "${this.profileId}" not in hub "${hubId}"`,
+        hint: 'Run `ai-primitives-hub profile list` to see available profiles.'
+      }));
+    }
+    formatOutput({
+      ctx, command: 'profile.show', output: fmt, status: 'ok',
+      data: { hubId, profile },
+      textRenderer: (d) => `${d.profile.name} (${d.profile.id})\n`
+        + `  Bundles: ${String(d.profile.bundles.length)}\n`
+        + d.profile.bundles.map((b) => `    - ${b.id}@${b.version} (source: ${b.source})\n`).join('')
+    });
+    return 0;
+  }
+}
+
+/**
+ * profile current - show currently active profile
+ */
+export class ProfileCurrentCommand extends BaseProfileCommand {
+  public static readonly paths = [['profile', 'current']];
+  public static readonly usage = Command.Usage({
+    description: 'Show the currently active profile.',
+    category: 'Hub & Discovery',
+    details: `
+      Usage: ai-primitives-hub profile current
+
+      Examples:
+        $ ai-primitives-hub profile current
+    `
+  });
+
+  public async execute() {
+    const { ctx, http, tokens } = this.commandContext;
+    const fmt = (this.output ?? 'text') as OutputFormat;
+    const built = buildHubMgr(ctx, http, tokens);
+
+    const allActive = await built.activations.listAll();
+    const active = allActive[0];
+    if (!active) {
+      formatOutput({
+        ctx, command: 'profile.current', output: fmt, status: 'ok',
+        data: { active: null },
+        textRenderer: () => 'No active profile.\n'
+      });
+      return 0;
+    }
+    formatOutput({
+      ctx, command: 'profile.current', output: fmt, status: 'ok',
+      data: { active: { hubId: active.hubId, profileId: active.profileId } },
+      textRenderer: (d) => `Active profile: ${d.active.profileId} (hub: ${d.active.hubId})\n`
+    });
+    return 0;
+  }
+}
+
+/**
+ * Result of activating a single profile bundle against a single target.
+ */
+type ActivateBundleOutcome =
+  | { ok: true; written: string[]; entry: LockfileBundleEntry; sourceEntry: LockfileSourceEntry }
+  | { ok: false; reason: string };
+
+/**
+ * Fetch, validate, and write one profile bundle into one target,
+ * mirroring `install.ts`'s `performRemoteInstall` but sourced from an
+ * already-resolved `RegistrySource` (from `HubManager.listSources`)
+ * rather than a freshly-parsed bundle spec. Never throws.
+ * @param bundleRef Bundle reference from the profile.
+ * @param sources Sources configured on the profile's hub, keyed by source id.
+ * @param target Target to write into.
+ * @param writer Writer for this target (from `createWriterFactory`).
+ * @param http HTTP client.
+ * @param tokens Token provider.
+ * @param ctx CLI context.
+ * @returns The written files and lockfile entries on success, or a failure reason.
+ */
+async function activateBundleForTarget(
+  bundleRef: HubProfileBundle,
+  sources: Record<string, RegistrySource>,
+  target: Target,
+  writer: TargetWriter,
+  http: HttpClient,
+  tokens: TokenProvider,
+  ctx: Context
+): Promise<ActivateBundleOutcome> {
+  const src = sources[bundleRef.source];
+  if (!src) {
+    return { ok: false, reason: `source "${bundleRef.source}" not found in hub` };
+  }
+  const sourceEntry: LockfileSourceEntry = {
+    type: src.type,
+    url: src.url,
+    ...(src.config?.branch ? { branch: src.config.branch } : {}),
+    ...(src.config?.collectionsPath ? { collectionsPath: src.config.collectionsPath } : {})
+  };
+  // `fetchFilesForSource` only reads `.version`/`.sourceId` off this
+  // parameter — the rest are dummy values to satisfy `LockfileBundleEntry`'s
+  // shape without fabricating a fake install history.
+  const probeEntry: LockfileBundleEntry = {
+    version: bundleRef.version,
+    sourceId: src.id,
+    sourceType: src.type,
+    installedAt: '',
+    files: []
+  };
+  try {
+    const files = await fetchFilesForSource(sourceEntry, bundleRef.id, probeEntry, http, tokens, ctx, false);
+    if (files === null) {
+      return { ok: false, reason: 'failed to fetch bundle files' };
+    }
+    const manifest = validateManifest(files, {
+      expectedId: bundleRef.id,
+      expectedVersion: bundleRef.version === 'latest' ? undefined : bundleRef.version
+    });
+    const result = await writer.write(target, files);
+    const entry: LockfileBundleEntry = {
+      version: manifest.version,
+      sourceId: src.id,
+      sourceType: src.type,
+      installedAt: new Date().toISOString(),
+      files: checksumFiles(files)
+    };
+    if (target.scope === 'repository') {
+      entry.commitMode = target.commitMode ?? 'commit';
+    }
+    return { ok: true, written: result.written, entry, sourceEntry };
+  } catch (err) {
+    return { ok: false, reason: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+/**
+ * Remove every bundle recorded in a profile activation state from every
+ * given target — the inverse of the activate loop below. Mirrors
+ * `uninstall.ts`'s `performBundleUninstall` scope routing (repository
+ * scope via `UninstallPipeline`, everything else via
+ * `runUserScopeUninstall`), looped over every synced bundle. Best-effort:
+ * a bundle missing from a given target's lockfile is silently skipped
+ * (it was never written there).
+ * @param ctx CLI context.
+ * @param state Activation state recording which bundles were synced.
+ * @param targets Targets to remove the profile's bundles from.
+ */
+async function deactivateProfileBundles(ctx: Context, state: ProfileActivationState, targets: Target[]): Promise<void> {
+  for (const target of targets) {
+    if (target.scope === 'repository') {
+      const pipeline = new UninstallPipeline({
+        fs: ctx.fs,
+        target,
+        repositoryPath: target.rootPath ?? ctx.cwd(),
+        writerFactory: createUninstallWriterFactory(ctx, {})
+      });
+      for (const bundleId of state.syncedBundles) {
+        try {
+          await pipeline.run(bundleId);
+        } catch {
+          // Best-effort cleanup.
+        }
+      }
+    } else {
+      const lockPath = lockfilePathForTarget(ctx, target);
+      const writer = createUninstallWriterFactory(ctx, {})(target);
+      for (const bundleId of state.syncedBundles) {
+        try {
+          await runUserScopeUninstall(bundleId, lockPath, target, ctx, writer);
+        } catch {
+          // Best-effort cleanup.
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Result of {@link runProfileActivation}.
+ */
+export interface ProfileActivationResult {
+  state: ProfileActivationState;
+  written: Record<string, string[]>;
+  failures: { bundleId: string; target: string; reason: string }[];
+}
+
+/**
+ * Deactivate whatever profile(s) were previously active, then fetch and
+ * write every bundle in `profile` to every target, updating each
+ * target's lockfile and the shared `ProfileActivationStore`. Shared by
+ * `ProfileActivateCommand` and `apply.ts` (`apply` is, in effect,
+ * "re-activate whatever profile is currently active").
+ * @param ctx CLI context.
+ * @param built HubManager + activation store + HTTP/token deps (from `buildHubMgr`).
+ * @param hubId Hub the profile belongs to.
+ * @param profile Profile to activate.
+ * @param targets Targets to activate the profile on.
+ * @returns The new activation state plus per-target written files and per-bundle failures.
+ */
+export async function runProfileActivation(
+  ctx: Context,
+  built: BuiltHubMgr,
+  hubId: string,
+  profile: HubProfile,
+  targets: Target[]
+): Promise<ProfileActivationResult> {
+  // Enforce a single globally-active profile: deactivate whatever was
+  // previously active (if anything) before installing the new one.
+  const previouslyActive = await built.activations.listAll();
+  for (const prev of previouslyActive) {
+    await deactivateProfileBundles(ctx, prev, targets);
+    await built.activations.delete(prev.hubId, prev.profileId);
+    const prevActiveHub = await built.mgr.getActiveHub();
+    if (prevActiveHub?.id === prev.hubId) {
+      const prevProfile = prevActiveHub.config.profiles.find((p) => p.id === prev.profileId);
+      if (prevProfile) {
+        await built.mgr.addProfile(prev.hubId, { ...prevProfile, active: false, updatedAt: new Date().toISOString() });
+      }
+    }
+  }
+
+  const sources = Object.fromEntries((await built.mgr.listSources(hubId)).map((s) => [s.id, s]));
+  const syncedBundles: string[] = [];
+  const syncedBundleVersions: Record<string, string> = {};
+  const failures: { bundleId: string; target: string; reason: string }[] = [];
+  const writtenByTarget: Record<string, string[]> = {};
+
+  for (const target of targets) {
+    const writer = createWriterFactory(ctx, {})(target);
+    const written: string[] = [];
+    const lockPath = lockfilePathForTarget(ctx, target);
+    let lock: Lockfile = await readLockfile(lockPath, ctx.fs) ?? emptyLockfile('ai-primitives-hub-cli');
+
+    for (const bundleRef of profile.bundles) {
+      const outcome = await activateBundleForTarget(bundleRef, sources, target, writer, built.http, built.tokens, ctx);
+      if (!outcome.ok) {
+        failures.push({ bundleId: bundleRef.id, target: target.name, reason: outcome.reason });
+        continue;
+      }
+      written.push(...outcome.written);
+      lock = upsertBundleEntry(lock, bundleRef.id, outcome.entry);
+      lock = upsertSource(lock, outcome.entry.sourceId, outcome.sourceEntry);
+      syncedBundleVersions[bundleRef.id] = outcome.entry.version;
+      if (!syncedBundles.includes(bundleRef.id)) {
+        syncedBundles.push(bundleRef.id);
+      }
+    }
+    await writeLockfile(lockPath, lock, ctx.fs);
+    writtenByTarget[target.name] = written;
+  }
+
+  const state: ProfileActivationState = {
+    hubId,
+    profileId: profile.id,
+    activatedAt: new Date().toISOString(),
+    syncedBundles,
+    syncedBundleVersions
+  };
+  await built.activations.save(hubId, profile.id, state);
+  await built.mgr.addProfile(hubId, { ...profile, active: true, updatedAt: new Date().toISOString() });
+
+  return { state, written: writtenByTarget, failures };
+}
+
+/**
+ * profile activate - activate a profile
+ */
+export class ProfileActivateCommand extends BaseProfileCommand {
+  public static readonly paths = [['profile', 'activate']];
+  public static readonly usage = Command.Usage({
+    description: 'Activate a profile on configured targets.',
+    category: 'Hub & Discovery',
+    details: `
+      Usage: ai-primitives-hub profile activate <profile-id> [options]
+
+      Options:
+        --hub <hub-id>           Hub ID containing the profile
+        --target <name>          Comma-separated target names to limit activation
+        --dry-run                Preview changes without applying
+        -o, --output <format>     Output format (text, json, yaml, ndjson)
+
+      Examples:
+        ai-primitives-hub profile activate default
+        ai-primitives-hub profile activate default --target vscode
+        ai-primitives-hub profile activate default --dry-run
+    `
+  });
+
+  public profileId = Option.String({ required: false });
+  public targets = Option.String('--target');
+  public dryRun = Option.Boolean('--dry-run', false);
+
+  public async execute() {
+    const { ctx, http, tokens } = this.commandContext;
+    const fmt = (this.output ?? 'text') as OutputFormat;
+    const built = buildHubMgr(ctx, http, tokens);
+
+    if (!this.profileId) {
+      return failWith(ctx, fmt, 'profile', new RegistryError({
+        code: 'USAGE.MISSING_FLAG',
+        message: 'profile activate: <profileId> required',
+        hint: 'Run `ai-primitives-hub profile list` to see available profile IDs.'
+      }));
+    }
+
+    let hubId: string;
+    try {
+      hubId = await resolveHubId(built.mgr, this.hubId);
+    } catch (err) {
+      if (err instanceof RegistryError) {
+        return failWith(ctx, fmt, 'profile', err);
+      }
+      throw err;
+    }
+
+    const active = await requireActiveHubOrFail(built.mgr, hubId, 'profile.activate', ctx, fmt);
+    if (typeof active === 'number') {
+      return active;
+    }
+    const profile = active.config.profiles.find((p) => p.id === this.profileId);
+    if (profile === undefined) {
+      return failWith(ctx, fmt, 'profile', new RegistryError({
+        code: 'BUNDLE.NOT_FOUND',
+        message: `profile activate: "${this.profileId}" not in hub "${hubId}"`,
+        hint: 'Run `ai-primitives-hub profile list` to see available profiles.'
+      }));
+    }
+
+    let targets = await loadTargets(ctx);
+    if (this.targets) {
+      const wanted = new Set(this.targets.split(',').map((s) => s.trim()).filter((s) => s.length > 0));
+      targets = targets.filter((t) => wanted.has(t.name));
+    }
+    if (targets.length === 0) {
+      return failWith(ctx, fmt, 'profile', new RegistryError({
+        code: 'USAGE.MISSING_FLAG',
+        message: 'profile activate: no targets configured',
+        hint: 'Run `ai-primitives-hub target add <name> --type <type>` to configure a target.'
+      }));
+    }
+
+    if (this.dryRun) {
+      formatOutput({
+        ctx, command: 'profile.activate', output: fmt, status: 'ok',
+        data: {
+          dryRun: true,
+          hubId,
+          profileId: profile.id,
+          profileName: profile.name,
+          bundles: profile.bundles.map((b) => b.id),
+          targets: targets.map((t) => t.name)
+        },
+        textRenderer: (d) => `[dry-run] Would activate profile "${d.profileId}" from hub "${d.hubId}":\n`
+          + `  Bundles: ${d.bundles.join(', ')}\n`
+          + `  Targets: ${d.targets.join(', ')}\n`
+          + 'Run without --dry-run to apply.\n'
+      });
+      return 0;
+    }
+
+    const { state, written, failures } = await runProfileActivation(ctx, built, hubId, profile, targets);
+
+    const status = failures.length === 0 ? 'ok' : 'warning';
+    formatOutput({
+      ctx, command: 'profile.activate', output: fmt, status,
+      data: { hubId, profileId: profile.id, state, written, failures },
+      warnings: failures.length > 0 ? failures.map((f) => `${f.bundleId} (${f.target}): ${f.reason}`) : undefined,
+      textRenderer: (d) => `Activated profile "${d.profileId}" from hub "${d.hubId}":\n`
+        + `  Bundles: ${[...new Set(d.state.syncedBundles)].join(', ')}\n`
+        + `  Targets: ${Object.keys(d.written).join(', ')}\n`
+        + (d.failures.length > 0
+          ? `  Failures:\n${d.failures.map((f) => `    - ${f.bundleId} (${f.target}): ${f.reason}\n`).join('')}`
+          : '')
+    });
+    return failures.length === 0 ? 0 : 1;
+  }
+}
+
+/**
+ * profile deactivate - deactivate the active profile
+ */
+export class ProfileDeactivateCommand extends BaseProfileCommand {
+  public static readonly paths = [['profile', 'deactivate']];
+  public static readonly usage = Command.Usage({
+    description: 'Deactivate the currently active profile.',
+    category: 'Hub & Discovery',
+    details: `
+      Usage: ai-primitives-hub profile deactivate [options]
+
+      Options:
+        --dry-run                Preview changes without applying
+        -o, --output <format>     Output format (text, json, yaml, ndjson)
+
+      Examples:
+        ai-primitives-hub profile deactivate
+        ai-primitives-hub profile deactivate --dry-run
+    `
+  });
+
+  public dryRun = Option.Boolean('--dry-run', false);
+
+  public async execute() {
+    const { ctx, http, tokens } = this.commandContext;
+    const fmt = (this.output ?? 'text') as OutputFormat;
+    const built = buildHubMgr(ctx, http, tokens);
+
+    const allActive = await built.activations.listAll();
+    const cur = allActive[0];
+    if (!cur) {
+      formatOutput({
+        ctx, command: 'profile.deactivate', output: fmt, status: 'ok',
+        data: { deactivated: null },
+        textRenderer: () => 'No active profile.\n'
+      });
+      return 0;
+    }
+
+    if (this.dryRun) {
+      formatOutput({
+        ctx, command: 'profile.deactivate', output: fmt, status: 'ok',
+        data: {
+          dryRun: true,
+          deactivated: { hubId: cur.hubId, profileId: cur.profileId },
+          bundles: cur.syncedBundles
+        },
+        textRenderer: (d) => `[dry-run] Would deactivate profile "${d.deactivated?.profileId}" from hub "${d.deactivated?.hubId}":\n`
+          + `  Bundles: ${d.bundles.join(', ')}\n`
+          + 'Run without --dry-run to apply.\n'
+      });
+      return 0;
+    }
+
+    const targets = await loadTargets(ctx);
+    await deactivateProfileBundles(ctx, cur, targets);
+    await built.activations.delete(cur.hubId, cur.profileId);
+
+    const activeHub = await built.mgr.getActiveHub();
+    if (activeHub?.id === cur.hubId) {
+      const p = activeHub.config.profiles.find((pp) => pp.id === cur.profileId);
+      if (p) {
+        await built.mgr.addProfile(cur.hubId, { ...p, active: false, updatedAt: new Date().toISOString() });
+      }
+    }
+
+    formatOutput({
+      ctx, command: 'profile.deactivate', output: fmt, status: 'ok',
+      data: { deactivated: { hubId: cur.hubId, profileId: cur.profileId } },
+      textRenderer: (d) => `Deactivated profile "${d.deactivated?.profileId}".\n`
+    });
+    return 0;
+  }
+}
+
+/**
+ * profile create - create a new local profile
+ */
+export class ProfileCreateCommand extends BaseProfileCommand {
+  public static readonly paths = [['profile', 'create']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Create a new local profile in the default-local hub.',
+    category: 'Hub & Discovery',
+    details: `
+      Usage: ai-primitives-hub profile create <profile-id> --name <name> [options]
+
+      Examples:
+        ai-primitives-hub profile create my-profile --name "My Profile" --description "A custom profile"
+        ai-primitives-hub profile create dev-tools --name "Dev Tools" --bundles bundle1,bundle2
+
+      Options:
+        --name <name>           Profile display name (required)
+        --description <text>   Profile description
+        --bundles <list>        Comma-separated list of bundle IDs
+        --hub <id>             Hub ID (defaults to default-local)
+    `
+  });
+
+  public profileId = Option.String({ required: false });
+  public name = Option.String('--name');
+  public description = Option.String('--description');
+  public bundles = Option.String('--bundles');
+
+  public async execute() {
+    const { ctx, http, tokens } = this.commandContext;
+    const fmt = (this.output ?? 'text') as OutputFormat;
+    const built = buildHubMgr(ctx, http, tokens);
+    const mgr = built.mgr;
+
+    if (!this.profileId) {
+      return failWith(ctx, fmt, 'profile', new RegistryError({
+        code: 'USAGE.MISSING_FLAG',
+        message: 'profile create: <profile-id> is required'
+      }));
+    }
+
+    if (!this.name) {
+      return failWith(ctx, fmt, 'profile', new RegistryError({
+        code: 'USAGE.MISSING_FLAG',
+        message: 'profile create: --name is required'
+      }));
+    }
+
+    const hubId = this.hubId ?? 'default-local';
+    const bundleList = this.bundles ? this.bundles.split(',').map((b) => b.trim()) : [];
+
+    const profileBundles: HubProfileBundle[] = bundleList.map((bundleId) => ({
+      id: bundleId,
+      version: 'latest',
+      source: hubId,
+      required: false
+    }));
+
+    const now = new Date().toISOString();
+    const profile = await mgr.addProfile(hubId, {
+      id: this.profileId,
+      name: this.name,
+      description: this.description ?? '',
+      icon: '',
+      active: false,
+      createdAt: now,
+      updatedAt: now,
+      bundles: profileBundles
+    });
+
+    formatOutput({
+      ctx, command: 'profile.create', output: fmt, status: 'ok',
+      data: { hubId, profile: { id: profile.id, name: profile.name, bundles: profile.bundles.length } },
+      textRenderer: (d) => `Created profile "${d.profile.id}" in hub "${d.hubId}" with ${String(d.profile.bundles)} bundle${d.profile.bundles === 1 ? '' : 's'}.\n`
+    });
+    return 0;
+  }
+}
+
+const applyBundleRemovals = (bundles: HubProfileBundle[], spec: string): HubProfileBundle[] => {
+  const result = [...bundles];
+  for (const bundleId of spec.split(',').map((b) => b.trim())) {
+    const idx = result.findIndex((b) => b.id === bundleId);
+    if (idx !== -1) {
+      result.splice(idx, 1);
+    }
+  }
+  return result;
+};
+
+const applyBundleAdditions = (bundles: HubProfileBundle[], spec: string, hubId: string): HubProfileBundle[] => {
+  const result = [...bundles];
+  for (const bundleId of spec.split(',').map((b) => b.trim())) {
+    if (!result.some((b) => b.id === bundleId)) {
+      result.push({ id: bundleId, version: 'latest', source: hubId, required: false });
+    }
+  }
+  return result;
+};
+
+/**
+ * profile edit - edit an existing local profile
+ */
+export class ProfileEditCommand extends BaseProfileCommand {
+  public static readonly paths = [['profile', 'edit']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Edit an existing local profile (add/remove bundles, change description).',
+    category: 'Hub & Discovery',
+    details: `
+      Usage: ai-primitives-hub profile edit <profile-id> [options]
+
+      Examples:
+        ai-primitives-hub profile edit my-profile --description "Updated description"
+        ai-primitives-hub profile edit my-profile --add-bundles bundle1,bundle2
+        ai-primitives-hub profile edit my-profile --remove-bundles bundle1,bundle2
+        ai-primitives-hub profile edit my-profile --name "New Name"
+
+      Options:
+        --name <name>           New profile display name
+        --description <text>   New profile description
+        --add-bundles <list>    Comma-separated list of bundle IDs to add
+        --remove-bundles <list> Comma-separated list of bundle IDs to remove
+        --hub <id>             Hub ID (defaults to default-local)
+    `
+  });
+
+  public profileId = Option.String({ required: false });
+  public name = Option.String('--name');
+  public description = Option.String('--description');
+  public addBundles = Option.String('--add-bundles');
+  public removeBundles = Option.String('--remove-bundles');
+
+  public async execute() {
+    const { ctx, http, tokens } = this.commandContext;
+    const fmt = (this.output ?? 'text') as OutputFormat;
+    const built = buildHubMgr(ctx, http, tokens);
+    const mgr = built.mgr;
+
+    if (!this.profileId) {
+      return failWith(ctx, fmt, 'profile', new RegistryError({
+        code: 'USAGE.MISSING_FLAG',
+        message: 'profile edit: <profile-id> is required'
+      }));
+    }
+
+    const hubId = this.hubId ?? 'default-local';
+
+    const hubs = await mgr.listHubs();
+    const hub = hubs.find((h) => h.id === hubId);
+    if (!hub) {
+      return failWith(ctx, fmt, 'profile', new RegistryError({
+        code: 'USAGE.MISSING_FLAG',
+        message: `profile edit: hub "${hubId}" not found`
+      }));
+    }
+
+    const active = await mgr.getActiveHub();
+    const profiles = active?.id === hubId ? active.config.profiles : [];
+    const existingProfile = profiles.find((p) => p.id === this.profileId);
+
+    if (!existingProfile) {
+      return failWith(ctx, fmt, 'profile', new RegistryError({
+        code: 'USAGE.MISSING_FLAG',
+        message: `profile edit: profile "${this.profileId}" not found in hub "${hubId}"`
+      }));
+    }
+
+    let updatedBundles = [...existingProfile.bundles];
+    if (this.removeBundles) {
+      updatedBundles = applyBundleRemovals(updatedBundles, this.removeBundles);
+    }
+    if (this.addBundles) {
+      updatedBundles = applyBundleAdditions(updatedBundles, this.addBundles, hubId);
+    }
+
+    const updatedProfile = await mgr.addProfile(hubId, {
+      ...existingProfile,
+      name: this.name ?? existingProfile.name,
+      description: this.description ?? existingProfile.description,
+      bundles: updatedBundles,
+      updatedAt: new Date().toISOString()
+    });
+
+    formatOutput({
+      ctx, command: 'profile.edit', output: fmt, status: 'ok',
+      data: { hubId, profile: { id: updatedProfile.id, name: updatedProfile.name, bundles: updatedProfile.bundles.length } },
+      textRenderer: (d) => `Updated profile "${d.profile.id}" in hub "${d.hubId}" with ${String(d.profile.bundles)} bundle${d.profile.bundles === 1 ? '' : 's'}.\n`
+    });
+    return 0;
+  }
+}
+
+/**
+ * Shape accepted from a `<profile-id>.profile.yml` file — looser than
+ * `HubProfile` since hand-authored YAML won't set bookkeeping fields.
+ */
+interface ProfileYamlFile {
+  id?: string;
+  name?: string;
+  description?: string;
+  icon?: string;
+  bundles?: HubProfileBundle[];
+}
+
+/**
+ * profile publish - inject a profile into a hub's config
+ */
+export class ProfilePublishCommand extends BaseProfileCommand {
+  public static readonly paths = [['profile', 'publish']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Publish a profile to a hub by injecting it into the hub\'s config.',
+    category: 'Hub & Discovery',
+    details: `
+      Usage: ai-primitives-hub profile publish <profile-id> --hub <hub-id> [--file <path>]
+
+      Examples:
+        ai-primitives-hub profile publish my-profile --hub default-local
+        ai-primitives-hub profile publish my-profile --hub default-local --file ./my-profile.yml
+
+      Options:
+        --hub <id>      Hub ID to publish to (required)
+        --file <path>   Path to profile YAML file (defaults to <profile-id>.profile.yml)
+    `
+  });
+
+  public profileId = Option.String({ required: false });
+  public hubId = Option.String('--hub');
+  public profileFile = Option.String('--file');
+
+  public async execute() {
+    const { ctx, http, tokens } = this.commandContext;
+    const fmt = (this.output ?? 'text') as OutputFormat;
+    const built = buildHubMgr(ctx, http, tokens);
+    const mgr = built.mgr;
+
+    if (!this.profileId) {
+      return failWith(ctx, fmt, 'profile', new RegistryError({
+        code: 'USAGE.MISSING_FLAG',
+        message: 'profile publish: <profile-id> is required',
+        hint: 'Run `ai-primitives-hub profile publish <id> --hub <hub-id>`'
+      }));
+    }
+
+    if (!this.hubId) {
+      return failWith(ctx, fmt, 'profile', new RegistryError({
+        code: 'USAGE.MISSING_FLAG',
+        message: 'profile publish: --hub <id> is required',
+        hint: 'Run `ai-primitives-hub hub list` to see available hubs.'
+      }));
+    }
+
+    const profilePath = this.profileFile ?? path.join(ctx.cwd(), `${this.profileId}.profile.yml`);
+    if (!(await ctx.fs.exists(profilePath))) {
+      return failWith(ctx, fmt, 'profile', new RegistryError({
+        code: 'FS.NOT_FOUND',
+        message: `Profile file not found: ${profilePath}`,
+        hint: 'Export a profile first or provide --file <path>.'
+      }));
+    }
+
+    const profileYaml = await ctx.fs.readFile(profilePath);
+    const parsed = yaml.load(profileYaml) as ProfileYamlFile | undefined;
+    if (!parsed || typeof parsed !== 'object') {
+      return failWith(ctx, fmt, 'profile', new RegistryError({
+        code: 'PROFILE.INVALID_YAML',
+        message: 'Profile YAML is invalid or empty'
+      }));
+    }
+
+    const hubs = await mgr.listHubs();
+    if (!hubs.some((h) => h.id === this.hubId)) {
+      return failWith(ctx, fmt, 'profile', new RegistryError({
+        code: 'HUB.NOT_FOUND',
+        message: `Hub "${this.hubId}" not found`,
+        hint: 'Run `ai-primitives-hub hub list` to see available hubs.'
+      }));
+    }
+
+    const now = new Date().toISOString();
+    await mgr.addProfile(this.hubId, {
+      id: parsed.id ?? this.profileId,
+      name: parsed.name ?? this.profileId,
+      description: parsed.description ?? '',
+      icon: parsed.icon ?? '',
+      active: false,
+      createdAt: now,
+      updatedAt: now,
+      bundles: parsed.bundles ?? []
+    });
+
+    formatOutput({
+      ctx, command: 'profile.publish', output: fmt, status: 'ok',
+      data: { profileId: this.profileId, hubId: this.hubId },
+      textRenderer: (d) => `Published profile "${d.profileId}" to hub "${d.hubId}".\n`
+    });
+    return 0;
+  }
+}

--- a/packages/cli/src/commands/prompt-create.ts
+++ b/packages/cli/src/commands/prompt-create.ts
@@ -1,0 +1,161 @@
+/**
+ * `prompt create` subcommand.
+ *
+ * Creates a new prompt file with proper structure using templates.
+ *
+ * Usage:
+ *   ai-primitives-hub prompt create hello \
+ *     --description "A greeting prompt"
+ * @module commands/prompt-create
+ */
+import * as path from 'node:path';
+import {
+  readCollection,
+  writeCollection,
+} from '@ai-primitives-hub/app';
+import {
+  generateSanitizedId,
+  TemplateContext,
+} from '@ai-primitives-hub/core';
+import type {
+  CollectionItem,
+} from '@ai-primitives-hub/core';
+import {
+  TEMPLATE_PATHS,
+  TemplateEngine,
+} from '@ai-primitives-hub/infra';
+import {
+  Command,
+  type Context,
+  formatOutput,
+  Option,
+  type OutputFormat,
+  RegistryError,
+  renderError,
+} from '../framework';
+
+/**
+ * Prompt create command class.
+ */
+export class PromptCreateCommand extends Command {
+  public static readonly paths = [['prompt', 'create']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Create a new prompt file',
+    category: 'Primitive',
+    details: `
+      Usage: ai-primitives-hub prompt create <name> [options]
+
+      Options:
+        --description <text>   Prompt description
+        --path <dir>           Output directory (default: prompts/)
+        -o, --output <format>  Output format (text, json, yaml, ndjson)
+
+      Examples:
+        ai-primitives-hub prompt create hello
+        ai-primitives-hub prompt create hello --description "A greeting prompt"
+    `
+  });
+
+  public name = Option.String({ required: true });
+  public description = Option.String('--description');
+  public collection = Option.String('--collection');
+  public pathOption = Option.String('--path');
+  public output = Option.String('-o', '--output') as OutputFormat | undefined;
+  public commandContext!: { ctx: Context };
+
+  public async execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+    const fmt = (this.output ?? 'text');
+
+    try {
+      // Determine prompt name
+      const promptName = generateSanitizedId(this.name);
+      const displayName = this.name;
+
+      // Build template context
+      const context: TemplateContext = {
+        projectName: promptName,
+        collectionId: promptName,
+        name: displayName,
+        description: this.description || `A ${displayName} prompt`
+      };
+
+      // Determine output path
+      const outputPath = this.pathOption || 'prompts';
+      const targetPath = path.isAbsolute(outputPath) ? outputPath : path.join(ctx.cwd(), outputPath);
+
+      // Initialize template engine
+      const templateEngine = new TemplateEngine(TEMPLATE_PATHS.prompt);
+
+      // Scaffold the prompt
+      const result = await templateEngine.scaffoldProject(targetPath, context);
+
+      if (!result.success) {
+        const err = new RegistryError({
+          code: 'FS.SCAFFOLD_FAILED',
+          message: result.error || 'Scaffolding failed'
+        });
+        renderError(err, ctx);
+        return 1;
+      }
+
+      // Add to collection if specified
+      if (this.collection) {
+        const collectionId = this.collection;
+        const collectionFile = path.join(ctx.cwd(), 'collections', `${collectionId}.collection.yml`);
+
+        try {
+          const collection = readCollection(ctx.cwd(), collectionFile);
+
+          // Calculate repo-root relative path
+          const createdFile = result.createdFiles[0];
+          const relativePath = path.relative(ctx.cwd(), createdFile).replace(/\\/g, '/');
+
+          // Add item to collection
+          const newItem: CollectionItem = {
+            path: relativePath,
+            kind: 'prompt',
+            name: displayName,
+            description: this.description
+          };
+
+          collection.items.push(newItem);
+          writeCollection(ctx.cwd(), collectionFile, collection);
+        } catch (error) {
+          const err = new RegistryError({
+            code: 'FS.COLLECTION_UPDATE_FAILED',
+            message: `Failed to add prompt to collection: ${(error as Error).message}`
+          });
+          renderError(err, ctx);
+          return 1;
+        }
+      }
+
+      // Format output
+      formatOutput({
+        ctx,
+        command: 'prompt create',
+        output: fmt,
+        status: 'ok',
+        data: {
+          name: promptName,
+          path: result.createdFiles[0],
+          createdFiles: result.createdFiles,
+          collection: this.collection
+        }
+      });
+      return 0;
+    } catch (error) {
+      const registryError = error instanceof RegistryError
+        ? error
+        : new RegistryError({
+          code: 'INTERNAL.UNEXPECTED',
+          message: (error as Error).message
+        });
+
+      renderError(registryError, ctx);
+      return 1;
+    }
+  }
+}

--- a/packages/cli/src/commands/skill-create.ts
+++ b/packages/cli/src/commands/skill-create.ts
@@ -1,0 +1,164 @@
+/**
+ * `skill create` subcommand.
+ *
+ * Creates a new skill directory with SKILL.md using templates.
+ *
+ * Usage:
+ *   ai-primitives-hub skill create code-review \
+ *     --description "Code review skill"
+ * @module commands/skill-create
+ */
+import * as path from 'node:path';
+import {
+  readCollection,
+  writeCollection,
+} from '@ai-primitives-hub/app';
+import {
+  generateSanitizedId,
+  TemplateContext,
+} from '@ai-primitives-hub/core';
+import type {
+  CollectionItem,
+} from '@ai-primitives-hub/core';
+import {
+  TEMPLATE_PATHS,
+  TemplateEngine,
+} from '@ai-primitives-hub/infra';
+import {
+  Command,
+  type Context,
+  formatOutput,
+  Option,
+  type OutputFormat,
+  RegistryError,
+  renderError,
+} from '../framework';
+
+/**
+ * Skill create command class.
+ */
+export class SkillCreateCommand extends Command {
+  public static readonly paths = [['skill', 'create']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Create a new skill directory',
+    category: 'Primitive',
+    details: `
+      Usage: ai-primitives-hub skill create <name> [options]
+
+      Options:
+        --description <text>   Skill description
+        --author <name>        Author name
+        --path <dir>           Output directory (default: skills/)
+        -o, --output <format>  Output format (text, json, yaml, ndjson)
+
+      Examples:
+        ai-primitives-hub skill create code-review
+        ai-primitives-hub skill create code-review --description "Code review skill"
+    `
+  });
+
+  public name = Option.String({ required: true });
+  public description = Option.String('--description');
+  public author = Option.String('--author');
+  public collection = Option.String('--collection');
+  public pathOption = Option.String('--path');
+  public output = Option.String('-o', '--output') as OutputFormat | undefined;
+  public commandContext!: { ctx: Context };
+
+  public async execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+    const fmt = (this.output ?? 'text');
+
+    try {
+      // Determine skill name
+      const skillName = generateSanitizedId(this.name);
+      const displayName = this.name;
+
+      // Build template context
+      const context: TemplateContext = {
+        projectName: skillName,
+        collectionId: skillName,
+        name: displayName,
+        description: this.description || `A ${displayName} skill`,
+        author: this.author || process.env.USER || 'Your Name'
+      };
+
+      // Determine output path
+      const outputPath = this.pathOption || 'skills';
+      const targetPath = path.isAbsolute(outputPath) ? outputPath : path.join(ctx.cwd(), outputPath);
+
+      // Initialize template engine
+      const templateEngine = new TemplateEngine(TEMPLATE_PATHS.skill);
+
+      // Scaffold the skill
+      const result = await templateEngine.scaffoldProject(targetPath, context);
+
+      if (!result.success) {
+        const err = new RegistryError({
+          code: 'FS.SCAFFOLD_FAILED',
+          message: result.error || 'Scaffolding failed'
+        });
+        renderError(err, ctx);
+        return 1;
+      }
+
+      // Add to collection if specified
+      if (this.collection) {
+        const collectionId = this.collection;
+        const collectionFile = path.join(ctx.cwd(), 'collections', `${collectionId}.collection.yml`);
+
+        try {
+          const collection = readCollection(ctx.cwd(), collectionFile);
+
+          // Calculate repo-root relative path
+          const createdFile = result.createdFiles[0];
+          const relativePath = path.relative(ctx.cwd(), createdFile).replace(/\\/g, '/');
+
+          // Add item to collection
+          const newItem: CollectionItem = {
+            path: relativePath,
+            kind: 'skill',
+            name: displayName,
+            description: this.description
+          };
+
+          collection.items.push(newItem);
+          writeCollection(ctx.cwd(), collectionFile, collection);
+        } catch (error) {
+          const err = new RegistryError({
+            code: 'FS.COLLECTION_UPDATE_FAILED',
+            message: `Failed to add skill to collection: ${(error as Error).message}`
+          });
+          renderError(err, ctx);
+          return 1;
+        }
+      }
+
+      // Format output
+      formatOutput({
+        ctx,
+        command: 'skill create',
+        output: fmt,
+        status: 'ok',
+        data: {
+          name: skillName,
+          path: result.createdFiles[0],
+          createdFiles: result.createdFiles,
+          collection: this.collection
+        }
+      });
+      return 0;
+    } catch (error) {
+      const registryError = error instanceof RegistryError
+        ? error
+        : new RegistryError({
+          code: 'INTERNAL.UNEXPECTED',
+          message: (error as Error).message
+        });
+
+      renderError(registryError, ctx);
+      return 1;
+    }
+  }
+}

--- a/packages/cli/src/commands/skill-new.ts
+++ b/packages/cli/src/commands/skill-new.ts
@@ -1,0 +1,117 @@
+/**
+ * `skill new` subcommand.
+ *
+ * Creates a new skill folder under `<cwd>/<skillsDir>/<skillName>/`
+ * containing a populated `SKILL.md`.
+ *
+ * Non-interactive only — an interactive wizard (via `inquirer`, with the
+ * prompt stream injected through `Context.stdin`/`stdout`) is a possible
+ * future follow-up, not implemented here (matches the reference branch's
+ * own deferred state for this command).
+ * @module commands/skill-new
+ */
+import {
+  createSkill,
+} from '@ai-primitives-hub/app';
+import {
+  Command,
+  type Context,
+  formatOutput,
+  Option,
+  type OutputFormat,
+  RegistryError,
+  renderError,
+} from '../framework';
+
+interface SkillNewData {
+  skillName: string;
+  path: string;
+}
+
+/**
+ * Classify a `createSkill` failure reason into a `RegistryError` code.
+ * @param msg Failure message from `createSkill`.
+ * @returns Error code.
+ */
+const classifyError = (msg: string): string => {
+  if (msg.includes('already exists')) {
+    return 'PRIMITIVE.ALREADY_EXISTS';
+  }
+  if (msg.toLowerCase().includes('invalid')) {
+    return 'PRIMITIVE.INVALID_NAME';
+  }
+  return 'PRIMITIVE.CREATE_FAILED';
+};
+
+/**
+ * Emit error in appropriate format.
+ * @param ctx CLI context.
+ * @param output Output format.
+ * @param err Registry error.
+ */
+const emitError = (ctx: Context, output: OutputFormat, err: RegistryError): void => {
+  if (output === 'json' || output === 'yaml' || output === 'ndjson') {
+    formatOutput({
+      ctx,
+      command: 'skill.new',
+      output,
+      status: 'error',
+      data: null,
+      errors: [err.toJSON()]
+    });
+  } else {
+    renderError(err, ctx);
+  }
+};
+
+/**
+ * Skill new command class.
+ */
+export class SkillNewCommand extends Command {
+  public static readonly paths = [['skill', 'new']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Create a new agent skill folder + SKILL.md template.',
+    category: 'Build & Author',
+    details: `
+      Usage: ai-primitives-hub skill new [options]
+
+      Options:
+        -o, --output <format>       Output format (text, json, yaml, ndjson)
+        --skill-name <name>         Skill name (required)
+        --description <desc>        Description for SKILL.md (required)
+        --skills-dir <dir>          Skills directory (default: skills)
+    `
+  });
+
+  public output = Option.String('-o', '--output') as OutputFormat | undefined;
+  public skillName = Option.String('--skill-name');
+  public description = Option.String('--description');
+  public skillsDir = Option.String('--skills-dir');
+  public commandContext!: { ctx: Context };
+
+  public execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+    const fmt = (this.output ?? 'text');
+    const cwd = ctx.cwd();
+    const result = createSkill(cwd, this.skillName ?? '', this.description ?? '', this.skillsDir ?? 'skills');
+    if (!result.success) {
+      const err = new RegistryError({
+        code: classifyError(result.error ?? 'unknown error'),
+        message: result.error ?? 'createSkill failed',
+        context: { skillName: this.skillName, path: result.path }
+      });
+      emitError(ctx, fmt, err);
+      return Promise.resolve(1);
+    }
+    formatOutput({
+      ctx,
+      command: 'skill.new',
+      output: fmt,
+      status: 'ok',
+      data: { skillName: this.skillName ?? '', path: result.path } satisfies SkillNewData,
+      textRenderer: (d) => `Created skill at ${d.path}\n`
+    });
+    return Promise.resolve(0);
+  }
+}

--- a/packages/cli/src/commands/skill-validate.ts
+++ b/packages/cli/src/commands/skill-validate.ts
@@ -1,0 +1,86 @@
+/**
+ * `skill validate` subcommand.
+ *
+ * Wraps `validateAllSkills` from `@ai-primitives-hub/app` and routes the
+ * result through the framework's output formatter.
+ * @module commands/skill-validate
+ */
+import {
+  validateAllSkills,
+} from '@ai-primitives-hub/app';
+import type {
+  AllSkillsValidationResult,
+} from '@ai-primitives-hub/core';
+import {
+  Command,
+  type Context,
+  formatOutput,
+  Option,
+  type OutputFormat,
+} from '../framework';
+
+/**
+ * Render skill validation results as text.
+ * @param d Validation result.
+ * @param verbose Whether to also print each passing skill.
+ * @returns Formatted text output.
+ */
+const renderText = (d: AllSkillsValidationResult, verbose: boolean): string => {
+  const lines: string[] = [`Validated ${d.totalSkills} skill(s): ${d.validSkills} valid, ${d.invalidSkills} invalid`];
+  for (const s of d.skills) {
+    if (!s.valid) {
+      lines.push(`[FAIL] ${s.skillName}: ${s.errors.join('; ')}`);
+    } else if (verbose) {
+      lines.push(`[ OK ] ${s.skillName}`);
+    }
+  }
+  return `${lines.join('\n')}\n`;
+};
+
+/**
+ * Skill validate command class.
+ */
+export class SkillValidateCommand extends Command {
+  public static readonly paths = [['skill', 'validate']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Validate every skill folder under <cwd>/skills/ against the Agent Skills spec.',
+    category: 'Build & Author',
+    details: `
+      Usage: ai-primitives-hub skill validate [options]
+
+      Validates SKILL.md files and folder structure against the Agent Skills specification.
+
+      Options:
+        -o, --output <format>       Output format (text, json, yaml, ndjson)
+        --skills-dir <dir>          Skills directory (default: skills)
+        --verbose                   Print each ok skill in text mode
+
+      Examples:
+        ai-primitives-hub skill validate
+        ai-primitives-hub skill validate --skills-dir my-skills
+        ai-primitives-hub skill validate -o json
+    `
+  });
+
+  public output = Option.String('-o', '--output') as OutputFormat | undefined;
+  public skillsDir = Option.String('--skills-dir');
+  public verbose = Option.Boolean('--verbose', false);
+  public commandContext!: { ctx: Context };
+
+  public execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+    const fmt = this.output ?? 'text';
+    const cwd = ctx.cwd();
+    const result = validateAllSkills(cwd, this.skillsDir ?? 'skills');
+    formatOutput({
+      ctx,
+      command: 'skill.validate',
+      output: fmt,
+      status: result.valid ? 'ok' : 'error',
+      data: result,
+      textRenderer: (d) => renderText(d, this.verbose)
+    });
+    return Promise.resolve(result.valid ? 0 : 1);
+  }
+}

--- a/packages/cli/src/commands/source.ts
+++ b/packages/cli/src/commands/source.ts
@@ -1,0 +1,202 @@
+/**
+ * `source` commands (default-local-hub UX).
+ *
+ * Subcommands:
+ *   source add --type {github|local} --url <ref> [--id <id>] [--name <n>]
+ *                                                     [--enabled true|false]
+ *   source list [--hub <id>]
+ *   source remove <sourceId>
+ */
+import {
+  generateSourceId,
+} from '@ai-primitives-hub/core';
+import type {
+  HttpClient,
+  TokenProvider,
+} from '@ai-primitives-hub/core';
+import {
+  Command,
+  createHubManager,
+  Option,
+} from '../framework';
+import {
+  type Context,
+  formatOutput,
+  type OutputFormat,
+  RegistryError,
+  renderError,
+} from '../framework';
+
+/**
+ * Context passed to source command execute methods.
+ */
+interface SourceCommandContext {
+  ctx: Context;
+  http?: HttpClient;
+  tokens?: TokenProvider;
+}
+
+/**
+ * Base class for source commands with shared context.
+ */
+abstract class BaseSourceCommand extends Command {
+  /**
+   * Get the CLI context. This needs to be set by the CLI entry point.
+   */
+  public commandContext!: SourceCommandContext;
+
+  public output = Option.String('-o,--output');
+}
+
+/**
+ * source add - add a detached source to the default-local hub
+ */
+export class SourceAddCommand extends BaseSourceCommand {
+  public static readonly paths = [['source', 'add']];
+  public static readonly usage = Command.Usage({
+    description: 'Add a detached source to the default-local hub.',
+    category: 'Hub & Discovery',
+    details: `
+      Usage: ai-primitives-hub source add --url <ref> [--type <type>] [--id <id>] [--name <name>]
+
+      Options:
+        --type <type>   Source type: github (default) or local.
+        --url <ref>     GitHub owner/repo or local path.
+        --id <id>       Source ID (defaults to generated ID).
+        --name <name>   Display name (defaults to ID).
+        --enabled       Enable the source (default true).
+
+      Examples:
+        $ ai-primitives-hub source add --url amadeus/copilot-skills
+        $ ai-primitives-hub source add --type local --url ./skills --id local-skills
+    `
+  });
+
+  public sourceType = Option.String('--type');
+  public url = Option.String('--url');
+  public sourceId = Option.String('--id');
+  public name = Option.String('--name');
+  public enabled = Option.Boolean('--enabled');
+
+  public async execute() {
+    const { ctx, http, tokens } = this.commandContext;
+    const fmt = (this.output ?? 'text') as OutputFormat;
+    const mgr = createHubManager({ ctx, http, tokens });
+
+    if (!this.url) {
+      renderError(new RegistryError({
+        code: 'USAGE.MISSING_FLAG',
+        message: 'source add: --url <owner/repo|path> is required'
+      }), ctx);
+      return 1;
+    }
+
+    const type = (this.sourceType ?? 'github') as 'github' | 'local';
+    const id = this.sourceId ?? generateSourceId(type, this.url);
+    const added = await mgr.addDetachedSource({
+      id, name: this.name ?? id, type, url: this.url,
+      enabled: this.enabled ?? true, priority: 0
+    });
+    formatOutput({
+      ctx, command: 'source.add', output: fmt, status: 'ok',
+      data: { source: added },
+      textRenderer: (d) => `Added source "${d.source.id}" (${d.source.type}: ${d.source.url}) to default-local hub.\n`
+    });
+    return 0;
+  }
+}
+
+/**
+ * source list - list sources across all hubs or a specific hub
+ */
+export class SourceListCommand extends BaseSourceCommand {
+  public static readonly paths = [['source', 'list']];
+  public static readonly usage = Command.Usage({
+    description: 'List sources across all hubs or a specific hub.',
+    category: 'Hub & Discovery',
+    details: `
+      Usage: ai-primitives-hub source list [--hub <hub-id>]
+
+      Examples:
+        $ ai-primitives-hub source list
+        $ ai-primitives-hub source list --hub my-hub
+    `
+  });
+
+  public hubId = Option.String('--hub');
+
+  public async execute() {
+    const { ctx, http, tokens } = this.commandContext;
+    const fmt = (this.output ?? 'text') as OutputFormat;
+    const mgr = createHubManager({ ctx, http, tokens });
+
+    try {
+      const sources = (this.hubId && this.hubId.length > 0)
+        ? await mgr.listSources(this.hubId)
+        : await mgr.listSourcesAcrossAllHubs();
+
+      formatOutput({
+        ctx, command: 'source.list', output: fmt, status: 'ok',
+        data: { sources },
+        textRenderer: (d) => d.sources.length === 0
+          ? 'No sources.\n'
+          : d.sources.map((s) => `${String(s.id)}  [${String(s.hubId)}]  ${String(s.type)}: ${String(s.url)}\n`).join('')
+      });
+      return 0;
+    } catch (err) {
+      ctx.stderr.write(`Error in source list: ${err instanceof Error ? err.message : String(err)}\n`);
+      if (err instanceof Error) {
+        ctx.stderr.write(`${err.stack}\n`);
+      }
+      return 1;
+    }
+  }
+}
+
+/**
+ * source remove - remove a detached source from the default-local hub
+ */
+export class SourceRemoveCommand extends BaseSourceCommand {
+  public static readonly paths = [['source', 'remove']];
+  public static readonly usage = Command.Usage({
+    description: 'Remove a detached source from the default-local hub.',
+    category: 'Hub & Discovery',
+    details: `
+      Usage: ai-primitives-hub source remove <source-id>
+
+      Examples:
+        $ ai-primitives-hub source remove local-skills
+    `
+  });
+
+  public sourceId = Option.String();
+
+  public async execute() {
+    const { ctx, http, tokens } = this.commandContext;
+    const fmt = (this.output ?? 'text') as OutputFormat;
+    const mgr = createHubManager({ ctx, http, tokens });
+
+    if (!this.sourceId) {
+      renderError(new RegistryError({
+        code: 'USAGE.MISSING_FLAG',
+        message: 'source remove: <sourceId> required'
+      }), ctx);
+      return 1;
+    }
+
+    const removed = await mgr.removeDetachedSource(this.sourceId);
+    if (!removed) {
+      renderError(new RegistryError({
+        code: 'BUNDLE.NOT_FOUND',
+        message: `source remove: "${this.sourceId}" not in default-local hub`
+      }), ctx);
+      return 1;
+    }
+    formatOutput({
+      ctx, command: 'source.remove', output: fmt, status: 'ok',
+      data: { id: this.sourceId },
+      textRenderer: (d) => `Removed source "${d.id}".\n`
+    });
+    return 0;
+  }
+}

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -1,0 +1,283 @@
+/**
+ * `ai-primitives-hub status` — show current configuration state at a glance.
+ *
+ * Reads targets, active hub, primitive index, and lockfile to produce
+ * a concise dashboard without any network calls. Useful for verifying
+ * that a project is correctly configured before activating profiles.
+ *
+ * Lockfile section reads `app`'s dict-based `Lockfile` (`bundles: Record<bundleId,
+ * LockfileBundleEntry>`, extension-compatible schema) rather than the reference
+ * branch's array-of-entries schema — `LockfileBundleEntry` has no `target` field
+ * since repository-scope entries always write to `.github/` regardless of which
+ * IDE target nominally triggered the install (see `app/stores/json-lockfile-store.ts`).
+ * @module commands/status
+ */
+import {
+  readLockfile,
+  resolveUserConfigPaths,
+} from '@ai-primitives-hub/app';
+import {
+  ActiveHubStore,
+  defaultIndexFile,
+  HubStore,
+  tryLoadIndex,
+} from '@ai-primitives-hub/infra';
+import {
+  Command,
+  type CommandDefinition,
+  type Context,
+  defineCommand,
+  findProjectLockfile,
+  formatOutput,
+  loadTargets,
+  Option,
+  type OutputFormat,
+  RegistryError,
+  renderError,
+  resolveProjectConfigPath,
+} from '../framework';
+
+/** Bundle detail shown in verbose mode. */
+export interface StatusBundle {
+  bundleId: string;
+  bundleVersion: string;
+  installedAt: string;
+}
+
+/** Status data shape returned to callers. */
+export interface StatusData {
+  configPath: string | null;
+  userTargetsPath: string | null;
+  targets: { name: string; type: string; scope: string }[];
+  activeHubId: string | null;
+  hubs: string[];
+  index: { primitives: number; path: string } | null;
+  lockfile: { entries: number; path: string; bundles?: StatusBundle[] } | null;
+}
+
+/**
+ * Build the `status` command using defineCommand (for test compatibility).
+ * @param opts CLI options.
+ * @param opts.output Output format.
+ * @param opts.verbose Whether to include per-bundle details.
+ * @returns CommandDefinition wired to the framework adapter.
+ */
+export const createStatusCommand = (
+  opts: { output?: OutputFormat; verbose?: boolean } = {}
+): CommandDefinition =>
+  defineCommand({
+    path: ['status'],
+    description: 'Show current configuration state: targets, active hub, index, and lockfile.',
+    category: 'Configure & Debug',
+    run: async ({ ctx }: { ctx: Context }): Promise<number> => {
+      return runStatus(ctx, opts.output ?? 'text', opts.verbose ?? false);
+    }
+  });
+
+/**
+ * Status command class.
+ */
+export class StatusCommand extends Command {
+  public static readonly paths = [['status']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Show current configuration state: targets, active hub, index, and lockfile.',
+    category: 'Configure & Debug',
+    details: `
+      Usage: ai-primitives-hub status [options]
+
+      Reads local config files (no network calls) and prints a summary of:
+        - Project config file location (ai-primitives-hub.yml)
+        - Configured targets
+        - Active hub and available hubs
+        - Primitive index size
+        - Installed bundles from lockfile
+
+      Options:
+        -o, --output <format>  Output format (text, json, yaml, ndjson)
+        --verbose               Include per-bundle details from lockfile
+
+      Examples:
+        ai-primitives-hub status
+        ai-primitives-hub status -o json
+        ai-primitives-hub status --verbose
+    `
+  });
+
+  public output = Option.String('-o,--output');
+  public verbose = Option.Boolean('--verbose', false);
+  public commandContext!: { ctx: Context };
+
+  public async execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+    return runStatus(ctx, (this.output ?? 'text') as OutputFormat, this.verbose);
+  }
+}
+
+/**
+ * Core status logic shared by both command variants.
+ * @param ctx CLI context.
+ * @param fmt Output format.
+ * @param verbose Whether to include per-bundle details in the lockfile section.
+ * @returns Exit code.
+ */
+async function runStatus(ctx: Context, fmt: OutputFormat, verbose: boolean): Promise<number> {
+  try {
+    const userPaths = resolveUserConfigPaths(ctx.env);
+
+    const [targets, hubIds, activeHubId, configPath, userTargetsExists] = await Promise.all([
+      loadTargets(ctx),
+      readHubIds(userPaths.hubs, ctx),
+      readActiveHubId(userPaths.activeHub, ctx),
+      resolveProjectConfigPath({ cwd: ctx.cwd(), env: ctx.env, fs: ctx.fs }),
+      ctx.fs.exists(userPaths.userTargets)
+    ]);
+
+    const indexPath = defaultIndexFile(ctx.env);
+    const indexStats = tryLoadIndex(indexPath);
+
+    const lockPath = await findProjectLockfile(ctx);
+    const lockfile = lockPath === null ? null : await readLockfile(lockPath, ctx.fs);
+
+    let lockfileData: StatusData['lockfile'] = null;
+    if (lockfile !== null && lockPath !== null) {
+      const bundleIds = Object.keys(lockfile.bundles);
+      lockfileData = { entries: bundleIds.length, path: lockPath };
+      if (verbose) {
+        lockfileData.bundles = bundleIds.map((bundleId) => ({
+          bundleId,
+          bundleVersion: lockfile.bundles[bundleId].version,
+          installedAt: lockfile.bundles[bundleId].installedAt
+        }));
+      }
+    }
+
+    const data: StatusData = {
+      configPath: configPath ?? null,
+      userTargetsPath: userTargetsExists ? userPaths.userTargets : null,
+      targets: targets.map((t) => ({ name: t.name, type: t.type, scope: t.scope ?? 'user' })),
+      activeHubId,
+      hubs: hubIds,
+      index: indexStats === null
+        ? null
+        : { primitives: indexStats.search({}).total, path: indexPath },
+      lockfile: lockfileData
+    };
+
+    formatOutput({
+      ctx,
+      command: 'status',
+      output: fmt,
+      status: 'ok',
+      data,
+      textRenderer: renderStatusText
+    });
+    return 0;
+  } catch (err) {
+    if (err instanceof RegistryError) {
+      renderError(err, ctx);
+      return 1;
+    }
+    renderError(new RegistryError({
+      code: 'INTERNAL.UNEXPECTED',
+      message: err instanceof Error ? err.message : String(err),
+      cause: err instanceof Error ? err : undefined
+    }), ctx);
+    return 1;
+  }
+}
+
+/**
+ * Read list of hub IDs from the hubs directory.
+ * @param hubsDir Path to hubs directory.
+ * @param ctx CLI context.
+ * @returns Array of hub IDs.
+ */
+async function readHubIds(hubsDir: string, ctx: Context): Promise<string[]> {
+  try {
+    const store = new HubStore(hubsDir, ctx.fs);
+    return await store.list();
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Read the active hub ID pointer.
+ * @param activeHubPath Path to active-hub.json.
+ * @param ctx CLI context.
+ * @returns Active hub ID or null.
+ */
+async function readActiveHubId(activeHubPath: string, ctx: Context): Promise<string | null> {
+  try {
+    const store = new ActiveHubStore(activeHubPath, ctx.fs);
+    return await store.get();
+  } catch {
+    return null;
+  }
+}
+
+function renderConfigLine(configPath: string | null, userTargetsPath: string | null): string {
+  if (configPath !== null) {
+    return `config      ${configPath}\n`;
+  }
+  if (userTargetsPath !== null) {
+    return `config      ${userTargetsPath} (user)\n`;
+  }
+  return 'config      (none — run `ai-primitives-hub init`)\n';
+}
+
+function renderTargetsLine(targets: StatusData['targets']): string {
+  if (targets.length === 0) {
+    return 'targets     (none — run `ai-primitives-hub target add`)\n';
+  }
+  const targetStrings = targets.map((t) => t.name + ' [' + t.type + ']');
+  return 'targets     ' + targetStrings.join(', ') + '\n';
+}
+
+function renderHubLines(activeHubId: string | null, hubs: string[]): string[] {
+  if (activeHubId !== null) {
+    return [`active hub  ${activeHubId}\n`];
+  }
+  if (hubs.length > 0) {
+    return [`active hub  (none — run \`ai-primitives-hub hub use <id>\`)\n`, `hubs        ${hubs.join(', ')}\n`];
+  }
+  return ['active hub  (none — run `ai-primitives-hub hub add <ref>`)\n'];
+}
+
+function renderIndexLine(index: StatusData['index']): string {
+  if (index === null) {
+    return 'index       (none — run `ai-primitives-hub index build`)\n';
+  }
+  return `index       ${index.primitives} primitives  [${index.path}]\n`;
+}
+
+function renderLockfileLines(lockfile: StatusData['lockfile']): string[] {
+  if (lockfile === null) {
+    return ['lockfile    (none)\n'];
+  }
+  const lines: string[] = [`lockfile    ${lockfile.entries} bundle${lockfile.entries === 1 ? '' : 's'} installed  [${lockfile.path}]\n`];
+  if (lockfile.bundles !== undefined && lockfile.bundles.length > 0) {
+    for (const b of lockfile.bundles) {
+      lines.push(`              ${b.bundleId}@${b.bundleVersion}  installed=${b.installedAt}\n`);
+    }
+  }
+  return lines;
+}
+
+/**
+ * Render status as human-readable text.
+ * @param d Status data.
+ * @returns Rendered text.
+ */
+function renderStatusText(d: StatusData): string {
+  return [
+    'ai-primitives-hub status\n',
+    '─'.repeat(40) + '\n',
+    renderConfigLine(d.configPath, d.userTargetsPath),
+    renderTargetsLine(d.targets),
+    ...renderHubLines(d.activeHubId, d.hubs),
+    renderIndexLine(d.index),
+    ...renderLockfileLines(d.lockfile)
+  ].join('');
+}

--- a/packages/cli/src/commands/target-add.ts
+++ b/packages/cli/src/commands/target-add.ts
@@ -1,0 +1,300 @@
+/**
+ * `target add`.
+ *
+ * Wires the persist side: parse + validate input, then
+ * delegate to `addTarget()` from the infra/stores/target-store module.
+ * The command writes to the nearest project config (cargo upward
+ * walk), creating one in `cwd` when none exists.
+ *
+ * Per-type fields are kept minimal at this point: `--scope`, `--path`,
+ * `--allowed-kinds <a,b,c>`. The Target tagged-union admits more
+ * fields in future iterations as target writers grow.
+ * @module commands/target-add
+ */
+import * as path from 'node:path';
+import type {
+  Target,
+  TargetType,
+} from '@ai-primitives-hub/core';
+import {
+  TARGET_TYPES,
+} from '@ai-primitives-hub/core';
+import {
+  addTarget,
+} from '@ai-primitives-hub/infra';
+import {
+  Command,
+  type Context,
+  failWith,
+  formatOutput,
+  Option,
+  type OutputFormat,
+  RegistryError,
+} from '../framework';
+
+/**
+ * Target add command options.
+ */
+interface TargetAddOptions {
+  output?: OutputFormat;
+  /** Target name (required). */
+  name: string;
+  /** Target type (required). */
+  type: string;
+  /** Optional scope override ('user' or 'repository'). */
+  scope?: string;
+  /** Optional path override. */
+  path?: string;
+  /** Optional workspace root for repository scope. */
+  workspaceRoot?: string;
+  /** Optional comma-separated allowed kinds. */
+  allowedKinds?: string;
+}
+
+/** Known target types. */
+const KNOWN_TYPES: ReadonlySet<string> = new Set(TARGET_TYPES);
+
+/**
+ * Validate target name.
+ * @param name Target name.
+ * @returns Registry error if invalid, null otherwise.
+ */
+function validateTargetName(name: string): RegistryError | null {
+  if (name.length === 0) {
+    return new RegistryError({
+      code: 'USAGE.MISSING_FLAG',
+      message: 'target add: missing target name',
+      hint: 'Usage: `ai-primitives-hub target add <name> --type <kind>`'
+    });
+  }
+  return null;
+}
+
+/**
+ * Validate target type.
+ * @param type Target type.
+ * @returns Registry error if invalid, null otherwise.
+ */
+function validateTargetType(type: string): RegistryError | null {
+  if (!KNOWN_TYPES.has(type)) {
+    return new RegistryError({
+      code: 'USAGE.MISSING_FLAG',
+      message: `target add: unknown --type "${type}"`,
+      hint: `Known types: ${[...KNOWN_TYPES].toSorted((a, b) => a.localeCompare(b)).join(', ')}`,
+      context: { type }
+    });
+  }
+  return null;
+}
+
+/**
+ * Normalize target path.
+ * @param targetPath Target path.
+ * @param cwd Current working directory.
+ * @returns Normalized absolute path.
+ */
+function normalizeTargetPath(targetPath: string | undefined, cwd: string): string | undefined {
+  if (targetPath !== undefined && targetPath.length > 0 && !path.isAbsolute(targetPath)) {
+    return path.resolve(cwd, targetPath);
+  }
+  return targetPath;
+}
+
+/**
+ * Ensure target directory exists.
+ * @param fs File system interface.
+ * @param targetPath Target path.
+ */
+async function ensureTargetDirectory(fs: Context['fs'], targetPath: string | undefined): Promise<void> {
+  if (targetPath !== undefined && targetPath.length > 0) {
+    try {
+      await fs.mkdir(targetPath, { recursive: true });
+    } catch {
+      // Permission/ENOSPC etc. — non-fatal at this point;
+      // activation will surface a clearer error later.
+    }
+  }
+}
+
+/**
+ * Validate target inputs.
+ * @param opts Target add options.
+ * @returns Registry error if invalid, null otherwise.
+ */
+function validateTargetInputs(opts: TargetAddOptions): RegistryError | null {
+  const nameError = validateTargetName(opts.name);
+  if (nameError) {
+    return nameError;
+  }
+  const typeError = validateTargetType(opts.type);
+  if (typeError) {
+    return typeError;
+  }
+  return null;
+}
+
+/**
+ * Build target add error from cause.
+ * @param cause Error cause.
+ * @param opts Target add options.
+ * @returns Registry error.
+ */
+function buildTargetAddError(cause: unknown, opts: TargetAddOptions): RegistryError {
+  const message = cause instanceof Error ? cause.message : String(cause);
+  const isDup = message.includes('already exists');
+  return new RegistryError({
+    code: isDup ? 'USAGE.MISSING_FLAG' : 'INTERNAL.UNEXPECTED',
+    message: `target add: ${message}`,
+    hint: isDup
+      ? `Pick a different name, or run \`ai-primitives-hub target remove ${opts.name}\` first.`
+      : 'See `ai-primitives-hub doctor` for environment diagnostics.',
+    context: { name: opts.name, type: opts.type },
+    cause: cause instanceof Error ? cause : undefined
+  });
+}
+
+/**
+ * Parse allowed kinds string.
+ * @param allowedKinds Comma-separated kinds.
+ * @returns Array of kinds.
+ */
+function parseAllowedKinds(allowedKinds: string | undefined): string[] | undefined {
+  if (allowedKinds === undefined || allowedKinds.length === 0) {
+    return undefined;
+  }
+  return allowedKinds.split(',').map((s) => s.trim()).filter((s) => s.length > 0);
+}
+
+/**
+ * Build Copilot CLI target. Always `user`-scoped, regardless of `--scope` —
+ * matches `target types`' documented "GitHub Copilot CLI (user scope)".
+ * @param opts Target add options.
+ * @param type Target type.
+ * @param allowedKinds Allowed kinds.
+ * @returns Target configuration.
+ */
+function buildCopilotCliTarget(opts: TargetAddOptions, type: TargetType, allowedKinds: string[] | undefined): Target {
+  return {
+    name: opts.name,
+    type,
+    scope: 'user',
+    ...(opts.path === undefined ? {} : { path: opts.path }),
+    ...(opts.workspaceRoot === undefined ? {} : { rootPath: opts.workspaceRoot }),
+    ...(allowedKinds === undefined ? {} : { allowedKinds })
+  };
+}
+
+/**
+ * Build standard target.
+ * @param opts Target add options.
+ * @param type Target type.
+ * @param scope Target scope.
+ * @param allowedKinds Allowed kinds.
+ * @returns Target configuration.
+ */
+function buildStandardTarget(opts: TargetAddOptions, type: TargetType, scope: string, allowedKinds: string[] | undefined): Target {
+  return {
+    name: opts.name,
+    type,
+    scope,
+    ...(opts.path === undefined ? {} : { path: opts.path }),
+    ...(opts.workspaceRoot === undefined ? {} : { rootPath: opts.workspaceRoot }),
+    ...(allowedKinds === undefined ? {} : { allowedKinds })
+  } as Target;
+}
+
+/**
+ * Build target from options.
+ * @param opts Target add options.
+ * @returns Target configuration.
+ */
+const buildTarget = (opts: TargetAddOptions): Target => {
+  const type = opts.type as TargetType;
+  const allowedKinds = parseAllowedKinds(opts.allowedKinds);
+  const scope = (opts.scope === 'repository' ? 'repository' : 'user');
+  if (type === 'copilot-cli') {
+    return buildCopilotCliTarget(opts, type, allowedKinds);
+  }
+  return buildStandardTarget(opts, type, scope, allowedKinds);
+};
+
+/**
+ * Target add command class. Accepts positional arguments for name and type.
+ */
+export class TargetAddCommand extends Command {
+  public static readonly paths = [['target', 'add']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Register a new install target.',
+    category: 'Install & Manage',
+    details: `
+      Usage: ai-primitives-hub target add <name> --type <kind> [options]
+
+      Options:
+        --type <type>              Target type (required): vscode, vscode-insiders, copilot-cli, kiro, windsurf, claude-code
+        --scope <scope>            Installation scope: user (default) or repository
+        --path <path>              Custom installation path
+        --workspace-root <dir>     Workspace root for repository scope
+        --allowed-kinds <kinds>    Comma-separated allowed primitive kinds
+        -o, --output <format>     Output format (text, json, yaml, ndjson)
+
+      Examples:
+        ai-primitives-hub target add my-copilot --type copilot-cli
+        ai-primitives-hub target add workspace-prompts --type vscode --scope repository --path .prompts
+    `
+  });
+
+  public name = Option.String();
+  public type = Option.String('--type');
+  public scope = Option.String('--scope');
+  public targetPath = Option.String('--path');
+  public workspaceRoot = Option.String('--workspace-root');
+  public allowedKinds = Option.String('--allowed-kinds');
+  public output = Option.String('-o,--output');
+  public commandContext!: { ctx: Context };
+
+  public async execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+
+    const fmt = (this.output ?? 'text') as OutputFormat;
+
+    const opts: TargetAddOptions = {
+      name: this.name ?? '',
+      type: this.type ?? '',
+      scope: this.scope,
+      path: this.targetPath,
+      workspaceRoot: this.workspaceRoot,
+      allowedKinds: this.allowedKinds,
+      output: fmt
+    };
+
+    const validationError = validateTargetInputs(opts);
+    if (validationError) {
+      return failWith(ctx, fmt, 'target.add', validationError);
+    }
+    const cwd = ctx.cwd();
+    opts.path = normalizeTargetPath(opts.path, cwd);
+    const target = buildTarget(opts);
+    try {
+      const result = await addTarget(
+        { cwd, fs: ctx.fs },
+        target
+      );
+      await ensureTargetDirectory(ctx.fs, target.path);
+      formatOutput({
+        ctx,
+        command: 'target.add',
+        output: fmt,
+        status: 'ok',
+        data: { target, file: result.file, created: result.created },
+        textRenderer: (d) => d.created
+          ? `Created ${d.file} with target "${d.target.name}" (${d.target.type}).\n`
+          : `Added target "${d.target.name}" (${d.target.type}) to ${d.file}.\n`
+      });
+      return 0;
+    } catch (cause) {
+      const error = buildTargetAddError(cause, opts);
+      return failWith(ctx, fmt, 'target.add', error);
+    }
+  }
+}

--- a/packages/cli/src/commands/target-list.ts
+++ b/packages/cli/src/commands/target-list.ts
@@ -1,0 +1,80 @@
+/**
+ * `target list`.
+ *
+ * Lists configured install targets, reading through the hierarchical
+ * target resolution (`framework/target.ts`'s `loadTargets`): project-level
+ * targets when present, falling back to user-level targets otherwise.
+ * @module commands/target-list
+ */
+import type {
+  Target,
+} from '@ai-primitives-hub/core';
+import {
+  Command,
+  type Context,
+  formatOutput,
+  loadTargets,
+  Option,
+  type OutputFormat,
+  renderTable,
+} from '../framework';
+
+/**
+ * Render a target list as a fixed-width text table. Empty list is
+ * rendered as a friendly message that points users at `target add`.
+ * @param targets - Array of Target rows.
+ * @returns Rendered table string (newline-terminated).
+ */
+const renderTargetTable = (targets: Target[]): string =>
+  renderTable<Target>({
+    columns: [
+      { header: 'NAME', get: (t) => t.name },
+      { header: 'TYPE', get: (t) => t.type },
+      { header: 'SCOPE', get: (t) => t.scope },
+      { header: 'PATH', get: (t) => t.path ?? '' },
+      { header: 'ALLOWED-KINDS', get: (t) => t.allowedKinds?.join(',') ?? '' }
+    ],
+    rows: targets,
+    emptyMessage: 'No targets configured.\n'
+      + 'Add one with: `ai-primitives-hub target add <name> --type <vscode|copilot-cli|kiro|windsurf|claude-code>`\n'
+  });
+
+/**
+ * Target list command class.
+ */
+export class TargetListCommand extends Command {
+  public static readonly paths = [['target', 'list']];
+
+  public static readonly usage = Command.Usage({
+    description: 'List configured install targets (vscode, copilot-cli, kiro, …).',
+    category: 'Install & Manage',
+    details: `
+      Usage: ai-primitives-hub target list [options]
+
+      Options:
+        -o, --output <format>  Output format (text, json, yaml, ndjson)
+
+      Examples:
+        ai-primitives-hub target list
+        ai-primitives-hub target list -o json
+    `
+  });
+
+  public output = Option.String('-o,--output');
+  public commandContext!: { ctx: Context };
+
+  public async execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+
+    const targets = await loadTargets(ctx);
+    formatOutput({
+      ctx,
+      command: 'target.list',
+      output: (this.output as OutputFormat) ?? 'text',
+      status: 'ok',
+      data: targets,
+      textRenderer: (d) => renderTargetTable(d)
+    });
+    return 0;
+  }
+}

--- a/packages/cli/src/commands/target-remove.ts
+++ b/packages/cli/src/commands/target-remove.ts
@@ -1,0 +1,87 @@
+/**
+ * `target remove`.
+ *
+ * Wires the persist side: validates the positional name,
+ * delegates to `removeTargetByName()`, and surfaces a not-found
+ * error code distinct from the USAGE.MISSING_FLAG code used for
+ * an empty name.
+ * @module commands/target-remove
+ */
+import {
+  removeTargetByName,
+} from '@ai-primitives-hub/infra';
+import {
+  Command,
+  type Context,
+  failWith,
+  formatOutput,
+  Option,
+  type OutputFormat,
+  RegistryError,
+} from '../framework';
+
+/**
+ * Target remove command class.
+ */
+export class TargetRemoveCommand extends Command {
+  public static readonly paths = [['target', 'remove']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Remove a configured install target.',
+    category: 'Install & Manage',
+    details: `
+      Usage: ai-primitives-hub target remove <name> [options]
+
+      Options:
+        -o, --output <format>  Output format (text, json, yaml, ndjson)
+
+      Examples:
+        ai-primitives-hub target remove my-vscode
+    `
+  });
+
+  public output = Option.String('-o,--output');
+  public name = Option.String();
+  public commandContext!: { ctx: Context };
+
+  public async execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+    const fmt = (this.output ?? 'text') as OutputFormat;
+    const name = this.name ?? '';
+
+    if (name.length === 0) {
+      return failWith(ctx, fmt, 'target.remove', new RegistryError({
+        code: 'USAGE.MISSING_FLAG',
+        message: 'target remove: missing target name',
+        hint: 'Usage: `ai-primitives-hub target remove <name>`'
+      }));
+    }
+    try {
+      const result = await removeTargetByName(
+        { cwd: ctx.cwd(), fs: ctx.fs },
+        name
+      );
+      formatOutput({
+        ctx,
+        command: 'target.remove',
+        output: fmt,
+        status: 'ok',
+        data: { name, file: result.file },
+        textRenderer: (d) => `Removed target "${d.name}" from ${d.file}.\n`
+      });
+      return 0;
+    } catch (cause) {
+      const message = cause instanceof Error ? cause.message : String(cause);
+      const isMissing = message.includes('not found');
+      return failWith(ctx, fmt, 'target.remove', new RegistryError({
+        code: isMissing ? 'USAGE.MISSING_FLAG' : 'INTERNAL.UNEXPECTED',
+        message: `target remove: ${message}`,
+        hint: isMissing
+          ? 'Run `ai-primitives-hub target list` to see configured targets.'
+          : 'See `ai-primitives-hub doctor` for environment diagnostics.',
+        context: { name },
+        cause: cause instanceof Error ? cause : undefined
+      }));
+    }
+  }
+}

--- a/packages/cli/src/commands/target-types.ts
+++ b/packages/cli/src/commands/target-types.ts
@@ -1,0 +1,83 @@
+/**
+ * `target types` command.
+ *
+ * Lists all supported install target types with a human-readable
+ * description. Removes the guessing-game of valid `--type` values
+ * from `target add`.
+ * @module commands/target-types
+ */
+import {
+  TARGET_TYPES,
+} from '@ai-primitives-hub/core';
+import {
+  Command,
+  type Context,
+  formatOutput,
+  Option,
+  type OutputFormat,
+} from '../framework';
+
+/**
+ * Human-readable description for each target type.
+ * @internal
+ */
+const TARGET_DESCRIPTIONS: Record<string, string> = {
+  vscode: 'VS Code (user scope — ~/.config/Code/User/prompts/)',
+  'vscode-insiders': 'VS Code Insiders (user scope — ~/.config/Code - Insiders/User/prompts/)',
+  'copilot-cli': 'GitHub Copilot CLI (user scope — ~/.config/github-copilot/prompts/)',
+  kiro: 'Kiro IDE',
+  windsurf: 'Windsurf IDE (Codeium)',
+  'claude-code': 'Anthropic Claude Code'
+};
+
+/**
+ * Target type entry.
+ */
+export interface TargetTypeEntry {
+  type: string;
+  description: string;
+}
+
+/**
+ * Target types command class.
+ */
+export class TargetTypesCommand extends Command {
+  public static readonly paths = [['target', 'types']];
+
+  public static readonly usage = Command.Usage({
+    description: 'List all supported install target types with descriptions.',
+    category: 'Install & Manage',
+    details: `
+      Usage: ai-primitives-hub target types [-o <format>]
+
+      Examples:
+        $ ai-primitives-hub target types
+        $ ai-primitives-hub target types -o json
+    `
+  });
+
+  public output = Option.String('-o,--output');
+  public commandContext!: { ctx: Context };
+
+  public execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+
+    const data: TargetTypeEntry[] = TARGET_TYPES.map((t) => ({
+      type: t,
+      description: TARGET_DESCRIPTIONS[t] ?? ''
+    }));
+    formatOutput({
+      ctx,
+      command: 'target.types',
+      output: (this.output as OutputFormat) ?? 'text',
+      status: 'ok',
+      data,
+      textRenderer: (d) => [
+        'Supported target types:\n',
+        ...d.map((t) => `  ${t.type.padEnd(22)} ${t.description}\n`),
+        '\nUsage: ai-primitives-hub target add <name> --type <type>\n'
+      ].join('')
+    });
+    return Promise.resolve(0);
+  }
+}

--- a/packages/cli/src/commands/uninstall.ts
+++ b/packages/cli/src/commands/uninstall.ts
@@ -1,0 +1,766 @@
+/**
+ * Uninstall command for removing bundles from targets.
+ *
+ * Symmetric to install: supports three modes:
+ *   ai-primitives-hub uninstall <bundle-id>        (by bundle ID)
+ *   ai-primitives-hub uninstall --lockfile <path>  (from lockfile)
+ *   ai-primitives-hub uninstall --all              (all bundles for target)
+ *
+ * Repository-scope targets delegate to `UninstallPipeline`
+ * (`@ai-primitives-hub/app`), which already encapsulates the
+ * commit/local-only two-file split (see its module doc). User/workspace
+ * scope has no such split — there is a single, non-split
+ * `resolveUserConfigPaths(env).userLockfile` — so those targets are
+ * handled inline here with the same `readLockfile`/`removeBundleEntry`/
+ * `writeLockfile` primitives `install.ts` uses to write it.
+ */
+import * as path from 'node:path';
+import {
+  cleanupOrphanedSource,
+  FileTreeTargetWriter,
+  type LockfileBundleEntry,
+  readLockfile,
+  removeBundleEntry,
+  type TargetWriter,
+  TransformerRegistry,
+  UninstallPipeline,
+  type UninstallResult,
+  writeLockfile,
+} from '@ai-primitives-hub/app';
+import type {
+  Target,
+} from '@ai-primitives-hub/core';
+import {
+  FileSystemLayoutConfigLoader,
+  readTargets,
+  type RepositoryCommitMode,
+  RepositoryScopeWriter,
+  RepositoryScopeWriterAdapter,
+  resolveUserConfigDir,
+  TargetStateStore,
+} from '@ai-primitives-hub/infra';
+import {
+  Command,
+  failWith,
+  findProjectLockfile,
+  loadTargets,
+  lockfilePathForTarget,
+  Option,
+} from '../framework';
+import {
+  type CommandDefinition,
+  type Context,
+  defineCommand,
+  formatOutput,
+  type OutputFormat,
+  readTargetsSafely,
+  RegistryError,
+  resolveTarget,
+  resolveTargetName,
+  validateInputs,
+} from '../framework';
+
+/**
+ * Uninstall command options.
+ */
+export interface UninstallOptions {
+  output?: OutputFormat;
+  /** Bundle id to uninstall (imperative mode). */
+  bundle?: string;
+  /** Lockfile path (declarative mode). */
+  lockfile?: string;
+  /** Target name (resolved against `targets[]` in config). */
+  target?: string;
+  /** Uninstall all bundles for target. */
+  all?: boolean;
+  /** Dry-run: preview removal without deleting files. */
+  dryRun?: boolean;
+  /**
+   * Installation scope (user or repository).
+   * Overrides target's scope if specified.
+   */
+  scope?: 'user' | 'repository';
+  /**
+   * Commit mode for repository scope.
+   * Only applies when scope=repository.
+   */
+  commitMode?: RepositoryCommitMode;
+}
+
+/**
+ * Detect uninstall context from the project environment (symmetric with install).
+ * Fills in `opts.lockfile` and `opts.target` when they can be inferred.
+ * @param opts Uninstall options (mutated in-place).
+ * @param ctx CLI context.
+ */
+async function detectUninstallContext(opts: UninstallOptions, ctx: Context): Promise<void> {
+  if (!opts.bundle && !opts.lockfile && !opts.all) {
+    const foundLock = await findProjectLockfile(ctx);
+    if (foundLock !== null) {
+      opts.lockfile = foundLock;
+    }
+  }
+
+  if (!opts.target || opts.target.length === 0) {
+    const targets = await readTargetsSafely(
+      loadTargets(ctx)
+    );
+    if (targets.length === 1) {
+      opts.target = targets[0].name;
+    }
+  }
+}
+
+/**
+ * Command context for the uninstall command.
+ */
+interface CommandContext {
+  ctx: Context;
+}
+
+/**
+ * Base class for the uninstall command.
+ */
+abstract class BaseUninstallCommand extends Command {
+  public commandContext: CommandContext = { ctx: null as unknown as Context };
+  public output?: OutputFormat;
+}
+
+/**
+ * Native clipanion class command for uninstall.
+ */
+export class UninstallCommand extends BaseUninstallCommand {
+  public static readonly paths = [['uninstall']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Remove bundles from a configured target.',
+    category: 'Install & Manage',
+    details: `
+      Usage: ai-primitives-hub uninstall [options]
+
+      Options:
+        --bundle <id>          Bundle id to uninstall
+        --lockfile <path>      Path to a lockfile for declarative uninstallation
+        --target <name>        Target name to uninstall from
+        --all                  Remove all bundles for target
+        --dry-run              Preview removal without deleting files
+        --scope <scope>        Installation scope (user or repository)
+        --commit-mode <mode>   Commit mode for repository scope
+        -o, --output <format> Output format (text, json, yaml, ndjson)
+
+      Examples:
+        ai-primitives-hub uninstall --lockfile prompt-registry.lock.json --target my-vscode
+        ai-primitives-hub uninstall --all --target my-vscode
+        ai-primitives-hub uninstall --dry-run --target my-vscode
+    `
+  });
+
+  public output = Option.String('-o', '--output') as OutputFormat | undefined;
+  public bundle = Option.String('--bundle');
+  public lockfile = Option.String('--lockfile');
+  public target = Option.String('--target');
+  public all = Option.Boolean('--all');
+  public dryRun = Option.Boolean('--dry-run');
+  public scope = Option.String('--scope');
+  public commitMode = Option.String('--commit-mode');
+
+  public async execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+    const fmt = (this.output ?? 'text');
+
+    const opts: UninstallOptions = {
+      output: fmt,
+      bundle: this.bundle,
+      lockfile: this.lockfile,
+      target: this.target,
+      all: this.all,
+      dryRun: this.dryRun,
+      scope: this.scope as 'user' | 'repository' | undefined,
+      commitMode: this.commitMode as RepositoryCommitMode | undefined
+    };
+
+    await detectUninstallContext(opts, ctx);
+
+    const { bundle: noBundle, lockfile: noLockfile, all: noAll } = validateInputs(opts, { flags: ['bundle', 'lockfile', 'all'] });
+    if (noBundle && noLockfile && noAll) {
+      return failWith(ctx, fmt, 'uninstall', new RegistryError({
+        code: 'USAGE.MISSING_FLAG',
+        message: 'uninstall: provide <bundle-id>, --lockfile <path>, or --all',
+        hint: 'Examples:\n'
+          + '  ai-primitives-hub uninstall <bundle-id> --target my-vscode\n'
+          + '  ai-primitives-hub uninstall --lockfile prompt-registry.lock.json\n'
+          + '  ai-primitives-hub uninstall --all\n\n'
+          + 'Note: Lockfile is auto-detected in current directory and parent directories.'
+      }));
+    }
+
+    try {
+      const targetName = await resolveTargetName(opts.target, 'uninstall', ctx, () => readTargets({ cwd: ctx.cwd(), fs: ctx.fs }));
+      const target = await resolveTarget(targetName, 'uninstall', ctx, () => readTargets({ cwd: ctx.cwd(), fs: ctx.fs }));
+
+      if (opts.all === true) {
+        return await performAllUninstall(opts, target, ctx, fmt);
+      }
+
+      if (opts.lockfile !== undefined && opts.lockfile.length > 0) {
+        return await performLockfileUninstall(opts, target, ctx, fmt);
+      }
+
+      return await performBundleUninstall(opts, target, ctx, fmt);
+    } catch (err) {
+      if (err instanceof RegistryError) {
+        return failWith(ctx, fmt, 'uninstall', err);
+      }
+      throw err;
+    }
+  }
+}
+
+/**
+ * Create a writer factory that routes to the appropriate writer based on target scope.
+ * - user scope → FileTreeTargetWriter
+ * - repository scope → RepositoryScopeWriter
+ * @param ctx CLI context.
+ * @param opts Uninstall options.
+ * @returns Writer factory function.
+ */
+export const createWriterFactory = (
+  ctx: Context,
+  opts: UninstallOptions
+): (target: Target) => TargetWriter => {
+  // Create transformer registry with built-in transformers — must match
+  // install.ts's factory so `writer.remove()` computes the same on-disk
+  // path that `writer.write()` used (targets with a real, non-identity
+  // transformer like Kiro would otherwise resolve the wrong path).
+  const transformerRegistry = TransformerRegistry.withBuiltIns();
+  const layoutLoader = new FileSystemLayoutConfigLoader({
+    cwd: ctx.cwd(),
+    fs: ctx.fs,
+    userConfigDir: resolveUserConfigDir(ctx.env)
+  });
+
+  return (target: Target): TargetWriter => {
+    // Use CLI flags to override target scope if specified
+    const scope = opts.scope ?? target.scope;
+    const commitMode = opts.commitMode ?? target.commitMode ?? 'commit';
+    const workspaceRoot = target.rootPath ?? ctx.cwd();
+
+    if (scope === 'repository') {
+      const writer = new RepositoryScopeWriter({
+        fs: ctx.fs,
+        workspaceRoot,
+        commitMode
+      });
+      return new RepositoryScopeWriterAdapter(writer);
+    }
+    // Default to FileTreeTargetWriter for user scope
+    const transformer = transformerRegistry.getTransformer(target.type);
+    return new FileTreeTargetWriter({
+      fs: ctx.fs,
+      env: ctx.env,
+      transformer,
+      layoutLoader
+    });
+  };
+};
+
+/**
+ * Remove a single bundle's files + lockfile entry directly against the
+ * non-split user-scope lockfile. Mirrors `UninstallPipeline.run`'s
+ * shape, minus the commit/local-only split that only applies to
+ * repository scope.
+ * @param bundleId Bundle id to remove.
+ * @param lockPath Absolute path to the user-scope lockfile.
+ * @param target Target being uninstalled from.
+ * @param ctx CLI context.
+ * @param writer Target writer.
+ * @returns Uninstall result (matches `UninstallPipeline`'s shape).
+ */
+export async function runUserScopeUninstall(
+  bundleId: string,
+  lockPath: string,
+  target: Target,
+  ctx: Context,
+  writer: TargetWriter
+): Promise<UninstallResult> {
+  const lock = await readLockfile(lockPath, ctx.fs);
+  const entry = lock?.bundles[bundleId];
+  if (lock === null || entry === undefined) {
+    return { bundleId, removed: [], skipped: [] };
+  }
+
+  const removed: string[] = [];
+  const skipped: string[] = [];
+  for (const file of entry.files) {
+    try {
+      await writer.remove(target, file.path);
+      removed.push(file.path);
+    } catch {
+      skipped.push(file.path);
+    }
+  }
+
+  let next = removeBundleEntry(lock, bundleId);
+  next = cleanupOrphanedSource(next, entry.sourceId);
+  await writeLockfile(lockPath, next, ctx.fs);
+
+  return { bundleId, removed, skipped };
+}
+
+/**
+ * Remove every bundle tracked in the non-split user-scope lockfile.
+ * Mirrors `UninstallPipeline.runAll`.
+ * @param lockPath Absolute path to the user-scope lockfile.
+ * @param target Target being uninstalled from.
+ * @param ctx CLI context.
+ * @param writer Target writer.
+ * @returns Uninstall results, one per bundle removed.
+ */
+async function runAllUserScopeUninstall(
+  lockPath: string,
+  target: Target,
+  ctx: Context,
+  writer: TargetWriter
+): Promise<UninstallResult[]> {
+  const lock = await readLockfile(lockPath, ctx.fs);
+  if (lock === null) {
+    return [];
+  }
+  const results: UninstallResult[] = [];
+  for (const bundleId of Object.keys(lock.bundles)) {
+    results.push(await runUserScopeUninstall(bundleId, lockPath, target, ctx, writer));
+  }
+  return results;
+}
+
+/**
+ * Look up a bundle entry for dry-run/preview purposes, from either the
+ * repository-scope lockfile pair or the single user-scope lockfile.
+ * @param bundleId Bundle id to look up.
+ * @param target Target being uninstalled from.
+ * @param opts Uninstall options.
+ * @param ctx CLI context.
+ * @returns The entry if found, else `null`.
+ */
+async function findBundleEntry(
+  bundleId: string,
+  target: Target,
+  opts: UninstallOptions,
+  ctx: Context
+): Promise<LockfileBundleEntry | null> {
+  const scope = opts.scope ?? target.scope;
+  if (scope === 'repository') {
+    const pipeline = new UninstallPipeline({
+      fs: ctx.fs,
+      target,
+      repositoryPath: target.rootPath ?? ctx.cwd(),
+      writerFactory: createWriterFactory(ctx, opts)
+    });
+    const plan = await pipeline.plan(bundleId);
+    return plan.lockfileEntry;
+  }
+  const lockPath = lockfilePathForTarget(ctx, target);
+  const lock = await readLockfile(lockPath, ctx.fs);
+  return lock?.bundles[bundleId] ?? null;
+}
+
+/**
+ * Load every bundle entry for dry-run/preview purposes.
+ * @param target Target being uninstalled from.
+ * @param opts Uninstall options.
+ * @param ctx CLI context.
+ * @returns Map of bundle id to lockfile entry.
+ */
+async function findAllBundleEntries(
+  target: Target,
+  opts: UninstallOptions,
+  ctx: Context
+): Promise<Record<string, LockfileBundleEntry>> {
+  const scope = opts.scope ?? target.scope;
+  if (scope === 'repository') {
+    const pipeline = new UninstallPipeline({
+      fs: ctx.fs,
+      target,
+      repositoryPath: target.rootPath ?? ctx.cwd(),
+      writerFactory: createWriterFactory(ctx, opts)
+    });
+    const plans = await pipeline.planAll();
+    const out: Record<string, LockfileBundleEntry> = {};
+    for (const plan of plans) {
+      if (plan.lockfileEntry !== null) {
+        out[plan.bundleId] = plan.lockfileEntry;
+      }
+    }
+    return out;
+  }
+  const lockPath = lockfilePathForTarget(ctx, target);
+  const lock = await readLockfile(lockPath, ctx.fs);
+  return lock?.bundles ?? {};
+}
+
+/**
+ * Perform uninstall by bundle ID.
+ * @param opts Uninstall options.
+ * @param target Target configuration.
+ * @param ctx CLI context.
+ * @param fmt Output format.
+ * @returns Exit code.
+ */
+async function performBundleUninstall(
+  opts: UninstallOptions,
+  target: Target,
+  ctx: Context,
+  fmt: OutputFormat
+): Promise<number> {
+  const bundleId = opts.bundle as string;
+  const entry = await findBundleEntry(bundleId, target, opts, ctx);
+
+  if (entry === null) {
+    formatOutput({
+      ctx,
+      command: 'uninstall',
+      output: fmt,
+      status: 'warning',
+      data: {
+        target: target.name,
+        bundle: bundleId,
+        reason: 'not found in lockfile'
+      },
+      textRenderer: (d) => `Bundle "${d.bundle}" is not installed in target "${d.target}". Nothing to uninstall.\n`
+    });
+    return 0;
+  }
+
+  // Dry-run: show what would be removed without deleting
+  if (opts.dryRun === true) {
+    formatOutput({
+      ctx,
+      command: 'uninstall',
+      output: fmt,
+      status: 'ok',
+      data: {
+        dryRun: true,
+        target: target.name,
+        bundle: bundleId,
+        files: entry.files.map((f) => f.path)
+      },
+      textRenderer: (d) => `[dry-run] Would uninstall bundle "${d.bundle}" from target "${d.target}":\n`
+        + `  Files: ${d.files.join(', ')}\n`
+        + 'Run without --dry-run to apply.\n'
+    });
+    return 0;
+  }
+
+  const scope = opts.scope ?? target.scope;
+  const writerFactory = createWriterFactory(ctx, opts);
+  let result: UninstallResult;
+  let lockPath: string;
+  if (scope === 'repository') {
+    const commitMode = entry.commitMode ?? opts.commitMode ?? target.commitMode ?? 'commit';
+    lockPath = lockfilePathForTarget(ctx, target, commitMode);
+    const pipeline = new UninstallPipeline({
+      fs: ctx.fs,
+      target,
+      repositoryPath: target.rootPath ?? ctx.cwd(),
+      writerFactory
+    });
+    result = await pipeline.run(bundleId);
+  } else {
+    lockPath = lockfilePathForTarget(ctx, target);
+    result = await runUserScopeUninstall(bundleId, lockPath, target, ctx, writerFactory(target));
+  }
+
+  // Update target state
+  await updateTargetState(ctx, target.name, bundleId);
+
+  formatOutput({
+    ctx,
+    command: 'uninstall',
+    output: fmt,
+    status: 'ok',
+    data: {
+      target: target.name,
+      bundle: bundleId,
+      removed: result.removed,
+      lockfile: lockPath
+    },
+    textRenderer: (d) => `Uninstalled ${d.bundle} from target "${d.target}" `
+      + `(${d.removed.length} file${d.removed.length === 1 ? '' : 's'} removed). `
+      + `Updated ${d.lockfile}.\n`
+  });
+  return 0;
+}
+
+/**
+ * Perform uninstall from lockfile.
+ * @param opts Uninstall options.
+ * @param target Target configuration.
+ * @param ctx CLI context.
+ * @param fmt Output format.
+ * @returns Exit code.
+ */
+async function performLockfileUninstall(
+  opts: UninstallOptions,
+  target: Target,
+  ctx: Context,
+  fmt: OutputFormat
+): Promise<number> {
+  const lockfile = opts.lockfile as string;
+  const lockPath = path.isAbsolute(lockfile)
+    ? lockfile
+    : path.join(ctx.cwd(), lockfile);
+  const lock = await readLockfile(lockPath, ctx.fs);
+
+  if (lock === null) {
+    formatOutput({
+      ctx,
+      command: 'uninstall',
+      output: fmt,
+      status: 'ok',
+      data: { lockfile: lockPath, target: target.name, uninstalled: 0 },
+      textRenderer: (d) => `No lockfile found at ${d.lockfile}. Nothing to uninstall.\n`
+    });
+    return 0;
+  }
+
+  const bundleIds = Object.keys(lock.bundles);
+
+  // Dry-run: show what would be removed without deleting
+  if (opts.dryRun === true) {
+    const allFiles = bundleIds.flatMap((id) => lock.bundles[id].files.map((f) => f.path));
+    formatOutput({
+      ctx,
+      command: 'uninstall',
+      output: fmt,
+      status: 'ok',
+      data: {
+        dryRun: true,
+        lockfile: lockPath,
+        target: target.name,
+        bundles: bundleIds,
+        files: allFiles
+      },
+      textRenderer: (d) => `[dry-run] Would uninstall ${d.bundles.length} bundle${d.bundles.length === 1 ? '' : 's'} from target "${d.target}" (from ${d.lockfile}):\n`
+        + `  Bundles: ${d.bundles.join(', ')}\n`
+        + `  Files: ${d.files.length} total\n`
+        + 'Run without --dry-run to apply.\n'
+    });
+    return 0;
+  }
+
+  const writerFactory = createWriterFactory(ctx, opts);
+  let results: UninstallResult[];
+  const scope = opts.scope ?? target.scope;
+  if (scope === 'repository') {
+    const pipeline = new UninstallPipeline({
+      fs: ctx.fs,
+      target,
+      repositoryPath: path.dirname(lockPath),
+      writerFactory
+    });
+    results = await pipeline.runFromLockfile();
+  } else {
+    results = await runAllUserScopeUninstall(lockPath, target, ctx, writerFactory(target));
+  }
+
+  if (results.length === 0) {
+    formatOutput({
+      ctx,
+      command: 'uninstall',
+      output: fmt,
+      status: 'ok',
+      data: {
+        lockfile: lockPath,
+        target: target.name,
+        uninstalled: 0
+      },
+      textRenderer: (d) => `No bundles found to uninstall from target "${d.target}".\n`
+    });
+    return 0;
+  }
+
+  formatOutput({
+    ctx,
+    command: 'uninstall',
+    output: fmt,
+    status: 'ok',
+    data: {
+      lockfile: lockPath,
+      target: target.name,
+      uninstalled: results.length,
+      bundles: results.map((r) => ({ id: r.bundleId, removed: r.removed.length }))
+    },
+    textRenderer: (d) => `Uninstalled ${d.uninstalled} bundle${d.uninstalled === 1 ? '' : 's'} `
+      + `from target "${d.target}" (from ${d.lockfile}).\n`
+  });
+  return 0;
+}
+
+/**
+ * Perform uninstall of all bundles for target.
+ * @param opts Uninstall options.
+ * @param target Target configuration.
+ * @param ctx CLI context.
+ * @param fmt Output format.
+ * @returns Exit code.
+ */
+async function performAllUninstall(
+  opts: UninstallOptions,
+  target: Target,
+  ctx: Context,
+  fmt: OutputFormat
+): Promise<number> {
+  const entries = await findAllBundleEntries(target, opts, ctx);
+  const bundleIds = Object.keys(entries);
+
+  // Dry-run: show what would be removed without deleting
+  if (opts.dryRun === true) {
+    const allFiles = bundleIds.flatMap((id) => entries[id].files.map((f) => f.path));
+    formatOutput({
+      ctx,
+      command: 'uninstall',
+      output: fmt,
+      status: 'ok',
+      data: {
+        dryRun: true,
+        target: target.name,
+        bundles: bundleIds,
+        files: allFiles
+      },
+      textRenderer: (d) => `[dry-run] Would uninstall all bundles from target "${d.target}":\n`
+        + `  Bundles: ${d.bundles.join(', ')}\n`
+        + `  Files: ${d.files.length} total\n`
+        + 'Run without --dry-run to apply.\n'
+    });
+    return 0;
+  }
+
+  const writerFactory = createWriterFactory(ctx, opts);
+  const scope = opts.scope ?? target.scope;
+  let results: UninstallResult[];
+  if (scope === 'repository') {
+    const pipeline = new UninstallPipeline({
+      fs: ctx.fs,
+      target,
+      repositoryPath: target.rootPath ?? ctx.cwd(),
+      writerFactory
+    });
+    results = await pipeline.runAll();
+  } else {
+    const lockPath = lockfilePathForTarget(ctx, target);
+    results = await runAllUserScopeUninstall(lockPath, target, ctx, writerFactory(target));
+  }
+
+  if (results.length === 0) {
+    formatOutput({
+      ctx,
+      command: 'uninstall',
+      output: fmt,
+      status: 'ok',
+      data: {
+        target: target.name,
+        uninstalled: 0
+      },
+      textRenderer: (d) => `No bundles installed in target "${d.target}". Nothing to uninstall.\n`
+    });
+    return 0;
+  }
+
+  // Update target state (clear all bundles)
+  const stateStore = new TargetStateStore({
+    fs: ctx.fs,
+    statePath: path.join(ctx.cwd(), '.ai-primitives-hub', 'target-state.json')
+  });
+  await stateStore.save({
+    targetName: target.name,
+    lastInstalledBundles: [],
+    lastUsedAt: new Date().toISOString()
+  });
+
+  formatOutput({
+    ctx,
+    command: 'uninstall',
+    output: fmt,
+    status: 'ok',
+    data: {
+      target: target.name,
+      uninstalled: results.length,
+      bundles: results.map((r) => ({ id: r.bundleId, removed: r.removed.length }))
+    },
+    textRenderer: (d) => `Uninstalled ${d.uninstalled} bundle${d.uninstalled === 1 ? '' : 's'} `
+      + `from target "${d.target}".\n`
+  });
+  return 0;
+}
+
+/**
+ * Update target state by removing bundle.
+ * @param ctx CLI context.
+ * @param targetName Target name.
+ * @param bundleId Bundle ID to remove.
+ */
+async function updateTargetState(ctx: Context, targetName: string, bundleId: string): Promise<void> {
+  const stateStore = new TargetStateStore({
+    fs: ctx.fs,
+    statePath: path.join(ctx.cwd(), '.ai-primitives-hub', 'target-state.json')
+  });
+  const existingState = await stateStore.load(targetName);
+  const newBundles = existingState?.lastInstalledBundles ?? [];
+  const bundleIndex = newBundles.findIndex((b) => b.bundleId === bundleId);
+  if (bundleIndex !== -1) {
+    newBundles.splice(bundleIndex, 1);
+  }
+  await stateStore.save({
+    targetName,
+    lastInstalledBundles: newBundles,
+    lastUsedAt: new Date().toISOString()
+  });
+}
+
+/**
+ * Build the `uninstall` command.
+ * @param opts - Command options.
+ * @returns CommandDefinition wired to the framework adapter.
+ */
+export const createUninstallCommand = (
+  opts: UninstallOptions = {}
+): CommandDefinition =>
+  defineCommand({
+    path: ['uninstall'],
+    description: 'Remove bundles from a configured target.',
+    category: 'Install & Manage',
+    run: async ({ ctx }: { ctx: Context }): Promise<number> => {
+      const fmt = opts.output ?? 'text';
+      const { bundle: noBundle, lockfile: noLockfile, all: noAll } = validateInputs(opts, { flags: ['bundle', 'lockfile', 'all'] });
+      if (noBundle && noLockfile && noAll) {
+        return failWith(ctx, fmt, 'uninstall', new RegistryError({
+          code: 'USAGE.MISSING_FLAG',
+          message: 'uninstall: provide <bundle-id>, --lockfile <path>, or --all',
+          hint: 'Examples:\n'
+            + '  ai-primitives-hub uninstall <bundle-id> --target my-vscode\n'
+            + '  ai-primitives-hub uninstall --lockfile prompt-registry.lock.json\n'
+            + '  ai-primitives-hub uninstall --all --target my-vscode'
+        }));
+      }
+
+      try {
+        const targetName = await resolveTargetName(opts.target, 'uninstall', ctx, () => readTargets({ cwd: ctx.cwd(), fs: ctx.fs }));
+        const target = await resolveTarget(targetName, 'uninstall', ctx, () => readTargets({ cwd: ctx.cwd(), fs: ctx.fs }));
+
+        if (opts.all === true) {
+          return await performAllUninstall(opts, target, ctx, fmt);
+        }
+
+        if (opts.lockfile !== undefined && opts.lockfile.length > 0) {
+          return await performLockfileUninstall(opts, target, ctx, fmt);
+        }
+
+        return await performBundleUninstall(opts, target, ctx, fmt);
+      } catch (err) {
+        if (err instanceof RegistryError) {
+          return failWith(ctx, fmt, 'uninstall', err);
+        }
+        throw err;
+      }
+    }
+  });

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -1,0 +1,525 @@
+/**
+ * `update` command — checks installed bundles for newer versions and upgrades them.
+ *
+ * Reference's version keys each lockfile entry by its own `target` field and
+ * resolves a target per-entry. Our `LockfileBundleEntry` has no `target`
+ * field (see `app/stores/json-lockfile-store.ts`'s module doc — repository
+ * scope always writes to `.github/`, invariant of target), so `update`
+ * instead resolves a single target for the whole run — same
+ * flag/auto-detect pattern as `install`/`uninstall` — and updates every
+ * bundle tracked by that target's lockfile.
+ */
+import * as path from 'node:path';
+import {
+  checksumFiles,
+  FileTreeTargetWriter,
+  type Lockfile,
+  type LockfileBundleEntry,
+  type LockfileSourceEntry,
+  readLockfile,
+  resolveUserConfigPaths,
+  type TargetWriter,
+  TransformerRegistry,
+  upsertBundleEntry,
+  upsertSource,
+  writeLockfile,
+} from '@ai-primitives-hub/app';
+import type {
+  HttpClient,
+  Installable,
+  RegistrySource,
+  SourceType,
+  Target,
+  TokenProvider,
+} from '@ai-primitives-hub/core';
+import {
+  validateManifest,
+} from '@ai-primitives-hub/core';
+import {
+  ActiveHubStore,
+  defaultTokenProvider,
+  FileSystemLayoutConfigLoader,
+  GitHubApiClient,
+  HttpsBundleDownloader,
+  NodeHttpClient,
+  readTargets,
+  type RepositoryCommitMode,
+  RepositoryScopeWriter,
+  RepositoryScopeWriterAdapter,
+  resolveUserConfigDir,
+  SourceDispatcher,
+  TargetStateStore,
+  ZipBundleExtractor,
+} from '@ai-primitives-hub/infra';
+import inquirer from 'inquirer';
+import {
+  Command,
+  createHubManager,
+  failWith,
+  findProjectLockfile,
+  loadTargets,
+  lockfilePathForTarget,
+  Option,
+} from '../framework';
+import {
+  type Context,
+  formatOutput,
+  type OutputFormat,
+  readTargetsSafely,
+  RegistryError,
+  resolveTarget,
+  resolveTargetName,
+} from '../framework';
+
+/**
+ * Return true when `candidate` is a strictly higher semver than `installed`.
+ * Strips leading `v` from either value before comparing.
+ * @param candidate Resolved latest version.
+ * @param installed Currently installed version.
+ */
+export const isNewerVersion = (candidate: string, installed: string): boolean => {
+  const parse = (v: string): number[] =>
+    v.replace(/^v/, '').split('.').map((p) => Number.parseInt(p.split('-')[0], 10) || 0);
+  const c = parse(candidate);
+  const i = parse(installed);
+  for (let idx = 0; idx < Math.max(c.length, i.length); idx++) {
+    const cv = c[idx] ?? 0;
+    const iv = i[idx] ?? 0;
+    if (cv > iv) {
+      return true;
+    }
+    if (cv < iv) {
+      return false;
+    }
+  }
+  return false;
+};
+
+interface UpdateCandidate {
+  bundleId: string;
+  entry: LockfileBundleEntry;
+  source: LockfileSourceEntry;
+  from: string;
+  to: string;
+  installable: Installable;
+}
+
+interface UpdateContext {
+  ctx: Context;
+  http?: HttpClient;
+  tokens?: TokenProvider;
+}
+
+abstract class BaseUpdateCommand extends Command {
+  public commandContext: UpdateContext = { ctx: null as unknown as Context };
+}
+
+type UpdateEntry = { bundleId: string; from: string; to: string };
+
+function renderDryRunOutput(d: { checked: number; updates: UpdateEntry[] }): string {
+  if (d.updates.length === 0) {
+    return `All bundles are up to date. (checked ${String(d.checked)})
+`;
+  }
+  const lines = [`Available updates (${String(d.updates.length)}):`];
+  for (const u of d.updates) {
+    lines.push(`  ${u.bundleId}: ${u.from} → ${u.to}`);
+  }
+  lines.push('\nRe-run without --dry-run to apply.');
+  return lines.join('\n') + '\n';
+}
+
+function renderUpdateOutput(d: { updated: number; checked: number; updates: UpdateEntry[] }): string {
+  if (d.updated === 0) {
+    return `All bundles are up to date. (checked ${String(d.checked)})
+`;
+  }
+  const lines = [`Updated ${String(d.updated)} bundle${d.updated === 1 ? '' : 's'}:`];
+  for (const u of d.updates) {
+    lines.push(`  ${u.bundleId}: ${u.from} → ${u.to}`);
+  }
+  return lines.join('\n') + '\n';
+}
+
+/**
+ * Update command options.
+ */
+export interface UpdateOptions {
+  output?: OutputFormat;
+  lockfile?: string;
+  target?: string;
+  dryRun?: boolean;
+  interactive?: boolean;
+  noHubSync?: boolean;
+  scope?: 'user' | 'repository';
+  commitMode?: RepositoryCommitMode;
+}
+
+export class UpdateCommand extends BaseUpdateCommand {
+  public static readonly paths = [['update']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Check for newer versions of installed bundles and upgrade them.',
+    category: 'Install & Manage',
+    details: `
+      Usage: ai-primitives-hub update [options]
+
+      Reads the lockfile, checks each remote bundle against its upstream source,
+      and installs available upgrades.
+
+      Options:
+        --lockfile <path>       Path to a lockfile
+        --target <name>         Target name to update
+        --dry-run               Check for updates without applying
+        --interactive           Interactive mode: select which updates to apply
+        --no-hub-sync           Skip syncing hub before checking updates
+        -o, --output <format>  Output format (text, json, yaml, ndjson)
+
+      Examples:
+        ai-primitives-hub update
+        ai-primitives-hub update --target my-vscode
+        ai-primitives-hub update --dry-run
+        ai-primitives-hub update --interactive
+    `
+  });
+
+  public output = Option.String('-o,--output');
+  public lockfile = Option.String('--lockfile');
+  public target = Option.String('--target');
+  public dryRun = Option.Boolean('--dry-run', false);
+  public interactive = Option.Boolean('--interactive', false);
+  public noHubSync = Option.Boolean('--no-hub-sync', false);
+  public scope = Option.String('--scope');
+  public commitMode = Option.String('--commit-mode');
+
+  public async execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+    const http = this.commandContext.http ?? new NodeHttpClient();
+    const tokens = this.commandContext.tokens ?? defaultTokenProvider(ctx.env);
+    const fmt: OutputFormat = (this.output ?? 'text') as OutputFormat;
+
+    const opts: UpdateOptions = {
+      output: fmt,
+      lockfile: this.lockfile,
+      target: this.target,
+      dryRun: this.dryRun,
+      interactive: this.interactive,
+      noHubSync: this.noHubSync,
+      scope: this.scope as 'user' | 'repository' | undefined,
+      commitMode: this.commitMode as RepositoryCommitMode | undefined
+    };
+
+    await detectUpdateContext(opts, ctx);
+
+    try {
+      const targetName = await resolveTargetName(opts.target, 'update', ctx, () => readTargets({ cwd: ctx.cwd(), fs: ctx.fs }));
+      const target = await resolveTarget(targetName, 'update', ctx, () => readTargets({ cwd: ctx.cwd(), fs: ctx.fs }));
+
+      const commitMode = opts.commitMode ?? target.commitMode ?? 'commit';
+      const scope = opts.scope ?? target.scope;
+      const lockPath = opts.lockfile !== undefined && opts.lockfile.length > 0
+        ? (path.isAbsolute(opts.lockfile) ? opts.lockfile : path.join(ctx.cwd(), opts.lockfile))
+        : lockfilePathForTarget(ctx, target, commitMode);
+
+      const lock = await readLockfile(lockPath, ctx.fs);
+      if (lock === null) {
+        return failWith(ctx, fmt, 'update', new RegistryError({
+          code: 'USAGE.MISSING_FLAG',
+          message: 'update: no lockfile found',
+          hint: 'Run `ai-primitives-hub install` first, or pass --lockfile <path>.'
+        }));
+      }
+
+      if (!this.noHubSync) {
+        await syncActiveHub(ctx);
+      }
+
+      const bundleIds = Object.keys(lock.bundles);
+      const remoteBundleIds = bundleIds.filter((id) => {
+        const src = lock.sources[lock.bundles[id].sourceId];
+        return src !== undefined && isRemoteSource(src.type);
+      });
+      const { candidates, skipped } = await findUpdateCandidates(remoteBundleIds, lock, ctx, http, tokens);
+
+      if (this.dryRun) {
+        return renderDryRun(ctx, fmt, lockPath, bundleIds.length, skipped.length, candidates);
+      }
+
+      const toInstall = await selectUpdatesInteractively(this.interactive, candidates);
+      if (toInstall.length === 0) {
+        return renderNoUpdates(ctx, fmt, bundleIds.length, skipped.length);
+      }
+
+      const { updatedCount, updateResults } = await applyUpdates(toInstall, target, scope, commitMode, lockPath, ctx, http, tokens);
+
+      formatOutput({
+        ctx, command: 'update', output: fmt, status: 'ok',
+        data: { lockfile: lockPath, target: target.name, checked: bundleIds.length, updated: updatedCount, skipped: skipped.length, updates: updateResults },
+        textRenderer: renderUpdateOutput
+      });
+      return 0;
+    } catch (err) {
+      if (err instanceof RegistryError) {
+        return failWith(ctx, fmt, 'update', err);
+      }
+      throw err;
+    }
+  }
+}
+
+/**
+ * Detect update context from the project environment (symmetric with install/uninstall).
+ * Fills in `opts.target` when it can be inferred.
+ * @param opts Update options (mutated in-place).
+ * @param ctx CLI context.
+ */
+async function detectUpdateContext(opts: UpdateOptions, ctx: Context): Promise<void> {
+  if (!opts.lockfile || opts.lockfile.length === 0) {
+    const found = await findProjectLockfile(ctx);
+    if (found !== null) {
+      opts.lockfile = found;
+    }
+  }
+  if (!opts.target || opts.target.length === 0) {
+    const targets = await readTargetsSafely(loadTargets(ctx));
+    if (targets.length === 1) {
+      opts.target = targets[0].name;
+    }
+  }
+}
+
+function isRemoteSource(type: string): boolean {
+  return type === 'github' || type === 'awesome-copilot' || type === 'skills';
+}
+
+/**
+ * Build a `RegistrySource`-shaped object from a lockfile source entry,
+ * for `SourceDispatcher.resolverFor` — the dispatcher only reads
+ * `type`/`url`/`config`, so the remaining `RegistrySource` fields are
+ * filled with harmless placeholders.
+ * @param sourceId Source id (the `lock.sources` key).
+ * @param src Lockfile source entry.
+ * @returns Synthetic RegistrySource.
+ */
+function toRegistrySource(sourceId: string, src: LockfileSourceEntry): RegistrySource {
+  return {
+    id: sourceId,
+    name: sourceId,
+    type: src.type as SourceType,
+    url: src.url,
+    enabled: true,
+    priority: 0,
+    config: {
+      branch: src.branch,
+      collectionsPath: src.collectionsPath
+    }
+  };
+}
+
+async function findUpdateCandidates(
+  bundleIds: string[],
+  lock: Lockfile,
+  ctx: Context,
+  http: HttpClient,
+  tokens: TokenProvider
+): Promise<{ candidates: UpdateCandidate[]; skipped: string[] }> {
+  const candidates: UpdateCandidate[] = [];
+  const skipped: string[] = [];
+  const githubApi = new GitHubApiClient(http, { tokenProvider: tokens });
+  const dispatcher = new SourceDispatcher({ githubApi, fs: ctx.fs });
+
+  for (const bundleId of bundleIds) {
+    const entry = lock.bundles[bundleId];
+    const src = lock.sources[entry.sourceId];
+    try {
+      const resolver = dispatcher.resolverFor(toRegistrySource(entry.sourceId, src));
+      if (resolver === null) {
+        skipped.push(bundleId);
+        continue;
+      }
+      const installable = await resolver.resolve({ bundleId, bundleVersion: 'latest' });
+      if (installable === null) {
+        skipped.push(bundleId);
+        continue;
+      }
+      const latestVersion = installable.ref.bundleVersion;
+      if (isNewerVersion(latestVersion, entry.version)) {
+        candidates.push({ bundleId, entry, source: src, from: entry.version, to: latestVersion, installable });
+      }
+    } catch {
+      skipped.push(bundleId);
+    }
+  }
+
+  return { candidates, skipped };
+}
+
+function renderDryRun(
+  ctx: Context,
+  fmt: OutputFormat,
+  lockPath: string,
+  checked: number,
+  skippedCount: number,
+  candidates: UpdateCandidate[]
+): number {
+  formatOutput({
+    ctx, command: 'update', output: fmt, status: 'ok',
+    data: {
+      dryRun: true, lockfile: lockPath,
+      checked, updated: 0, skipped: skippedCount,
+      updates: candidates.map((c) => ({ bundleId: c.bundleId, from: c.from, to: c.to }))
+    },
+    textRenderer: renderDryRunOutput
+  });
+  return 0;
+}
+
+async function selectUpdatesInteractively(interactive: boolean, candidates: UpdateCandidate[]): Promise<UpdateCandidate[]> {
+  if (!interactive || candidates.length === 0) {
+    return candidates;
+  }
+  const answers = await (inquirer.prompt as (q: unknown) => Promise<{ selected: UpdateCandidate[] }>)([{
+    type: 'checkbox',
+    name: 'selected',
+    message: 'Select bundles to update:',
+    choices: candidates.map((c) => ({
+      name: `${c.bundleId}: ${c.from} → ${c.to}`,
+      value: c,
+      checked: true
+    }))
+  }]);
+  return answers.selected;
+}
+
+function renderNoUpdates(ctx: Context, fmt: OutputFormat, checked: number, skippedCount: number): number {
+  formatOutput({
+    ctx, command: 'update', output: fmt, status: 'ok',
+    data: { checked, updated: 0, skipped: skippedCount, updates: [] },
+    textRenderer: () => `All bundles are up to date. (checked ${String(checked)})\n`
+  });
+  return 0;
+}
+
+/**
+ * Build a scope-aware target writer, matching install/uninstall's own
+ * `createWriterFactory`.
+ * @param ctx CLI context.
+ * @param target Target being updated.
+ * @param scope Effective scope (may override `target.scope`).
+ * @param commitMode Effective commit mode (repository scope only).
+ * @returns A TargetWriter.
+ */
+function writerFor(ctx: Context, target: Target, scope: string, commitMode: RepositoryCommitMode): TargetWriter {
+  if (scope === 'repository') {
+    const writer = new RepositoryScopeWriter({
+      fs: ctx.fs,
+      workspaceRoot: target.rootPath ?? ctx.cwd(),
+      commitMode
+    });
+    return new RepositoryScopeWriterAdapter(writer);
+  }
+  const transformer = TransformerRegistry.withBuiltIns().getTransformer(target.type);
+  const layoutLoader = new FileSystemLayoutConfigLoader({
+    cwd: ctx.cwd(),
+    fs: ctx.fs,
+    userConfigDir: resolveUserConfigDir(ctx.env)
+  });
+  return new FileTreeTargetWriter({ fs: ctx.fs, env: ctx.env, transformer, layoutLoader });
+}
+
+async function applyUpdates(
+  toInstall: UpdateCandidate[],
+  target: Target,
+  scope: string,
+  commitMode: RepositoryCommitMode,
+  lockPath: string,
+  ctx: Context,
+  http: HttpClient,
+  tokens: TokenProvider
+): Promise<{ updatedCount: number; updateResults: UpdateEntry[] }> {
+  let updatedCount = 0;
+  const updateResults: UpdateEntry[] = [];
+
+  for (const candidate of toInstall) {
+    try {
+      await applyUpdate(candidate, target, scope, commitMode, lockPath, ctx, http, tokens);
+      updateResults.push({ bundleId: candidate.bundleId, from: candidate.from, to: candidate.to });
+      updatedCount++;
+    } catch (err) {
+      ctx.stderr.write(`Failed to update ${candidate.bundleId}: ${err instanceof Error ? err.message : String(err)}\n`);
+    }
+  }
+
+  return { updatedCount, updateResults };
+}
+
+async function syncActiveHub(ctx: Context): Promise<void> {
+  try {
+    const userPaths = resolveUserConfigPaths(ctx.env);
+    if (!(await ctx.fs.exists(userPaths.root))) {
+      return;
+    }
+    const activeStore = new ActiveHubStore(userPaths.activeHub, ctx.fs);
+    const hubId = await activeStore.get();
+    if (hubId === null) {
+      return;
+    }
+    const mgr = createHubManager({ ctx });
+    await mgr.syncHub(hubId);
+  } catch {
+    // Hub sync failure is non-fatal.
+  }
+}
+
+async function applyUpdate(
+  candidate: UpdateCandidate,
+  target: Target,
+  scope: string,
+  commitMode: RepositoryCommitMode,
+  lockPath: string,
+  ctx: Context,
+  http: HttpClient,
+  tokens: TokenProvider
+): Promise<void> {
+  const downloader = new HttpsBundleDownloader(http, tokens);
+  const extractor = new ZipBundleExtractor();
+
+  const dl = await downloader.download(candidate.installable);
+  const files = await extractor.extract(dl.bytes);
+  const manifest = validateManifest(files, { expectedId: undefined, expectedVersion: undefined });
+
+  const writer = writerFor(ctx, target, scope, commitMode);
+  await writer.write(target, files);
+
+  const entry: LockfileBundleEntry = {
+    version: manifest.version,
+    sourceId: candidate.entry.sourceId,
+    sourceType: candidate.entry.sourceType,
+    checksum: dl.sha256,
+    installedAt: new Date().toISOString(),
+    files: checksumFiles(files)
+  };
+  if (scope === 'repository') {
+    entry.commitMode = commitMode;
+  }
+
+  const lock = await readLockfile(lockPath, ctx.fs);
+  if (lock === null) {
+    return;
+  }
+  let nextLock = upsertBundleEntry(lock, manifest.id, entry);
+  nextLock = upsertSource(nextLock, candidate.entry.sourceId, candidate.source);
+  await writeLockfile(lockPath, nextLock, ctx.fs);
+
+  const stateStore = new TargetStateStore({ fs: ctx.fs, statePath: path.join(ctx.cwd(), '.ai-primitives-hub', 'target-state.json') });
+  const existingState = await stateStore.load(target.name);
+  const bundles = existingState?.lastInstalledBundles ?? [];
+  const idx = bundles.findIndex((b) => b.bundleId === manifest.id);
+  const bundleState = { bundleId: manifest.id, version: manifest.version, installedAt: new Date().toISOString() };
+  if (idx === -1) {
+    bundles.push(bundleState);
+  } else {
+    bundles[idx] = bundleState;
+  }
+  await stateStore.save({ targetName: target.name, lastInstalledBundles: bundles, lastUsedAt: new Date().toISOString() });
+}

--- a/packages/cli/src/commands/version-compute.ts
+++ b/packages/cli/src/commands/version-compute.ts
@@ -1,0 +1,341 @@
+/**
+ * `version compute` subcommand.
+ *
+ * Computes the next semver version + git tag for a collection given:
+ *   - the collection file's `version` field (manual override), and
+ *   - the set of existing git tags matching `<collection-id>-v*`.
+ *
+ * The git interaction is behind the `gitTagsProvider` instance field so
+ * the command stays easy to drive with a fake in a future test-writing
+ * pass. The default provider shells out to `git tag --list`
+ * synchronously — the *only* place this command file touches a child
+ * process.
+ * @module commands/version-compute
+ */
+import {
+  spawnSync,
+} from 'node:child_process';
+import {
+  readCollection,
+} from '@ai-primitives-hub/app';
+import * as semver from 'semver';
+import {
+  Command,
+  type Context,
+  formatOutput,
+  Option,
+  type OutputFormat,
+  RegistryError,
+  renderError,
+} from '../framework';
+
+/**
+ * Version compute data structure.
+ */
+interface VersionComputeData {
+  collectionId: string;
+  collectionFile: string;
+  lastVersion: string | null;
+  manualVersion: string;
+  nextVersion: string;
+  tag: string;
+}
+
+/**
+ * Validate collection ID.
+ * @param collectionId Collection ID to validate.
+ * @returns Validated collection ID.
+ */
+function validateCollectionId(collectionId: unknown): string {
+  if (typeof collectionId !== 'string' || collectionId.length === 0) {
+    throw new RegistryError({
+      code: 'BUNDLE.INVALID_MANIFEST',
+      message: 'collection.id is required',
+      hint: 'Add an `id:` field to the collection.yml file.'
+    });
+  }
+  return collectionId;
+}
+
+/**
+ * Validate manual version.
+ * @param version Version to validate.
+ * @returns Validated version string.
+ */
+function validateManualVersion(version: unknown): string {
+  const DEFAULT_VERSION = '1.0.0';
+  if (version === undefined || typeof version !== 'string') {
+    return DEFAULT_VERSION;
+  }
+  if (semver.valid(version) === null) {
+    throw new RegistryError({
+      code: 'BUNDLE.INVALID_VERSION',
+      message: `collection.version must be a valid semver string (got: ${version})`,
+      context: { version }
+    });
+  }
+  return version;
+}
+
+/**
+ * Extract versions from git tags.
+ * @param collectionId Collection ID.
+ * @param allTags All git tags.
+ * @returns Sorted list of version strings.
+ */
+function extractVersionsFromTags(collectionId: string, allTags: string[]): string[] {
+  const tagPrefix = `${collectionId}-v`;
+  const tagsForCollection = allTags.filter((t) => t.startsWith(tagPrefix));
+  return tagsForCollection
+    .map((t) => t.slice(tagPrefix.length))
+    .filter((v) => semver.valid(v) !== null)
+    .toSorted(semver.rcompare);
+}
+
+/**
+ * Calculate version increment.
+ * @param manualVersion Manual version from collection file.
+ * @param lastVersion Last version from git tags.
+ * @returns Next version string.
+ */
+function calculateVersionIncrement(
+  manualVersion: string,
+  lastVersion: string | null
+): string {
+  if (lastVersion === null) {
+    return manualVersion;
+  }
+  if (semver.gt(manualVersion, lastVersion)) {
+    return manualVersion;
+  }
+  const incremented = semver.inc(lastVersion, 'patch');
+  if (incremented === null) {
+    throw new RegistryError({
+      code: 'BUNDLE.INVALID_VERSION',
+      message: `unable to increment patch on ${lastVersion}`
+    });
+  }
+  return incremented;
+}
+
+/**
+ * Check if tag exists and throw error if so.
+ * @param tag Tag to check.
+ * @param tagSet Set of existing tags.
+ * @param manualVersion Manual version.
+ * @returns Tag if it doesn't exist.
+ */
+function checkTagExistsAndThrow(tag: string, tagSet: Set<string>, manualVersion: string): string {
+  if (tagSet.has(tag)) {
+    throw new RegistryError({
+      code: 'BUNDLE.TAG_EXISTS',
+      message: `Tag already exists for manual version: ${tag}`,
+      hint: 'Bump the `version:` field in the collection.yml or remove the existing tag.',
+      context: { tag, manualVersion }
+    });
+  }
+  return tag;
+}
+
+/**
+ * Find a free tag by incrementing version until one doesn't exist.
+ * @param collectionId Collection ID.
+ * @param initialVersion Initial version.
+ * @param tagSet Set of existing tags.
+ * @returns Free tag string.
+ */
+function findFreeTag(collectionId: string, initialVersion: string, tagSet: Set<string>): string {
+  let nextVersion = initialVersion;
+  let tag = `${collectionId}-v${nextVersion}`;
+  while (tagSet.has(tag)) {
+    const incremented = semver.inc(nextVersion, 'patch');
+    if (incremented === null) {
+      throw new RegistryError({
+        code: 'BUNDLE.INVALID_VERSION',
+        message: `unable to find a free patch version after ${nextVersion}`
+      });
+    }
+    nextVersion = incremented;
+    tag = `${collectionId}-v${nextVersion}`;
+  }
+  return tag;
+}
+
+/**
+ * Resolve tag for next version.
+ * @param collectionId Collection ID.
+ * @param nextVersion Next version.
+ * @param manualVersion Manual version.
+ * @param lastVersion Last version from git tags.
+ * @param allTags All git tags.
+ * @returns Tag string.
+ */
+function resolveTag(
+  collectionId: string,
+  nextVersion: string,
+  manualVersion: string,
+  lastVersion: string | null,
+  allTags: string[]
+): string {
+  const tagSet = new Set(allTags);
+  if (lastVersion !== null && semver.gt(manualVersion, lastVersion)) {
+    return checkTagExistsAndThrow(`${collectionId}-v${nextVersion}`, tagSet, manualVersion);
+  }
+  return findFreeTag(collectionId, nextVersion, tagSet);
+}
+
+/**
+ * Compute version and tag.
+ * @param collectionId Collection ID.
+ * @param manualVersion Manual version.
+ * @param allTags All git tags.
+ * @returns Last version, next version, and tag.
+ */
+function computeVersionAndTag(collectionId: string, manualVersion: string, allTags: string[]): {
+  lastVersion: string | null;
+  nextVersion: string;
+  tag: string;
+} {
+  const versions = extractVersionsFromTags(collectionId, allTags);
+  const lastVersion = versions.length === 0 ? null : versions[0];
+  const nextVersion = calculateVersionIncrement(manualVersion, lastVersion);
+  const tag = resolveTag(collectionId, nextVersion, manualVersion, lastVersion, allTags);
+  return { lastVersion, nextVersion, tag };
+}
+
+/**
+ * Compute next version data.
+ * @param input Input data with repo root, collection file, and all tags.
+ * @param input.repoRoot Repository root path.
+ * @param input.collectionFile Collection file path.
+ * @param input.allTags All git tags.
+ * @returns Version compute data.
+ */
+const computeNextVersion = (input: {
+  repoRoot: string;
+  collectionFile: string;
+  allTags: string[];
+}): VersionComputeData => {
+  const collection = readCollection(input.repoRoot, input.collectionFile);
+  const collectionId = validateCollectionId(collection.id);
+  const manualVersion = validateManualVersion(collection.version);
+  const { lastVersion, nextVersion, tag } = computeVersionAndTag(collectionId, manualVersion, input.allTags);
+  return {
+    collectionId,
+    collectionFile: input.collectionFile.replaceAll('\\', '/'),
+    lastVersion,
+    manualVersion,
+    nextVersion,
+    tag
+  };
+};
+
+/**
+ * Default git tags provider using git command.
+ * @param cwd Current working directory.
+ * @returns List of git tags.
+ */
+const defaultGitTagsProvider = (cwd: string): string[] => {
+  // The single point in this command file where we shell out. Bounded
+  // and deterministic — any future migration to a `Context.git`
+  // abstraction can replace this one function.
+  const res = spawnSync('git', ['tag', '--list'], { cwd, encoding: 'utf8' });
+  if (res.status !== 0) {
+    return [];
+  }
+  return (res.stdout ?? '')
+    .split(/\r?\n/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+};
+
+/**
+ * Emit error in appropriate format.
+ * @param ctx CLI context.
+ * @param output Output format.
+ * @param err Registry error.
+ */
+const emitError = (ctx: Context, output: OutputFormat, err: RegistryError): void => {
+  if (output === 'json' || output === 'yaml' || output === 'ndjson') {
+    formatOutput({
+      ctx,
+      command: 'version.compute',
+      output,
+      status: 'error',
+      data: null,
+      errors: [err.toJSON()]
+    });
+  } else {
+    renderError(err, ctx);
+  }
+};
+
+/**
+ * Render version compute data as text.
+ * @param d Version compute data.
+ * @returns Formatted text output.
+ */
+const renderText = (d: VersionComputeData): string =>
+  `${d.collectionId}: ${d.lastVersion ?? '(none)'} -> ${d.nextVersion} (tag: ${d.tag})\n`;
+
+/**
+ * Version compute command class.
+ */
+export class VersionComputeCommand extends Command {
+  public static readonly paths = [['version', 'compute']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Compute the next semver version + git tag for a collection.',
+    category: 'Build & Author',
+    details: `
+      Usage: ai-primitives-hub version compute [options]
+
+      Options:
+        -o, --output <format>           Output format (text, json, yaml, ndjson)
+        --collection-file <path>        Collection file path (repo-relative)
+    `
+  });
+
+  public output = Option.String('-o', '--output') as OutputFormat | undefined;
+  public collectionFile = Option.String('--collection-file');
+  public commandContext!: { ctx: Context };
+  /**
+   * Git tag enumeration hook, overridable by tests (set the field
+   * directly on the instance before calling `execute()`). Production
+   * dispatch via `runCli` never sets this, so it always falls back to
+   * `defaultGitTagsProvider`.
+   */
+  public gitTagsProvider: (cwd: string) => string[] = defaultGitTagsProvider;
+
+  public execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+    const fmt = (this.output ?? 'text');
+    const cwd = ctx.cwd();
+    try {
+      const data = computeNextVersion({
+        repoRoot: cwd,
+        collectionFile: this.collectionFile ?? '',
+        allTags: this.gitTagsProvider(cwd)
+      });
+      formatOutput({
+        ctx,
+        command: 'version.compute',
+        output: fmt,
+        status: 'ok',
+        data,
+        textRenderer: renderText
+      });
+      return Promise.resolve(0);
+    } catch (err) {
+      const re = err instanceof RegistryError
+        ? err
+        : new RegistryError({
+          code: 'INTERNAL.UNEXPECTED',
+          message: err instanceof Error ? err.message : String(err),
+          cause: err
+        });
+      emitError(ctx, fmt, re);
+      return Promise.resolve(1);
+    }
+  }
+}

--- a/packages/cli/src/doctor/diagnostics.ts
+++ b/packages/cli/src/doctor/diagnostics.ts
@@ -1,0 +1,859 @@
+/**
+ * Doctor diagnostics runner.
+ *
+ * `doctor diagnostics` runs a self-contained end-to-end smoke test in a
+ * temporary directory, exercising the same command sequence as the E2E user
+ * flow script. It is fully idempotent and re-entrant: every run creates a
+ * fresh temp workspace, and every run cleans up that workspace before exiting.
+ *
+ * The runner captures stdout/stderr and exit code for each step, so the
+ * diagnostic report can show exactly what the system saw and produced.
+ * @module doctor/diagnostics
+ */
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  BundleManifestCommand,
+} from '../commands/bundle-manifest';
+import {
+  CollectionListCommand,
+} from '../commands/collection-list';
+import {
+  CollectionValidateCommand,
+} from '../commands/collection-validate';
+import {
+  ConfigGetCommand,
+} from '../commands/config-get';
+import {
+  ExplainCommand,
+} from '../commands/explain';
+import {
+  HubAddCommand,
+  HubCreateCommand,
+  HubListCommand,
+  HubRefreshCommand,
+  HubSyncCommand,
+  HubUseCommand,
+} from '../commands/hub';
+import {
+  IndexBuildCommand,
+} from '../commands/index-build';
+import {
+  IndexEvalCommand,
+} from '../commands/index-eval';
+import {
+  IndexExportCommand,
+} from '../commands/index-export';
+import {
+  IndexSearchCommand,
+} from '../commands/index-search';
+import {
+  IndexShortlistAddCommand,
+  IndexShortlistListCommand,
+  IndexShortlistNewCommand,
+  IndexShortlistRemoveCommand,
+} from '../commands/index-shortlist';
+import {
+  IndexStatsCommand,
+} from '../commands/index-stats';
+import {
+  InstallCommand,
+} from '../commands/install';
+import {
+  PluginsListCommand,
+} from '../commands/plugins-list';
+import {
+  ProfileActivateCommand,
+  ProfileCurrentCommand,
+  ProfileDeactivateCommand,
+  ProfileListCommand,
+  ProfileShowCommand,
+} from '../commands/profile';
+import {
+  SourceAddCommand,
+  SourceListCommand,
+  SourceRemoveCommand,
+} from '../commands/source';
+import {
+  StatusCommand,
+} from '../commands/status';
+import {
+  TargetAddCommand,
+} from '../commands/target-add';
+import {
+  TargetListCommand,
+} from '../commands/target-list';
+import {
+  TargetTypesCommand,
+} from '../commands/target-types';
+import {
+  UninstallCommand,
+} from '../commands/uninstall';
+import {
+  UpdateCommand,
+} from '../commands/update';
+import {
+  type CapturedOutputStream,
+  type CommandClass,
+  type Context,
+  type FsAbstraction,
+  runCli,
+} from '../framework';
+
+/** Public input options for the diagnostics runner. */
+export interface DiagnosticsOptions {
+  /** Parent CLI context — env, fs, and stdout/stderr are derived from it. */
+  ctx: Context;
+  /** Native clipanion command classes to register for the run. */
+  commandClasses: CommandClass[];
+  /** Print extra per-step progress to the parent stderr. */
+  verbose?: boolean;
+}
+
+/** A single step in the diagnostic report. */
+export interface DiagnosticStep {
+  /** Human-readable step name. */
+  name: string;
+  /** Argument vector dispatched to the CLI. */
+  argv: string[];
+  /** Exit code returned by the CLI dispatcher. */
+  exitCode: number;
+  /** Captured stdout content. */
+  stdout: string;
+  /** Captured stderr content. */
+  stderr: string;
+  /** Free-form input context captured before the step (never secrets). */
+  input?: Record<string, unknown>;
+  /** Free-form output summary captured after the step. */
+  output?: Record<string, unknown>;
+  /** Wall-clock duration in milliseconds. */
+  durationMs: number;
+}
+
+/** Aggregate result from the diagnostics run. */
+export interface DiagnosticsResult {
+  /** True when every step exited 0. */
+  ok: boolean;
+  /** Absolute path of the temporary workspace used. */
+  workspace: string;
+  /** Per-step detailed log. */
+  steps: DiagnosticStep[];
+  /** Human-readable summary line. */
+  summary: string;
+}
+
+const createCapturingStream = (): CapturedOutputStream => {
+  let buffer = '';
+  return {
+    write: (chunk: string): void => {
+      buffer += chunk;
+    },
+    captured: (): string => buffer
+  };
+};
+
+/**
+ * Build a child Context that shares the parent's real fs/net but redirects
+ * stdout/stderr to a capture buffer and pins cwd/env to the diagnostic
+ * workspace.
+ * @param parent Parent production context.
+ * @param cwd Workspace directory for this command.
+ * @param env Environment bag for this command.
+ * @returns A context suitable for `runCli`.
+ */
+interface StepContext extends Context {
+  stdout: CapturedOutputStream;
+  stderr: CapturedOutputStream;
+}
+
+const createStepContext = (
+  parent: Context,
+  cwd: string,
+  env: Record<string, string | undefined>
+): StepContext => {
+  const stdout = createCapturingStream();
+  const stderr = createCapturingStream();
+  return {
+    ...parent,
+    stdout,
+    stderr,
+    cwd: (): string => cwd,
+    env: Object.freeze(env) as Context['env']
+  };
+};
+
+/**
+ * Run a single command inside the diagnostic workspace and capture the
+ * result. Optionally returns the captured output streams separately so the
+ * caller can forward them to the parent.
+ * @param opts Runner options.
+ * @param workspace Diagnostic workspace directory.
+ * @param name Step name for the report.
+ * @param argv Command argument vector.
+ * @param input Optional input context to record in the report.
+ * @returns Step result.
+ */
+const runDiagnosticStep = async (
+  opts: DiagnosticsOptions,
+  workspace: string,
+  name: string,
+  argv: string[],
+  input?: Record<string, unknown>
+): Promise<DiagnosticStep> => {
+  const env = buildDiagnosticEnv(opts.ctx, workspace);
+  const stepCtx = createStepContext(opts.ctx, workspace, env);
+  const started = Date.now();
+
+  const exitCode = await runCli(argv, {
+    ctx: stepCtx,
+    name: 'ai-primitives-hub',
+    version: '1.0.0',
+    commands: [],
+    commandClasses: opts.commandClasses
+  });
+
+  const durationMs = Date.now() - started;
+
+  if (opts.verbose && exitCode !== 0) {
+    opts.ctx.stderr.write(
+      `  [diagnostics] ${name} exited ${String(exitCode)}\n`
+      + `    stdout: ${stepCtx.stdout.captured().slice(0, 500)}\n`
+      + `    stderr: ${stepCtx.stderr.captured().slice(0, 500)}\n`
+    );
+  }
+
+  return {
+    name,
+    argv,
+    exitCode,
+    stdout: stepCtx.stdout.captured(),
+    stderr: stepCtx.stderr.captured(),
+    input,
+    durationMs
+  };
+};
+
+/**
+ * Resolve the base workspace path for this run. The directory is not created
+ * here; callers create and clean it.
+ * @returns Absolute path.
+ */
+const resolveWorkspacePath = (): string => {
+  const tmp = os.tmpdir();
+  const stamp = `${Date.now()}-${String(Math.random()).slice(2, 8)}`;
+  return path.join(tmp, `ai-primitives-hub-doctor-${stamp}`);
+};
+
+/**
+ * Build an environment bag that isolates XDG config/cache inside the
+ * workspace, so the diagnostic run never mutates the user's real
+ * ai-primitives-hub state.
+ * @param parent Parent context.
+ * @param workspace Diagnostic workspace.
+ * @returns Environment bag.
+ */
+const buildDiagnosticEnv = (
+  parent: Context,
+  workspace: string
+): Record<string, string | undefined> => {
+  const base = parent.env as Record<string, string | undefined>;
+  return {
+    ...base,
+    XDG_CONFIG_HOME: path.join(workspace, 'xdg'),
+    XDG_CACHE_HOME: path.join(workspace, 'cache'),
+    HOME: workspace,
+    USERPROFILE: workspace
+  };
+};
+
+/**
+ * Prepare the temporary workspace with the synthetic bundle and local hub
+ * configuration used by the diagnostic steps.
+ * @param ctx Context with real fs.
+ * @param workspace Workspace directory.
+ * @returns Object describing the created fixtures.
+ */
+const prepareWorkspace = async (
+  ctx: Context,
+  workspace: string
+): Promise<{
+  bundleDir: string;
+  bundleSubDir: string;
+  hubDir: string;
+  hubConfigFile: string;
+  targetDir: string;
+  collectionsDir: string;
+  goldFile: string;
+  exportDir: string;
+  hubId: string;
+  bundleId: string;
+  sourceId: string;
+  profileId: string;
+}> => {
+  const fsPromises = ctx.fs;
+  const bundleDir = path.join(workspace, 'bundle');
+  const hubDir = path.join(workspace, 'hub');
+  const targetDir = path.join(workspace, 'target');
+
+  await fsPromises.mkdir(bundleDir, { recursive: true });
+  await fsPromises.mkdir(hubDir, { recursive: true });
+  await fsPromises.mkdir(targetDir, { recursive: true });
+  const localFooDir = path.join(bundleDir, 'local-foo');
+  await fsPromises.mkdir(path.join(localFooDir, 'prompts'), { recursive: true });
+  await fsPromises.mkdir(path.join(localFooDir, 'skills', 'test-skill'), { recursive: true });
+
+  await fsPromises.writeFile(
+    path.join(localFooDir, 'deployment-manifest.yml'),
+    DEPLOYMENT_MANIFEST
+  );
+  await fsPromises.writeFile(
+    path.join(localFooDir, 'prompts', 'hello.prompt.md'),
+    HELLO_PROMPT
+  );
+  await fsPromises.writeFile(
+    path.join(localFooDir, 'skills', 'test-skill', 'SKILL.md'),
+    TEST_SKILL
+  );
+
+  const hubConfig = HUB_CONFIG
+    .replace(/\{\{BUNDLE_DIR\}\}/g, localFooDir)
+    .replace(/\{\{BUNDLE_ID\}\}/g, 'local-foo')
+    .replace(/\{\{SOURCE_ID\}\}/g, 'local-foo-src')
+    .replace(/\{\{PROFILE_ID\}\}/g, 'backend')
+    .replace(/\{\{HUB_ID\}\}/g, 'local-test-hub');
+  await fsPromises.writeFile(path.join(hubDir, 'hub-config.yml'), hubConfig);
+
+  const collectionsDir = path.join(workspace, 'collections');
+  await fsPromises.mkdir(collectionsDir, { recursive: true });
+  await fsPromises.writeFile(
+    path.join(collectionsDir, 'foo.collection.yml'),
+    COLLECTION_YML
+  );
+
+  const goldFile = path.join(workspace, 'gold-queries.json');
+  await fsPromises.writeFile(goldFile, GOLD_QUERIES);
+
+  const exportDir = path.join(workspace, 'exports');
+  await fsPromises.mkdir(exportDir, { recursive: true });
+
+  return {
+    bundleDir,
+    bundleSubDir: localFooDir,
+    hubDir,
+    hubConfigFile: path.join(hubDir, 'hub-config.yml'),
+    targetDir,
+    collectionsDir,
+    goldFile,
+    exportDir,
+    hubId: 'local-test-hub',
+    bundleId: 'local-foo',
+    sourceId: 'local-foo-src',
+    profileId: 'backend'
+  };
+};
+
+const DEPLOYMENT_MANIFEST = `id: local-foo
+version: 1.0.0
+name: Local Foo
+items:
+  - path: prompts/hello.prompt.md
+    kind: prompt
+  - path: skills/test-skill/SKILL.md
+    kind: skill
+`;
+
+const HELLO_PROMPT = `# Hello Prompt
+
+A diagnostic prompt.
+`;
+
+const TEST_SKILL = `# Test Skill
+
+A diagnostic skill.
+`;
+
+const HUB_CONFIG = `version: 1.0.0
+metadata:
+  name: Local Test Hub
+  description: Synthetic hub for diagnostic run
+  maintainer: doctor
+  updatedAt: '2026-01-01T00:00:00Z'
+sources:
+  - id: {{SOURCE_ID}}
+    name: Local Foo Source
+    type: local
+    url: {{BUNDLE_DIR}}
+    enabled: true
+    priority: 0
+    hubId: {{HUB_ID}}
+profiles:
+  - id: {{PROFILE_ID}}
+    name: Backend Developer
+    description: Diagnostic profile
+    bundles:
+      - id: {{BUNDLE_ID}}
+        version: 1.0.0
+        source: {{SOURCE_ID}}
+        required: true
+`;
+
+const COLLECTION_YML = `id: foo
+name: Foo Collection
+description: Diagnostic collection for validation
+items:
+  - path: bundle/local-foo/prompts/hello.prompt.md
+    kind: prompt
+  - path: bundle/local-foo/skills/test-skill/SKILL.md
+    kind: skill
+`;
+
+const GOLD_QUERIES = JSON.stringify({
+  cases: [
+    {
+      id: 'case-1',
+      query: { q: 'hello' },
+      mustMatch: [{ bundleId: 'local-foo' }]
+    }
+  ]
+});
+
+/**
+ * Extract the shortlist ID from a `shortlist new` JSON response.
+ * Falls back to 'shortlist-1' if parsing fails.
+ * @param stdout Captured stdout from the shortlist new command.
+ * @returns Shortlist ID string.
+ */
+const extractShortlistId = (stdout: string): string => {
+  try {
+    const parsed = JSON.parse(stdout) as { data?: { shortlist?: { id?: string } } };
+    return parsed.data?.shortlist?.id ?? 'shortlist-1';
+  } catch {
+    return 'shortlist-1';
+  }
+};
+
+/**
+ * Extract the first primitive ID from a search JSON response.
+ * Falls back to 'local-foo/hello.prompt.md' if parsing fails.
+ * @param stdout Captured stdout from the search command.
+ * @returns Primitive ID string.
+ */
+const extractFirstPrimitiveId = (stdout: string): string => {
+  try {
+    const parsed = JSON.parse(stdout) as { data?: { hits?: { primitive?: { id?: string } }[] } };
+    return parsed.data?.hits?.[0]?.primitive?.id ?? 'local-foo/hello.prompt.md';
+  } catch {
+    return 'local-foo/hello.prompt.md';
+  }
+};
+
+/**
+ * Verify that a file exists on disk and record the result.
+ * @param fsAbstraction fs abstraction.
+ * @param file File to check.
+ * @returns true when present.
+ */
+const fileExists = async (fsAbstraction: FsAbstraction, file: string): Promise<boolean> => {
+  try {
+    return await fsAbstraction.exists(file);
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Run the full diagnostic suite.
+ *
+ * The workspace is created fresh, populated with fixtures, exercised, and
+ * then removed. If a step fails, subsequent steps still run so the report
+ * shows the full picture; `ok` is false if any step exited non-zero.
+ * @param opts Runner options.
+ * @returns Aggregate diagnostics result.
+ */
+export const runDiagnostics = async (
+  opts: DiagnosticsOptions
+): Promise<DiagnosticsResult> => {
+  const workspace = resolveWorkspacePath();
+  const fsAbstraction = opts.ctx.fs;
+  const steps: DiagnosticStep[] = [];
+
+  const runStep = async (
+    name: string,
+    argv: string[],
+    input?: Record<string, unknown>
+  ): Promise<DiagnosticStep> => {
+    const step = await runDiagnosticStep(opts, workspace, name, argv, input);
+    steps.push(step);
+    return step;
+  };
+
+  try {
+    // Clean up any leftover from a previous aborted run.
+    await fsAbstraction.remove(workspace, { recursive: true });
+    await fsAbstraction.mkdir(workspace, { recursive: true });
+
+    const fixtures = await prepareWorkspace(opts.ctx, workspace);
+
+    // Step 1: Create a target.
+    await runStep('create-target', [
+      'target', 'add', 'copilot', '--type', 'copilot-cli', '--path', fixtures.targetDir,
+      '-o', 'json'
+    ], { targetDir: fixtures.targetDir });
+
+    // Step 2: Add a local hub.
+    await runStep('add-hub', [
+      'hub', 'add', '--type', 'local', '--location', fixtures.hubConfigFile,
+      '--id', fixtures.hubId,
+      '-o', 'json'
+    ], { hubConfigFile: fixtures.hubConfigFile, hubId: fixtures.hubId });
+
+    // Step 3: Activate the hub.
+    await runStep('use-hub', [
+      'hub', 'use', fixtures.hubId,
+      '-o', 'json'
+    ], { hubId: fixtures.hubId });
+
+    // Step 4: Sync the hub.
+    await runStep('sync-hub', [
+      'hub', 'sync', fixtures.hubId,
+      '-o', 'json'
+    ], { hubId: fixtures.hubId });
+
+    // Step 5: List available profiles.
+    await runStep('list-profiles', [
+      'profile', 'list',
+      '-o', 'json'
+    ]);
+
+    // Step 6: Show profile details.
+    await runStep('profile-show', [
+      'profile', 'show', fixtures.profileId,
+      '-o', 'json'
+    ], { profileId: fixtures.profileId });
+
+    // Step 7: Activate a profile.
+    await runStep('activate-profile', [
+      'profile', 'activate', fixtures.profileId, '--target', 'copilot',
+      '-o', 'json'
+    ], { profileId: fixtures.profileId, targetDir: fixtures.targetDir });
+
+    // Step 8: Show currently active profile.
+    await runStep('profile-current', [
+      'profile', 'current',
+      '-o', 'json'
+    ]);
+
+    // Step 9: Verify resources were installed.
+    const promptInstalled = await fileExists(
+      fsAbstraction,
+      path.join(fixtures.targetDir, 'prompts', 'hello.prompt.md')
+    );
+    const skillInstalled = await fileExists(
+      fsAbstraction,
+      path.join(fixtures.targetDir, 'skills', 'test-skill', 'SKILL.md')
+    );
+    await runStep('verify-installed', [
+      'status', '-o', 'json'
+    ], { promptInstalled, skillInstalled });
+
+    // Step 10: Build a local primitive index.
+    const indexPath = path.join(workspace, 'primitive-index.json');
+    await runStep('build-index', [
+      'index', 'build',
+      '--root', fixtures.bundleDir,
+      '--out', indexPath,
+      '--source-id', fixtures.sourceId,
+      '-o', 'json'
+    ], { bundleDir: fixtures.bundleDir });
+
+    // Step 11: Search the index.
+    const searchStep = await runStep('search-index', [
+      'index', 'search',
+      '--query', 'hello',
+      '--index', indexPath,
+      '-o', 'json'
+    ]);
+
+    // Step 12: Search the index filtered by kind.
+    await runStep('search-index-kinds', [
+      'index', 'search',
+      '--query', 'hello',
+      '--kinds', 'prompt',
+      '--index', indexPath,
+      '-o', 'json'
+    ]);
+
+    // Step 13: Show index statistics.
+    await runStep('index-stats', [
+      'index', 'stats',
+      '--index', indexPath,
+      '-o', 'json'
+    ]);
+
+    // Step 14: Create a shortlist.
+    const shortlistStep = await runStep('shortlist-new', [
+      'index', 'shortlist', 'new',
+      '--name', 'Diagnostic Shortlist',
+      '--index', indexPath,
+      '-o', 'json'
+    ]);
+
+    // Step 15: Add a primitive to the shortlist.
+    const shortlistId = extractShortlistId(shortlistStep.stdout);
+    const primitiveId = extractFirstPrimitiveId(searchStep.stdout);
+    await runStep('shortlist-add', [
+      'index', 'shortlist', 'add',
+      '--id', shortlistId,
+      '--primitive', primitiveId,
+      '--index', indexPath,
+      '-o', 'json'
+    ], { shortlistId, primitiveId });
+
+    // Step 16: List shortlists.
+    await runStep('shortlist-list', [
+      'index', 'shortlist', 'list',
+      '--index', indexPath,
+      '-o', 'json'
+    ]);
+
+    // Step 17: Remove the primitive from the shortlist.
+    await runStep('shortlist-remove', [
+      'index', 'shortlist', 'remove',
+      '--id', shortlistId,
+      '--primitive', primitiveId,
+      '--index', indexPath,
+      '-o', 'json'
+    ]);
+
+    // Step 18: Export shortlist as a profile YAML.
+    await runStep('index-export', [
+      'index', 'export',
+      '--shortlist', shortlistId,
+      '--profile-id', 'exported-profile',
+      '--out-dir', fixtures.exportDir,
+      '--index', indexPath,
+      '-o', 'json'
+    ], { exportDir: fixtures.exportDir });
+
+    // Step 19: Run pattern-based relevance eval.
+    await runStep('index-eval', [
+      'index', 'eval',
+      '--gold', fixtures.goldFile,
+      '--index', indexPath,
+      '-o', 'json'
+    ], { goldFile: fixtures.goldFile });
+
+    // Step 20: Deactivate the profile.
+    await runStep('deactivate-profile', [
+      'profile', 'deactivate',
+      '-o', 'json'
+    ]);
+
+    // Step 21: Verify resources were removed.
+    const promptRemoved = !(await fileExists(
+      fsAbstraction,
+      path.join(fixtures.targetDir, 'prompts', 'hello.prompt.md')
+    ));
+    const skillRemoved = !(await fileExists(
+      fsAbstraction,
+      path.join(fixtures.targetDir, 'skills', 'test-skill', 'SKILL.md')
+    ));
+    await runStep('verify-removed', [
+      'status', '-o', 'json'
+    ], { promptRemoved, skillRemoved });
+
+    // Step 22: Direct bundle install.
+    await runStep('install-bundle', [
+      'install', fixtures.bundleId,
+      '--from', fixtures.bundleSubDir,
+      '--target', 'copilot',
+      '-o', 'json'
+    ], { bundleSubDir: fixtures.bundleSubDir });
+
+    // Step 23: Update dry-run (should report 0 updates).
+    await runStep('update-dry-run', [
+      'update', '--dry-run', '--no-hub-sync', '--target', 'copilot',
+      '-o', 'json'
+    ]);
+
+    // Step 24: Uninstall all bundles for the target.
+    await runStep('uninstall-bundle', [
+      'uninstall', '--target', 'copilot', '--all',
+      '-o', 'json'
+    ]);
+
+    // Step 25: List configured targets.
+    await runStep('target-list', [
+      'target', 'list',
+      '-o', 'json'
+    ]);
+
+    // Step 26: List supported target types.
+    await runStep('target-types', [
+      'target', 'types',
+      '-o', 'json'
+    ]);
+
+    // Step 27: List imported hubs.
+    await runStep('hub-list', [
+      'hub', 'list',
+      '-o', 'json'
+    ]);
+
+    // Step 28: Refresh the active hub.
+    await runStep('hub-refresh', [
+      'hub', 'refresh',
+      '-o', 'json'
+    ]);
+
+    // Step 29: Scaffold a hub-config.yml skeleton.
+    await runStep('hub-create', [
+      'hub', 'create', '--name', 'Diagnostic Hub',
+      '--out', path.join(workspace, 'scaffolded-hub'),
+      '-o', 'json'
+    ]);
+
+    // Step 30: Add a detached source.
+    await runStep('source-add', [
+      'source', 'add', '--type', 'local', '--url', fixtures.bundleSubDir,
+      '--id', 'diag-source', '--name', 'Diagnostic Source',
+      '-o', 'json'
+    ], { bundleSubDir: fixtures.bundleSubDir });
+
+    // Step 31: List sources across all hubs.
+    await runStep('source-list', [
+      'source', 'list',
+      '-o', 'json'
+    ]);
+
+    // Step 32: Remove the detached source.
+    await runStep('source-remove', [
+      'source', 'remove', 'diag-source',
+      '-o', 'json'
+    ]);
+
+    // Step 33: List collections (from collections/ dir in workspace).
+    await runStep('collection-list', [
+      'collection', 'list',
+      '-o', 'json'
+    ], { collectionsDir: fixtures.collectionsDir });
+
+    // Step 34: Validate collections.
+    await runStep('collection-validate', [
+      'collection', 'validate',
+      '-o', 'json'
+    ]);
+
+    // Step 35: Generate a deployment manifest from the collection.
+    await runStep('bundle-manifest', [
+      'bundle', 'manifest',
+      '--version', '1.0.0',
+      '--collection-file', 'collections/foo.collection.yml',
+      '--out-file', path.join(workspace, 'generated-manifest.yml'),
+      '-o', 'json'
+    ]);
+
+    // Step 36: Explain an error code.
+    await runStep('explain', [
+      'explain', 'INDEX.NOT_FOUND',
+      '-o', 'json'
+    ]);
+
+    // Step 37: List CLI plugins.
+    await runStep('plugins-list', [
+      'plugins', 'list',
+      '-o', 'json'
+    ]);
+
+    // Step 38: Read a config value.
+    await runStep('config-get', [
+      'config', 'get', 'output.json.indent',
+      '-o', 'json'
+    ]);
+
+    // Step 39: Final status check.
+    await runStep('final-status', [
+      'status', '-o', 'json'
+    ]);
+
+    // Step 40: Search alias as top-level command.
+    await runStep('search-alias', [
+      'search', '--query', 'hello',
+      '--index', indexPath,
+      '-o', 'json'
+    ]);
+  } catch (err) {
+    // Record the unexpected error as a synthetic step so the report always
+    // explains why the run stopped.
+    steps.push({
+      name: 'unexpected-error',
+      argv: [],
+      exitCode: 1,
+      stdout: '',
+      stderr: err instanceof Error ? err.message : String(err),
+      input: { workspace },
+      durationMs: 0
+    });
+  } finally {
+    // Always remove the workspace, even when steps fail.
+    try {
+      await fsAbstraction.remove(workspace, { recursive: true });
+    } catch {
+      // Best-effort cleanup; do not mask the real failure.
+    }
+  }
+
+  const failed = steps.filter((s) => s.exitCode !== 0);
+  const ok = failed.length === 0;
+  return {
+    ok,
+    workspace,
+    steps,
+    summary: ok
+      ? `all ${steps.length} diagnostic steps passed`
+      : `${failed.length} of ${steps.length} diagnostic steps failed`
+  };
+};
+
+/**
+ * Native clipanion command classes the diagnostic suite needs registered.
+ * @returns Command class array suitable for `runCli` / `DiagnosticsOptions`.
+ */
+export const getDiagnosticCommandClasses = (): CommandClass[] => [
+  StatusCommand,
+  TargetAddCommand,
+  TargetListCommand,
+  TargetTypesCommand,
+  HubAddCommand,
+  HubUseCommand,
+  HubSyncCommand,
+  HubListCommand,
+  HubRefreshCommand,
+  HubCreateCommand,
+  ProfileListCommand,
+  ProfileShowCommand,
+  ProfileCurrentCommand,
+  ProfileActivateCommand,
+  ProfileDeactivateCommand,
+  IndexBuildCommand,
+  IndexSearchCommand,
+  IndexStatsCommand,
+  IndexShortlistNewCommand,
+  IndexShortlistAddCommand,
+  IndexShortlistRemoveCommand,
+  IndexShortlistListCommand,
+  IndexExportCommand,
+  IndexEvalCommand,
+  InstallCommand,
+  UninstallCommand,
+  UpdateCommand,
+  SourceAddCommand,
+  SourceListCommand,
+  SourceRemoveCommand,
+  CollectionListCommand,
+  CollectionValidateCommand,
+  BundleManifestCommand,
+  ExplainCommand,
+  PluginsListCommand,
+  ConfigGetCommand
+];

--- a/packages/cli/src/framework/cli.ts
+++ b/packages/cli/src/framework/cli.ts
@@ -1,0 +1,275 @@
+/**
+ * Framework adapter (clipanion wrapping).
+ *
+ * Invariant — only this folder is allowed to import
+ * clipanion. Leaf command code uses `defineCommand` and `runCli` from
+ * the public barrel; clipanion details never leak.
+ *
+ * Adapter contract
+ *   defineCommand({ path, description, run }) — declarative definition
+ *   runCli(argv, opts) — dispatch argv against registered commands and
+ *                       return an exit code (never throws on usage errors)
+ *
+ * Exit-code policy
+ *   command return value -> propagated as-is
+ *   unknown command      -> 64 (EX_USAGE)
+ *   thrown error         -> 70 (EX_SOFTWARE)
+ *   --version / --help   -> 0
+ * @module framework/cli
+ */
+import type {
+  HttpClient,
+  TokenProvider,
+} from '@ai-primitives-hub/core';
+import {
+  Builtins,
+  Cli,
+  Command,
+  UsageError,
+} from 'clipanion';
+import type {
+  CommandClass,
+} from 'clipanion';
+import type {
+  Context,
+} from './context';
+import {
+  renderGlobalHelp,
+} from './help-renderer';
+import {
+  suggestCommand,
+} from './suggest';
+
+/**
+ * Public command shape returned by `defineCommand`. Pure data plus a run
+ * handler — no clipanion type leaks.
+ */
+export interface CommandDefinition {
+  /** Noun-verb path tuple, e.g. `['index', 'search']`. */
+  path: string[];
+  /** One-line description shown in --help listings. */
+  description: string;
+  /** Handler invoked when the command is dispatched. */
+  run: (args: { ctx: Context }) => number | Promise<number>;
+  /** Category for grouping commands in help output. */
+  category?: string;
+}
+
+/**
+ * Options accepted by `runCli`.
+ */
+export interface RunCliOptions {
+  /** Application Context (production or test). */
+  ctx: Context;
+  /** Registered commands (wrapped via DynamicCommand). */
+  commands: CommandDefinition[];
+  /** Native clipanion command classes registered directly. */
+  commandClasses?: CommandClass[];
+  /** Binary name used in usage output. */
+  name: string;
+  /** Binary version reported by --version. */
+  version: string;
+  /** Optional HTTP client for hub/profile commands. */
+  http?: HttpClient;
+  /** Optional token provider for hub/profile commands. */
+  tokens?: TokenProvider;
+  /** Default output format applied to commands that have no explicit -o flag. */
+  defaultOutput?: string;
+}
+
+/**
+ * Define a command declaratively.
+ * @param def Command definition (path / description / run).
+ * @returns The same definition object, frozen.
+ */
+export const defineCommand = (def: CommandDefinition): CommandDefinition =>
+  Object.freeze({ ...def });
+
+/**
+ * Adapt an `OutputStream` to the duck-typed `Writable` shape clipanion
+ * expects. Only `.write()` is invoked by clipanion's runtime for normal
+ * paths; we forward to our captured sink. `.end()` and other Writable
+ * methods are no-ops — clipanion does not require them for `cli.run`.
+ * @param out
+ * @param out.write
+ */
+const adaptWritable = (out: { write: (chunk: string) => void }): NodeJS.WriteStream => {
+  const stream = {
+    write: (chunk: string | Uint8Array): boolean => {
+      const text = typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+      out.write(text);
+      return true;
+    },
+    end: (): void => undefined
+  };
+  // Cast to clipanion's expected type. Clipanion's BaseContext narrows
+  // the type but only calls .write/.end at runtime, so this duck-type
+  // is sufficient.
+  return stream as unknown as NodeJS.WriteStream;
+};
+
+const adaptReadable = (): NodeJS.ReadStream => {
+  const stream = {
+    read: (): null => null
+  };
+  return stream as unknown as NodeJS.ReadStream;
+};
+
+/**
+ * Build a dynamic clipanion Command class that closes over our run
+ * handler and our `Context`. `execute()` returns the exit code so
+ * clipanion can propagate it unchanged.
+ * @param def
+ * @param ctx
+ */
+const toClipanionCommandClass = (
+  def: CommandDefinition,
+  ctx: Context
+): CommandClass => {
+  class DynamicCommand extends Command {
+    public static readonly paths: string[][] = [def.path];
+    // eslint-disable-next-line @typescript-eslint/explicit-member-accessibility -- clipanion's static factory uses PascalCase by convention; we mirror its API.
+    static readonly usage = Command.Usage({ description: def.description, category: def.category });
+
+    public async execute(): Promise<number> {
+      return def.run({ ctx });
+    }
+  }
+  return DynamicCommand;
+};
+
+/**
+ * Dispatch an argv vector against the registered commands.
+ * @param argv  Argument vector — typically `process.argv.slice(2)` in
+ *              production, or a literal array in tests.
+ * @param opts  ctx / commands / name / version.
+ * @returns Exit code (0 success, 64 usage, 70 internal, or whatever
+ *          the command handler returned).
+ */
+export const runCli = async (argv: string[], opts: RunCliOptions): Promise<number> => {
+  const cli = new Cli({
+    binaryName: opts.name,
+    binaryVersion: opts.version,
+    enableColors: opts.ctx.colorDepth > 0
+  });
+
+  // Built-in --help and --version commands.
+  cli.register(Builtins.HelpCommand);
+  cli.register(Builtins.VersionCommand);
+
+  for (const def of opts.commands) {
+    cli.register(toClipanionCommandClass(def, opts.ctx));
+  }
+
+  for (const cls of opts.commandClasses ?? []) {
+    cli.register(cls);
+  }
+
+  const clipanionCtx = {
+    env: opts.ctx.env as Record<string, string | undefined>,
+    stdin: adaptReadable(),
+    stdout: adaptWritable(opts.ctx.stdout),
+    stderr: adaptWritable(opts.ctx.stderr),
+    colorDepth: opts.ctx.colorDepth
+  };
+
+  // Bare invocation or top-level --help: render custom landing page.
+  if (argv.length === 0 || argv[0] === '--help' || argv[0] === '-h') {
+    opts.ctx.stdout.write(renderGlobalHelp(cli, opts.name, opts.version));
+    return 0;
+  }
+
+  // Top-level --version: print "name version" (clipanion's built-in only
+  // prints the version, but our tests and callers expect the binary name).
+  if (argv[0] === '--version' || argv[0] === '-v') {
+    opts.ctx.stdout.write(`${opts.name} ${opts.version}\n`);
+    return 0;
+  }
+
+  // We bypass clipanion's `cli.run` because (a) it always returns 0/1,
+  // collapsing the EX_USAGE / EX_SOFTWARE distinction we need,
+  // and (b) it writes errors to stdout instead of stderr.
+  // Instead we use `cli.process()` to parse argv into a Command, wire
+  // up the bindings clipanion's run() would otherwise set, then call
+  // validateAndExecute() ourselves with a try/catch around each phase.
+  let command;
+  try {
+    command = cli.process({ input: argv, context: clipanionCtx });
+  } catch (err) {
+    // process() throws on unknown command, bad flags, missing arg, etc.
+    // That's EX_USAGE = 64.
+    const message = err instanceof Error ? err.message : String(err);
+    opts.ctx.stderr.write(`${message}\n`);
+
+    const suggestion = suggestCommand(argv, cli, opts.name);
+    if (suggestion !== undefined) {
+      opts.ctx.stderr.write(`Did you mean: ${suggestion}\n`);
+    }
+
+    return 64;
+  }
+
+  // Wire bindings the way clipanion's own cli.run() does — without
+  // these, HelpCommand and VersionCommand crash because they read
+  // `this.context` and `this.cli`. Mirroring the binding shape from
+  // clipanion's lib/advanced/Cli.js#run().
+  command.context = clipanionCtx;
+  command.cli = {
+    binaryLabel: opts.name,
+    binaryName: opts.name,
+    binaryVersion: opts.version,
+    enableCapture: false,
+    enableColors: opts.ctx.colorDepth > 0,
+    definitions: () => cli.definitions(),
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- clipanion internal API accepts any
+    definition: (c: any) => cli.definition(c),
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- clipanion internal API accepts any
+    error: (e: any, o: any) => cli.error(e, o),
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- clipanion internal API accepts any
+    format: (c: any) => cli.format(c),
+
+    process: (input: any, subContext: any) => cli.process({
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- clipanion process() accepts any input
+      input,
+      context: { ...clipanionCtx, ...(subContext as object) }
+    }),
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- clipanion internal API accepts any
+    run: (input: any, subContext: any) => cli.run(input, { ...clipanionCtx, ...subContext }),
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- clipanion internal API accepts any
+    usage: (c: any, o: any) => cli.usage(c, o)
+  };
+
+  // Inject commandContext for all native clipanion command classes.
+  // Simple commands only read .ctx; hub/profile/source commands also read .http/.tokens.
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- dynamic property assignment on native clipanion command instance
+  (command as any).commandContext = { ctx: opts.ctx, http: opts.http, tokens: opts.tokens };
+
+  // Apply defaultOutput when the command declares an output field but the
+  // user did not pass an explicit -o / --output flag.
+  if (opts.defaultOutput !== undefined) {
+    const cmd = command as { output?: string };
+    cmd.output ??= opts.defaultOutput;
+  }
+
+  // Per-command --help: clipanion sets `command.help = true` when -h/
+  // --help follows a registered command path. Honour that by printing
+  // the detailed usage and exiting 0 — same behavior cli.run provides.
+  if ((command as { help?: boolean }).help === true) {
+    opts.ctx.stdout.write(cli.usage(command, { detailed: true }));
+    return 0;
+  }
+
+  try {
+    const exitCode = await command.validateAndExecute();
+    return exitCode ?? 0;
+  } catch (err) {
+    if (err instanceof UsageError) {
+      opts.ctx.stderr.write(`${(err as Error).message}\n`);
+      return 64;
+    }
+    // Any other thrown error is an internal bug — EX_SOFTWARE = 70.
+    const message = err instanceof Error ? err.message : String(err);
+    opts.ctx.stderr.write(`${message}\n`);
+    return 70;
+  }
+};

--- a/packages/cli/src/framework/command-class.ts
+++ b/packages/cli/src/framework/command-class.ts
@@ -1,0 +1,47 @@
+/**
+ * Utility for configuring native Clipanion command subclasses.
+ *
+ * The `copyCommandPrototype` helper ensures that Clipanion's option
+ * metadata (discovered via prototype property descriptors) is visible on
+ * the dynamically-created `ConfiguredCommand` subclass. Without this,
+ * Clipanion only sees options declared on the concrete subclass itself
+ * rather than inheriting them from the base class's prototype.
+ * @module framework/command-class
+ */
+
+/**
+ * Copy all non-constructor property descriptors from a base command class to
+ * a subclass prototype so that Clipanion discovers the inherited options and
+ * the static `usage` shape.
+ * @param baseClass - The original command class whose options to inherit.
+ * @param subClass - The dynamically-created subclass to configure.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type -- generic class reference
+export const copyCommandPrototype = (baseClass: Function, subClass: Function): void => {
+  // Copy prototype descriptors (methods, getters, setters).
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- dynamic prototype access
+  const baseDescriptors = Object.getOwnPropertyDescriptors((baseClass as any).prototype);
+  for (const [key, descriptor] of Object.entries(baseDescriptors)) {
+    if (key !== 'constructor') {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- dynamic prototype access
+      Object.defineProperty((subClass as any).prototype, key, descriptor);
+    }
+  }
+
+  // Copy class fields (own properties on a base instance) so inherited
+  // clipanion options and other field declarations are visible on the
+  // subclass instances.
+  const baseInstance = new (baseClass as unknown as new () => object)();
+  for (const [key, descriptor] of Object.entries(Object.getOwnPropertyDescriptors(baseInstance))) {
+    if (key !== 'constructor') {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- dynamic prototype access
+      Object.defineProperty((subClass as any).prototype, key, descriptor);
+    }
+  }
+
+  // Copy static clipanion metadata (paths / usage) to the subclass.
+  const staticBase = baseClass as unknown as { paths?: unknown; usage?: unknown };
+  const staticSub = subClass as unknown as { paths?: unknown; usage?: unknown };
+  staticSub.paths = staticBase.paths;
+  staticSub.usage = staticBase.usage;
+};

--- a/packages/cli/src/framework/config.ts
+++ b/packages/cli/src/framework/config.ts
@@ -1,0 +1,293 @@
+/**
+ * Layered YAML config loader.
+ *
+ * Implements the precedence chain:
+ *   1. Built-in defaults
+ *   2. User config         ($XDG_CONFIG_HOME/ai-primitives-hub/config.yml,
+ *                           or ~/.config/ai-primitives-hub/config.yml)
+ *   3. Project config      (./ai-primitives-hub.yml, walking upward
+ *                           Cargo-style)
+ *   4. Env vars            (AI_PRIMITIVES_HUB_<DOTTED_PATH> mapped to
+ *                           camelCase keys)
+ *   5. --config FILE       (explicit file override)
+ *   6. --config KEY=VALUE  (single-key override; stub, full
+ *                           support in a later iteration)
+ *   7. CLI flags           (handled by `runCli`, not here)
+ *   8. Profile activation  (later iteration alongside the formatter)
+ *
+ * Each layer is a plain object that gets *deeply merged* into the
+ * accumulator. Later layers override earlier ones at the leaf level,
+ * preserving sibling keys.
+ *
+ * No external config-loader library is used. We have js-yaml already as
+ * a dependency, and the discovery rules are simple enough that a custom
+ * loader stays under 100 lines and gives us full control over the
+ * precedence semantics. (The choice is "any loader that gives us full ordering
+ * control", and this hand-rolled implementation qualifies while saving
+ * a transitive dep tree.)
+ *
+ * User-config root and project/env-var names rebranded per migration
+ * plan §8 decision 3 (CLI-only, unreleased artifact — `prompt-registry`
+ * -> `ai-primitives-hub`). Layer 2's root delegates to `infra`'s
+ * `xdgConfigDir` (ADR-0005) instead of re-implementing the
+ * `XDG_CONFIG_HOME`/`~/.config` fallback inline as the reference
+ * branch's own version of this file does.
+ * @module framework/config
+ */
+import * as path from 'node:path';
+import {
+  xdgConfigDir,
+} from '@ai-primitives-hub/infra';
+import {
+  load as parseYaml,
+} from 'js-yaml';
+
+/**
+ * Subset of `FsAbstraction` the loader needs. Kept narrower than
+ * `FsAbstraction` so loadConfig() doesn't drag the full 8-op surface
+ * into its signature — only what it actually uses.
+ */
+export interface ConfigFs {
+  readFile(path: string): Promise<string>;
+  exists(path: string): Promise<boolean>;
+}
+
+export interface LoadConfigOptions {
+  /** Working directory to start the upward walk from. */
+  cwd: string;
+  /** Process-style env map (AI_PRIMITIVES_HUB_* keys are consumed). */
+  env: Readonly<Record<string, string>>;
+  /** Optional --config FILE path; if set, becomes layer 5. */
+  configFile?: string;
+  /** Filesystem surface (production fs or in-memory stub). */
+  fs: ConfigFs;
+}
+
+/**
+ * Resolved config — a plain Record with nested values. Specific keys
+ * (`output`, `verbose`, `quiet`, `index`, etc.) are documented
+ * but the loader is schema-agnostic: it produces a
+ * Record and lets later iterations validate.
+ */
+export type Config = Record<string, unknown>;
+
+const DEFAULTS: Config = {
+  version: 1,
+  output: 'text',
+  verbose: false,
+  quiet: false
+};
+
+const ENV_PREFIX = 'AI_PRIMITIVES_HUB_';
+const PROJECT_CONFIG_NAMES = ['ai-primitives-hub.yaml', 'ai-primitives-hub.yml'];
+const USER_CONFIG_FILENAME = 'config.yml';
+
+/**
+ * Load layered configuration.
+ * @param opts cwd / env / configFile / fs.
+ * @returns Deeply-merged Config object.
+ * @throws {Error} If `configFile` is set but does not exist.
+ */
+export const loadConfig = async (opts: LoadConfigOptions): Promise<Config> => {
+  const layers: Config[] = [DEFAULTS];
+
+  const userLayer = await loadUserConfig(opts);
+  if (userLayer !== undefined) {
+    layers.push(userLayer);
+  }
+
+  const projectLayer = await loadProjectConfig(opts);
+  if (projectLayer !== undefined) {
+    layers.push(projectLayer);
+  }
+
+  const envLayer = loadEnvLayer(opts.env);
+  if (Object.keys(envLayer).length > 0) {
+    layers.push(envLayer);
+  }
+
+  if (opts.configFile !== undefined) {
+    const fileLayer = await loadConfigFile(opts.configFile, opts.fs);
+    layers.push(fileLayer);
+  }
+
+  return layers.reduce((acc, layer) => deepMerge(acc, layer), {} as Config);
+};
+
+/**
+ * Layer 2: user config from $XDG_CONFIG_HOME or ~/.config.
+ * @param opts cwd / env / fs.
+ * @returns Parsed user config or undefined when the file is absent.
+ */
+const loadUserConfig = async (opts: LoadConfigOptions): Promise<Config | undefined> => {
+  const userPath = path.join(xdgConfigDir(opts.env), USER_CONFIG_FILENAME);
+  if (!(await opts.fs.exists(userPath))) {
+    return undefined;
+  }
+  return parseYamlFile(userPath, opts.fs);
+};
+
+/**
+ * Resolve the project config file path via Cargo-style upward walk.
+ * @param opts cwd / fs.
+ * @returns Absolute path to the first found config file, or undefined.
+ */
+export const resolveProjectConfigPath = async (opts: LoadConfigOptions): Promise<string | undefined> => {
+  let dir = opts.cwd;
+  while (true) {
+    for (const name of PROJECT_CONFIG_NAMES) {
+      const candidate = path.join(dir, name);
+      if (await opts.fs.exists(candidate)) {
+        return candidate;
+      }
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      return undefined;
+    }
+    dir = parent;
+  }
+};
+
+/**
+ * Layer 3: project config via Cargo-style upward walk.
+ * @param opts cwd / fs.
+ * @returns Parsed project config or undefined when no file is found
+ *          before reaching the filesystem root.
+ */
+const loadProjectConfig = async (opts: LoadConfigOptions): Promise<Config | undefined> => {
+  const configPath = await resolveProjectConfigPath(opts);
+  if (configPath === undefined) {
+    return undefined;
+  }
+  return parseYamlFile(configPath, opts.fs);
+};
+
+/**
+ * Layer 4: env vars. Keys starting with `AI_PRIMITIVES_HUB_` are mapped
+ * to config keys with the following convention:
+ *   - **Double underscore (`__`)** is the *path separator* — it nests
+ *     a value into a sub-object. `AI_PRIMITIVES_HUB_INDEX__TTL=120`
+ *     produces `{ index: { ttl: 120 } }`.
+ *   - **Single underscore (`_`)** within a path segment produces a
+ *     **camelCase** key. `AI_PRIMITIVES_HUB_INDEX_PATH=/x` produces
+ *     `{ indexPath: '/x' }` (one segment, camelCase joined).
+ *   - Values `"true"`/`"false"` coerce to booleans; pure numeric
+ *     strings coerce to numbers.
+ *
+ * The double-underscore convention is borrowed from environments like
+ * Helm, Hyperion, and various Java frameworks where nesting is common.
+ * It keeps the bare single-underscore case readable for the simple
+ * top-level flags (verbose, quiet, output) which are the usual case.
+ * @param env Process-style env map.
+ * @returns Sparse Config containing only the keys derived from env vars.
+ */
+const loadEnvLayer = (env: Readonly<Record<string, string>>): Config => {
+  const out: Config = {};
+  for (const [k, raw] of Object.entries(env)) {
+    if (!k.startsWith(ENV_PREFIX)) {
+      continue;
+    }
+    const tail = k.slice(ENV_PREFIX.length);
+    if (tail.length === 0) {
+      continue;
+    }
+    const segments = tail.split('__').filter((s) => s.length > 0);
+    if (segments.length === 0) {
+      continue;
+    }
+    const keyPath = segments.map((s) => toCamelCase(s));
+    setAtPath(out, keyPath, coerceEnvValue(raw));
+  }
+  return out;
+};
+
+/**
+ * Set a value at a nested key path, creating intermediate objects as
+ * needed. Used by the env-var layer to honour the double-underscore
+ * path-separator convention.
+ * @param target Object to mutate.
+ * @param keyPath Segments of the key path (camelCase already applied).
+ * @param value  The value to set at the leaf.
+ */
+const setAtPath = (target: Config, keyPath: string[], value: unknown): void => {
+  let cursor = target;
+  for (let i = 0; i < keyPath.length - 1; i += 1) {
+    const seg = keyPath[i];
+    const existing = cursor[seg];
+    if (!isPlainObject(existing)) {
+      cursor[seg] = {};
+    }
+    cursor = cursor[seg] as Config;
+  }
+  // Safe: caller guarantees keyPath.length >= 1 via the segments filter.
+  cursor[keyPath.at(-1) as string] = value;
+};
+
+/**
+ * Layer 5: explicit `--config FILE` override.
+ * @param file Absolute or cwd-relative path to a YAML config file.
+ * @param fs   Filesystem surface used to check existence and read.
+ * @returns Parsed config.
+ * @throws {Error} If the file is not found.
+ */
+const loadConfigFile = async (file: string, fs: ConfigFs): Promise<Config> => {
+  if (!(await fs.exists(file))) {
+    throw new Error(`Config file not found: ${file}`);
+  }
+  return parseYamlFile(file, fs);
+};
+
+const parseYamlFile = async (file: string, fs: ConfigFs): Promise<Config> => {
+  const raw = await fs.readFile(file);
+  const parsed = parseYaml(raw);
+  if (parsed === null || parsed === undefined) {
+    return {};
+  }
+  if (typeof parsed !== 'object') {
+    throw new TypeError(`Config at ${file} must be a YAML mapping at top level`);
+  }
+  return parsed as Config;
+};
+
+const toCamelCase = (token: string): string => {
+  const parts = token.toLowerCase().split('_').filter((p) => p.length > 0);
+  if (parts.length === 0) {
+    return '';
+  }
+  return parts.map((p, i) => i === 0 ? p : p.charAt(0).toUpperCase() + p.slice(1)).join('');
+};
+
+const coerceEnvValue = (raw: string): unknown => {
+  if (raw === 'true') {
+    return true;
+  }
+  if (raw === 'false') {
+    return false;
+  }
+  if (raw !== '' && /^-?\d+(\.\d+)?$/.test(raw)) {
+    return Number(raw);
+  }
+  return raw;
+};
+
+const isPlainObject = (v: unknown): v is Record<string, unknown> =>
+  typeof v === 'object' && v !== null && !Array.isArray(v);
+
+/**
+ * Deeply merge `over` into `base`. Plain objects merge recursively;
+ * arrays and primitives are replaced wholesale by `over`. Later layers
+ * win at the leaf level while preserving sibling keys from earlier
+ * layers — which is what "deep merge" means.
+ * @param base Earlier (lower-precedence) layer.
+ * @param over Later (higher-precedence) layer.
+ * @returns Merged Config (new object; inputs are not mutated).
+ */
+const deepMerge = (base: Config, over: Config): Config => {
+  const out: Config = { ...base };
+  for (const [k, v] of Object.entries(over)) {
+    const baseV = out[k];
+    out[k] = isPlainObject(v) && isPlainObject(baseV) ? deepMerge(baseV, v) : v;
+  }
+  return out;
+};

--- a/packages/cli/src/framework/context.ts
+++ b/packages/cli/src/framework/context.ts
@@ -1,0 +1,103 @@
+/**
+ * Context interface skeleton.
+ *
+ * The `Context` object is the single seam through which every
+ * ai-primitives-hub subcommand performs IO. This is called
+ * "Context-only IO" and is ESLint-enforced (rule lands in a later
+ * iteration).
+ *
+ * `FileSystem` and `Clock` are defined in `@ai-primitives-hub/core`'s
+ * `ports/` and re-exported here as backward-compatible type aliases
+ * (`FsAbstraction`, `ClockAbstraction`). Feature layers (`app`, `infra`)
+ * import directly from `@ai-primitives-hub/core`; CLI-layer code may
+ * continue to import from this file via the framework barrel.
+ * @module framework/context
+ */
+import type {
+  Clock,
+  FileSystem,
+} from '@ai-primitives-hub/core';
+
+/**
+ * Filesystem abstraction — backward-compatible alias for {@link FileSystem}.
+ * New code should import `FileSystem` from `@ai-primitives-hub/core` directly.
+ */
+export type FsAbstraction = FileSystem;
+
+/**
+ * Network abstraction — single fetch-like call returning a streaming body.
+ * Later wraps undici; tests use undici's MockAgent (same library in prod
+ * and test, no global mutation, no nock).
+ */
+export interface NetAbstraction {
+  fetch(url: string, init?: NetRequestInit): Promise<NetResponse>;
+}
+
+export interface NetRequestInit {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string | Uint8Array;
+}
+
+export interface NetResponse {
+  status: number;
+  headers: Record<string, string>;
+  text(): Promise<string>;
+  json<T = unknown>(): Promise<T>;
+  bytes(): Promise<Uint8Array>;
+}
+
+/**
+ * Clock abstraction — backward-compatible alias for {@link Clock}.
+ * New code should import `Clock` from `@ai-primitives-hub/core` directly.
+ */
+export type ClockAbstraction = Clock;
+
+export type {
+  TestClock,
+} from '@ai-primitives-hub/core';
+
+/**
+ * Output stream abstraction — `write()` is the only sink, mirroring the
+ * `Writable.write()` shape so production wiring (process.stdout) and the
+ * test capture sink can share a contract. `captured()` is exposed only
+ * by the test sink; production streams expose `flush()` instead (added in
+ * a later iteration alongside the formatter).
+ */
+export interface OutputStream {
+  write(chunk: string): void;
+}
+
+export interface CapturedOutputStream extends OutputStream {
+  captured(): string;
+}
+
+/**
+ * Input stream abstraction — only needs static `read()` for
+ * non-interactive command tests (e.g. piped JSON). Streaming stdin
+ * (interactive prompts) is added in a later iteration when the doctor stub lands.
+ */
+export interface InputStream {
+  read(): string;
+}
+
+/**
+ * Context — the single object passed to every command. Carries every IO
+ * surface the command might need plus environment/cwd/exit hooks.
+ */
+export interface Context {
+  fs: FileSystem;
+  net: NetAbstraction;
+  clock: ClockAbstraction;
+  stdin: InputStream;
+  stdout: OutputStream;
+  stderr: OutputStream;
+  env: Readonly<Record<string, string>>;
+  cwd(): string;
+  exit(code: number): void;
+  /**
+   * Terminal color depth (0 = monochrome, 1 = basic, 4 = ANSI, 8 = 256-color, 24 = truecolor).
+   * Used by the CLI framework to decide whether to emit ANSI color codes.
+   */
+  colorDepth: number;
+}

--- a/packages/cli/src/framework/error.ts
+++ b/packages/cli/src/framework/error.ts
@@ -1,0 +1,326 @@
+/**
+ * RegistryError + renderError + failWith.
+ *
+ * `RegistryError`, `isRegistryError`, and related types are defined in
+ * `@ai-primitives-hub/core`'s `domain/registry-error` and re-exported
+ * here for backward compatibility. Only `renderError` and `failWith`
+ * live here, because they depend on `Context` and `formatOutput` (CLI
+ * concepts) for stderr and structured output.
+ *
+ * Hint strings and the per-project state directory rebranded per
+ * migration plan §8 decision 3 (CLI-only, unreleased artifact —
+ * `prompt-registry` -> `ai-primitives-hub`, `.prompt-registry/` ->
+ * `.ai-primitives-hub/`).
+ * @module framework/error
+ */
+import {
+  isRegistryError,
+  RegistryError,
+} from '@ai-primitives-hub/core';
+import type {
+  Context,
+} from './context';
+import {
+  formatOutput,
+} from './output';
+import type {
+  OutputFormat,
+} from './output';
+
+export type {
+  RegistryErrorNamespace,
+  RegistryErrorOptions,
+} from '@ai-primitives-hub/core';
+
+export {
+  isRegistryError,
+  RegistryError,
+} from '@ai-primitives-hub/core';
+
+/**
+ * Render an error to `ctx.stderr` for human consumption. The output
+ * shape is:
+ *
+ *   error[CODE]: <message>
+ *     hint: <hint>
+ *     docs: <docsUrl>
+ *
+ * where the hint and docs lines are omitted when absent.
+ *
+ * Non-RegistryError values are wrapped as `INTERNAL.UNEXPECTED` so the
+ * renderer is total — callers do not need to type-narrow before
+ * delegating to it.
+ * @param err Anything thrown — RegistryError or otherwise.
+ * @param ctx Context whose stderr will receive the rendering.
+ */
+export const renderError = (err: unknown, ctx: Context): void => {
+  const re = isRegistryError(err) ? err : asInternalError(err);
+  const lines: string[] = [`error[${re.code}]: ${re.message}`];
+  if (re.hint !== undefined) {
+    lines.push(`  hint: ${re.hint}`);
+  }
+  if (re.docsUrl !== undefined) {
+    lines.push(`  docs: ${re.docsUrl}`);
+  }
+  ctx.stderr.write(`${lines.join('\n')}\n`);
+};
+
+const asInternalError = (err: unknown): RegistryError => {
+  const message = err instanceof Error ? err.message : String(err);
+  return new RegistryError({
+    code: 'INTERNAL.UNEXPECTED',
+    message,
+    cause: err
+  });
+};
+
+/**
+ * Shared error formatter for CLI commands.
+ *
+ * Outputs structured error data for json/yaml/ndjson formats, or renders
+ * human-readable error to stderr for text format. Returns exit code 1.
+ * @param ctx CLI context.
+ * @param output Output format (json, yaml, ndjson, text).
+ * @param command Command name for structured output (e.g., 'index.build').
+ * @param err RegistryError to format.
+ * @returns Exit code 1.
+ */
+export const failWith = (
+  ctx: Context,
+  output: OutputFormat,
+  command: string,
+  err: RegistryError
+): number => {
+  if (output === 'json' || output === 'yaml' || output === 'ndjson') {
+    formatOutput({
+      ctx,
+      command,
+      output,
+      status: 'error',
+      data: null,
+      errors: [err.toJSON()]
+    });
+  } else {
+    renderError(err, ctx);
+  }
+  return 1;
+};
+
+/**
+ * Generate a hint message for when no target is specified but multiple are configured.
+ * @param configuredTargets Array of configured targets with name property.
+ * @returns Hint message string.
+ */
+export const generateTargetHint = (configuredTargets: { name: string }[]): string => {
+  return configuredTargets.length > 1
+    ? `Multiple targets configured: ${configuredTargets.map((t) => t.name).join(', ')}. Specify with --target <name>.`
+    : 'Configure a target with `ai-primitives-hub target add <name> --type <kind>` first.';
+};
+
+/**
+ * Safely read targets with fallback to empty array on error.
+ * @param readFn Function that reads targets.
+ * @returns Array of targets or empty array on error.
+ */
+export const readTargetsSafely = async <T>(readFn: Promise<T[]>): Promise<T[]> => {
+  return readFn.catch(() => []);
+};
+
+/**
+ * Throw a RegistryError when a target is not found.
+ * @param commandName Command name for error message (e.g., 'install', 'uninstall').
+ * @param targetName Name of the target that was not found.
+ * @param targets Array of configured targets.
+ * @param hintGenerator Optional function to generate hint message. Defaults to ternary hint.
+ * @throws {RegistryError} Always throws with USAGE.MISSING_FLAG code.
+ */
+export const throwTargetNotFoundError = (
+  commandName: string,
+  targetName: string,
+  targets: { name: string }[],
+  hintGenerator?: (targets: { name: string }[]) => string
+): never => {
+  const defaultHint = targets.length === 0
+    ? 'Run `ai-primitives-hub target add <name> --type <kind>` to add one.'
+    : `Configured targets: ${targets.map((t) => t.name).join(', ')}.`;
+  const hint = hintGenerator ? hintGenerator(targets) : defaultHint;
+
+  throw new RegistryError({
+    code: 'USAGE.MISSING_FLAG',
+    message: `${commandName}: target "${targetName}" is not configured`,
+    hint,
+    context: { target: targetName }
+  });
+};
+
+/**
+ * Resolve target name from options or fallback to last used target.
+ * @param targetName Target name from options (may be undefined or empty).
+ * @param commandName Command name for error message (e.g., 'install', 'uninstall').
+ * @param ctx CLI context.
+ * @param readTargetsFn Function to read configured targets.
+ * @returns Resolved target name.
+ * @throws {RegistryError} When target is not provided and no last used target exists.
+ */
+export const resolveTargetName = async <T extends { name: string }>(
+  targetName: string | undefined,
+  commandName: string,
+  ctx: Context,
+  readTargetsFn: () => Promise<T[]>
+): Promise<string> => {
+  if (targetName === undefined || targetName.length === 0) {
+    const { TargetStateStore } = await import('@ai-primitives-hub/infra');
+    const path = await import('node:path');
+    const stateStore = new TargetStateStore({
+      fs: ctx.fs,
+      statePath: path.default.join(ctx.cwd(), '.ai-primitives-hub', 'target-state.json')
+    });
+    const lastUsed = await stateStore.getLastUsedTarget();
+    if (lastUsed !== null) {
+      return lastUsed;
+    }
+    const configuredTargets = await readTargetsSafely(readTargetsFn());
+    const hint = generateTargetHint(configuredTargets);
+    throw new RegistryError({
+      code: 'USAGE.MISSING_FLAG',
+      message: `${commandName}: --target <name> is required`,
+      hint
+    });
+  }
+  return targetName;
+};
+
+/**
+ * Validate command inputs based on configured flags.
+ * @param options Object containing optional string values to validate.
+ * @param config Configuration of which flags to check.
+ * @param config.flags
+ * @returns Object with boolean flags indicating which inputs are missing.
+ */
+export const validateInputs = (
+  options: object,
+  config: { flags: string[] }
+): Record<string, boolean> => {
+  const result: Record<string, boolean> = {};
+  const opts = options as Record<string, unknown>;
+  for (const flag of config.flags) {
+    const value = opts[flag];
+    if (typeof value === 'string') {
+      result[flag] = value === undefined || value.length === 0;
+    } else if (typeof value === 'boolean') {
+      result[flag] = value !== true;
+    } else {
+      result[flag] = true;
+    }
+  }
+  return result;
+};
+
+/**
+ * Resolve target by name.
+ * @param targetName Target name.
+ * @param commandName Command name for error message (e.g., 'install', 'uninstall').
+ * @param _ctx CLI context (unused, kept for API compatibility).
+ * @param readTargetsFn Function to read configured targets.
+ * @returns Target configuration.
+ * @throws {RegistryError} When target is not found.
+ */
+export const resolveTarget = async <T extends { name: string }>(
+  targetName: string,
+  commandName: string,
+  _ctx: Context,
+  readTargetsFn: () => Promise<T[]>
+): Promise<T> => {
+  const targets = await readTargetsFn();
+  const target = targets.find((t) => t.name === targetName);
+  if (target === undefined) {
+    throwTargetNotFoundError(commandName, targetName, targets);
+  }
+  return target!;
+};
+
+/**
+ * Get CommandContext from a command class.
+ *
+ * This helper extracts the Context from the commandContext property
+ * and throws a consistent error if not available. Use this in CLI
+ * commands to reduce duplication of the context extraction pattern.
+ * @param command Command class instance with optional commandContext property.
+ * @returns Context from commandContext.
+ * @throws {Error} When commandContext or ctx is not available.
+ */
+export const getCommandContext = (command: unknown): Context => {
+  const ctx = (command as { commandContext?: { ctx: Context } }).commandContext?.ctx;
+  if (!ctx) {
+    throw new Error('CommandContext not available');
+  }
+  return ctx;
+};
+
+/**
+ * Validate that the active hub matches the expected hub ID.
+ * @param mgr HubManager instance.
+ * @param mgr.getActiveHub
+ * @param hubId Expected hub ID.
+ * @param commandName Command name for error message.
+ * @returns Active hub configuration.
+ * @throws {RegistryError} When hub is not active or not found.
+ */
+export const requireActiveHub = async <T>(
+  mgr: { getActiveHub: () => Promise<{ id: string; config: T } | null> },
+  hubId: string,
+  commandName: string
+): Promise<{ id: string; config: T }> => {
+  const active = await mgr.getActiveHub();
+  if (!active) {
+    throw new RegistryError({
+      code: 'HUB.NOT_FOUND',
+      message: `${commandName}: no active hub`,
+      hint: 'Run `ai-primitives-hub hub add` to import a hub, then `hub use <id>` to activate it.'
+    });
+  }
+  if (active.id !== hubId) {
+    throw new RegistryError({
+      code: 'HUB.NOT_FOUND',
+      message: `${commandName}: hub "${hubId}" is not active`,
+      hint: `Run \`ai-primitives-hub hub use ${hubId}\` first.`
+    });
+  }
+  return active;
+};
+
+/**
+ * Validate that the active hub matches the expected hub ID and return failWith result.
+ * Use this in command execute methods that return exit codes.
+ * @param mgr HubManager instance.
+ * @param mgr.getActiveHub
+ * @param hubId Expected hub ID.
+ * @param commandName Command name for error message.
+ * @param ctx CLI context.
+ * @param fmt Output format.
+ * @returns Active hub configuration or failWith result.
+ */
+export const requireActiveHubOrFail = async <T>(
+  mgr: { getActiveHub: () => Promise<{ id: string; config: T } | null> },
+  hubId: string,
+  commandName: string,
+  ctx: Context,
+  fmt: OutputFormat
+): Promise<{ id: string; config: T } | number> => {
+  const active = await mgr.getActiveHub();
+  if (!active) {
+    return failWith(ctx, fmt, commandName, new RegistryError({
+      code: 'HUB.NOT_FOUND',
+      message: `${commandName}: no active hub`,
+      hint: 'Run `ai-primitives-hub hub add` to import a hub, then `hub use <id>` to activate it.'
+    }));
+  }
+  if (active.id !== hubId) {
+    return failWith(ctx, fmt, commandName, new RegistryError({
+      code: 'HUB.NOT_FOUND',
+      message: `${commandName}: hub "${hubId}" is not active`,
+      hint: `Run \`ai-primitives-hub hub use ${hubId}\` first.`
+    }));
+  }
+  return active;
+};

--- a/packages/cli/src/framework/golden.ts
+++ b/packages/cli/src/framework/golden.ts
@@ -1,0 +1,85 @@
+/**
+ * Golden-test runner.
+ *
+ * `runCommand(argv, opts)` is a thin convenience wrapper around
+ * `runCli` + `createTestContext`. It builds an ephemeral test
+ * Context, runs the dispatcher, and returns `{ exitCode, stdout, stderr }`
+ * — exactly the three values almost every end-to-end test needs.
+ *
+ * Why a separate helper?
+ *   1. Golden-style tests routinely need all three captured streams plus
+ *      the exit code; doing the createTestContext/runCli/captured triple
+ *      by hand for every assertion is repetitive.
+ *   2. Centralizing the test entry point gives the command
+ *      extractions a single place to evolve (e.g., adding a `clock`
+ *      override or pre-seeding fs/env without touching every test).
+ *
+ * What this is NOT:
+ *   - A snapshot harness. Snapshot diffing belongs in tests proper
+ *     (mocha + a JSON.stringify diff is sufficient for now).
+ *   - A clipanion runner. The framework adapter (`runCli`) handles all
+ *      dispatch; this helper only composes.
+ * @module framework/golden
+ */
+import type {
+  CommandClass,
+} from 'clipanion';
+import type {
+  CommandDefinition,
+} from './cli';
+import {
+  runCli,
+} from './cli';
+import type {
+  TestContextOptions,
+} from './test-context';
+import {
+  createTestContext,
+} from './test-context';
+
+export interface RunCommandOptions {
+  /** Commands available for dispatch (passed to `runCli`). */
+  commands?: CommandDefinition[];
+  /** Native clipanion command classes registered directly. */
+  commandClasses?: CommandClass[];
+  /** Binary name reported in usage / version output. Default: `ai-primitives-hub`. */
+  name?: string;
+  /** Binary version reported by --version. Default: `0.0.0-test`. */
+  version?: string;
+  /** Test-Context overrides (env, cwd, etc.). */
+  context?: TestContextOptions;
+}
+
+export interface RunCommandResult {
+  /** Exit code returned by the dispatcher. */
+  exitCode: number;
+  /** Captured stdout content. */
+  stdout: string;
+  /** Captured stderr content. */
+  stderr: string;
+}
+
+/**
+ * Run a command end-to-end through the framework adapter.
+ * @param argv Argument vector to dispatch (`['hello']`, `['index', 'search']`, etc.).
+ * @param opts Commands to register (either CommandDefinition or CommandClass), optional binary metadata, and optional Context overrides.
+ * @returns `{ exitCode, stdout, stderr }` — captured outcome.
+ */
+export const runCommand = async (
+  argv: string[],
+  opts: RunCommandOptions
+): Promise<RunCommandResult> => {
+  const ctx = createTestContext(opts.context);
+  const exitCode = await runCli(argv, {
+    ctx,
+    name: opts.name ?? 'ai-primitives-hub',
+    version: opts.version ?? '0.0.0-test',
+    commands: opts.commands ?? [],
+    commandClasses: opts.commandClasses
+  });
+  return {
+    exitCode,
+    stdout: ctx.stdout.captured(),
+    stderr: ctx.stderr.captured()
+  };
+};

--- a/packages/cli/src/framework/help-renderer.ts
+++ b/packages/cli/src/framework/help-renderer.ts
@@ -1,0 +1,139 @@
+/**
+ * Global help renderer.
+ *
+ * Produces a landing-page style help output when the CLI is invoked
+ * with no arguments or with `--help`. Replaces clipanion's default
+ * dense listing with progressive disclosure: a short Quick Start
+ * section followed by commands grouped into 6 consolidated categories.
+ * @module framework/help-renderer
+ */
+import type {
+  Cli,
+} from 'clipanion';
+
+const CATEGORY_ORDER: readonly string[] = [
+  'Getting Started',
+  'Install & Manage',
+  'Hub & Discovery',
+  'Build & Author',
+  'Primitive',
+  'Index & Search',
+  'Configure & Debug'
+];
+
+interface QuickStartEntry {
+  command: string;
+  description: string;
+}
+
+const QUICK_START: readonly QuickStartEntry[] = [
+  { command: 'target add', description: 'Add your first install target (e.g. vscode, copilot-cli).' },
+  { command: 'hub add', description: 'Import a hub from a GitHub repo or local path.' },
+  { command: 'profile activate', description: 'Activate a profile on your configured targets.' }
+];
+
+interface HelpEntry {
+  /** Command path without binary prefix, e.g. "init" or "index search". */
+  path: string;
+  /** One-line description. */
+  description: string;
+  /** Category for grouping. */
+  category: string;
+}
+
+/**
+ * Render the global help landing page.
+ * @param cli      — clipanion Cli instance (already has all commands registered).
+ * @param name     — binary name, e.g. "ai-primitives-hub".
+ * @param version  — binary version, e.g. "1.0.0".
+ * @returns Multi-line string ready for stdout.
+ */
+export const renderGlobalHelp = (
+  cli: Cli,
+  name: string,
+  version: string
+): string => {
+  const defs = cli.definitions({ colored: false });
+
+  const entries: HelpEntry[] = [];
+  for (const def of defs) {
+    // Skip built-ins (--help, --version) and commands with no description.
+    if (!def.description) {
+      continue;
+    }
+
+    // def.path includes the binary name prefix (e.g. "ai-primitives-hub init").
+    // Strip it so we show just the command path.
+    const prefix = `${name} `;
+    const rawPath = def.path.startsWith(prefix)
+      ? def.path.slice(prefix.length)
+      : def.path;
+
+    // Skip built-in --help / --version commands.
+    if (rawPath === '--help' || rawPath === '-h' || rawPath === '--version') {
+      continue;
+    }
+
+    entries.push({
+      path: rawPath,
+      description: def.description?.trim() ?? '',
+      category: def.category?.trim() ?? 'Other'
+    });
+  }
+
+  // Group by category.
+  const byCategory = new Map<string, HelpEntry[]>();
+  for (const entry of entries) {
+    const list = byCategory.get(entry.category) ?? [];
+    list.push(entry);
+    byCategory.set(entry.category, list);
+  }
+
+  // Sort alphabetically within each category.
+  for (const list of byCategory.values()) {
+    list.sort((a, b) => a.path.localeCompare(b.path));
+  }
+
+  const lines: string[] = [`${name} ${version} — Copilot prompt bundle manager\n`, 'Quick Start\n'];
+
+  // Quick Start — 3-command onboarding strip.
+  const qsMaxPath = Math.min(18, Math.max(...QUICK_START.map((e) => e.command.length)));
+  for (const entry of QUICK_START) {
+    const pathCol = entry.command.padEnd(qsMaxPath + 2);
+    lines.push(`  ${pathCol}${entry.description}\n`);
+  }
+  lines.push('\n');
+
+  // Render categories in the prescribed order first, then any unknown
+  // categories alphabetically so nothing is silently dropped.
+  const knownCategories = CATEGORY_ORDER;
+  const unknownCategories = [...byCategory.keys()]
+    .filter((c) => !knownCategories.includes(c))
+    .toSorted((a, b) => a.localeCompare(b));
+  const categories = [...knownCategories, ...unknownCategories];
+
+  for (const category of categories) {
+    const list = byCategory.get(category);
+    if (!list || list.length === 0) {
+      continue;
+    }
+
+    lines.push(`${category}\n`);
+
+    // Compute the longest path so we can align descriptions.
+    const maxPathLen = Math.min(
+      24,
+      Math.max(...list.map((e) => e.path.length))
+    );
+
+    for (const entry of list) {
+      const pathCol = entry.path.padEnd(maxPathLen + 2);
+      lines.push(`  ${pathCol}${entry.description}\n`);
+    }
+    lines.push('\n');
+  }
+
+  lines.push(`Run '${name} <command> -h' for detailed usage and examples.\n`);
+
+  return lines.join('');
+};

--- a/packages/cli/src/framework/hub-manager.ts
+++ b/packages/cli/src/framework/hub-manager.ts
@@ -1,0 +1,87 @@
+/**
+ * Shared HubManager factory for CLI commands.
+ *
+ * Centralizes HubManager creation logic to reduce duplication across
+ * commands. Adapted for three differences from the reference branch:
+ * `EnvTokenProvider` is a class here (not the reference's
+ * `envTokenProvider` factory function — matches this package's
+ * established `TokenProvider` pattern); `NodeHttpClient` takes no
+ * constructor options (no `{ env }` proxy-awareness config exists on
+ * this port's implementation); and `HubManager`'s constructor takes a
+ * single `HubManagerDeps` options object (not the reference's three
+ * positional args), which also requires a `favoritesStore` and a
+ * `validateConfig` function — supplied here via `FavoritesStore` and
+ * `infra`'s `validateHubConfig` (sync, wrapped to the async shape
+ * `HubManagerDeps` expects).
+ * @module framework/hub-manager
+ */
+import * as path from 'node:path';
+import {
+  HubManager,
+  resolveUserConfigPaths,
+} from '@ai-primitives-hub/app';
+import type {
+  HttpClient,
+  TokenProvider,
+} from '@ai-primitives-hub/core';
+import {
+  ActiveHubStore,
+  CompositeHubResolver,
+  EnvTokenProvider,
+  FavoritesStore,
+  GitHubHubResolver,
+  HubStore,
+  LocalHubResolver,
+  NodeHttpClient,
+  UrlHubResolver,
+  validateHubConfig,
+} from '@ai-primitives-hub/infra';
+import {
+  type Context,
+} from './context';
+
+/**
+ * Create HTTP client and token provider with defaults.
+ * @param http Optional HTTP client (for testing).
+ * @param ctx CLI context.
+ * @param tokens Optional token provider (for testing).
+ * @returns Tuple of [httpClient, tokenProvider].
+ */
+export const createHttpClientAndTokens = (
+  http: HttpClient | undefined,
+  ctx: Context,
+  tokens: TokenProvider | undefined
+): [HttpClient, TokenProvider] => {
+  const httpClient = http ?? new NodeHttpClient();
+  const tokenProvider = tokens ?? new EnvTokenProvider(ctx.env);
+  return [httpClient, tokenProvider];
+};
+
+export interface CreateHubManagerOptions {
+  ctx: Context;
+  http?: HttpClient;
+  tokens?: TokenProvider;
+}
+
+/**
+ * Create a HubManager with default HTTP client and token provider.
+ * @param opts Options for creating HubManager.
+ * @returns Configured HubManager instance.
+ */
+export const createHubManager = (opts: CreateHubManagerOptions): HubManager => {
+  const { ctx, http, tokens } = opts;
+  const paths = resolveUserConfigPaths(ctx.env);
+  const [httpClient, tokenProvider] = createHttpClientAndTokens(http, ctx, tokens);
+  const resolver = new CompositeHubResolver(
+    new GitHubHubResolver(httpClient, tokenProvider),
+    new LocalHubResolver(ctx.fs),
+    new UrlHubResolver(httpClient, tokenProvider)
+  );
+  return new HubManager({
+    store: new HubStore(paths.hubs, ctx.fs),
+    activeStore: new ActiveHubStore(paths.activeHub, ctx.fs),
+    resolver,
+    favoritesStore: new FavoritesStore(path.join(paths.hubs, 'favorites.json'), ctx.fs),
+    validateConfig: (config) => Promise.resolve(validateHubConfig(config))
+  });
+};

--- a/packages/cli/src/framework/index.ts
+++ b/packages/cli/src/framework/index.ts
@@ -1,0 +1,125 @@
+/**
+ * Public surface of the CLI framework.
+ *
+ * This barrel is the *only* import path command code (and tests) should use
+ * to reach the framework. Only `packages/cli/src/framework/` may import
+ * clipanion directly; a future ESLint rule enforces that (see this
+ * package's port of the reference's `local/no-framework-imports`).
+ * @module framework
+ */
+export type {
+  CapturedOutputStream,
+  ClockAbstraction,
+  Context,
+  FsAbstraction,
+  InputStream,
+  NetAbstraction,
+  NetRequestInit,
+  NetResponse,
+  OutputStream,
+  TestClock,
+} from './context';
+export type {
+  TestContext,
+  TestContextOptions,
+} from './test-context';
+export {
+  createTestContext,
+  isTestContext,
+} from './test-context';
+export {
+  createProductionContext,
+} from './production-context';
+export type {
+  CommandDefinition,
+  RunCliOptions,
+} from './cli';
+export type {
+  CommandClass,
+} from 'clipanion';
+export {
+  defineCommand,
+  runCli,
+} from './cli';
+export {
+  Command,
+  Option,
+} from 'clipanion';
+export type {
+  Config,
+  ConfigFs,
+  LoadConfigOptions,
+} from './config';
+export {
+  loadConfig,
+  resolveProjectConfigPath,
+} from './config';
+export type {
+  FormatOutputOptions,
+  OutputError,
+  OutputFormat,
+  OutputStatus,
+} from './output';
+export {
+  formatOutput,
+} from './output';
+export type {
+  RegistryErrorNamespace,
+  RegistryErrorOptions,
+} from './error';
+export {
+  RegistryError,
+  isRegistryError,
+  renderError,
+  failWith,
+  generateTargetHint,
+  readTargetsSafely,
+  throwTargetNotFoundError,
+  resolveTargetName,
+  resolveTarget,
+  validateInputs,
+  getCommandContext,
+  requireActiveHub,
+  requireActiveHubOrFail,
+} from './error';
+export type {
+  RunCommandOptions,
+  RunCommandResult,
+} from './golden';
+export {
+  runCommand,
+} from './golden';
+export type {
+  CreateHubManagerOptions,
+} from './hub-manager';
+export {
+  createHubManager,
+  createHttpClientAndTokens,
+} from './hub-manager';
+export {
+  findProjectLockfile,
+  loadTargets,
+  lockfilePathForTarget,
+} from './target';
+export {
+  copyCommandPrototype,
+} from './command-class';
+export type {
+  RenderTableOptions,
+  TableColumn,
+} from './table';
+export {
+  renderTable,
+} from './table';
+export {
+  parseCsv,
+  parseCsvEnum,
+  parseCsvKinds,
+  parseCsvNonEmpty,
+} from './parsers';
+export {
+  renderGlobalHelp,
+} from './help-renderer';
+export {
+  suggestCommand,
+} from './suggest';

--- a/packages/cli/src/framework/output.ts
+++ b/packages/cli/src/framework/output.ts
@@ -1,0 +1,158 @@
+/**
+ * Output formatter.
+ *
+ * Single sink for all command output. Leaf commands compute `data` and
+ * call `formatOutput()` once; this module handles serialization and
+ * stdout routing for all four modes (text, json, yaml, ndjson). The
+ * markdown and table modes are deferred to a later
+ * iteration alongside their domain-specific renderers — they are not
+ * universally meaningful and carrying empty stubs here would lie about
+ * the supported surface.
+ *
+ * JSON envelope
+ *   {
+ *     schemaVersion: 1,
+ *     command:       <dotted.path>,
+ *     status:        "ok" | "error" | "warning",
+ *     data:          <command-specific payload>,
+ *     warnings:      [...string],
+ *     errors:        [...{ code, message, ... }],
+ *     meta:          { ... }
+ *   }
+ *
+ * Routing rules
+ *   text mode: warnings -> ctx.stderr (stdout stays a clean payload)
+ *   json mode: warnings stay in the envelope; stderr untouched
+ *   quiet=true: suppresses stdout in text mode only; JSON consumers
+ *               always need the envelope
+ * @module framework/output
+ */
+import {
+  dump as toYaml,
+} from 'js-yaml';
+import type {
+  Context,
+} from './context';
+
+export type OutputFormat = 'text' | 'json' | 'yaml' | 'ndjson';
+export type OutputStatus = 'ok' | 'error' | 'warning';
+
+/**
+ * JSON-serializable error envelope item. RegistryError will
+ * produce records of this shape via a `.toJSON()` method.
+ */
+export interface OutputError {
+  code: string;
+  message: string;
+  hint?: string;
+  docsUrl?: string;
+  context?: Record<string, unknown>;
+}
+
+export interface FormatOutputOptions<T = unknown> {
+  ctx: Context;
+  /** Dotted command path used in the envelope (e.g. `index.search`). */
+  command: string;
+  output: OutputFormat;
+  status: OutputStatus;
+  data: T;
+  warnings?: string[];
+  errors?: OutputError[];
+  meta?: Record<string, unknown>;
+  /** Renderer used for `output=text`. Defaults to JSON.stringify. */
+  textRenderer?: (data: T) => string;
+  /** Suppress stdout in text mode. JSON output is unaffected. */
+  quiet?: boolean;
+}
+
+/**
+ * Format and emit a command result.
+ * @param opts ctx / command / output / status / data / warnings / errors / meta / textRenderer / quiet.
+ */
+export const formatOutput = <T>(opts: FormatOutputOptions<T>): void => {
+  const warnings = opts.warnings ?? [];
+  const errors = opts.errors ?? [];
+  const meta = opts.meta ?? {};
+
+  switch (opts.output) {
+    case 'json': {
+      const envelope = {
+        schemaVersion: 1,
+        command: opts.command,
+        status: opts.status,
+        data: opts.data,
+        warnings,
+        errors,
+        meta
+      };
+      opts.ctx.stdout.write(`${JSON.stringify(envelope)}\n`);
+      return;
+    }
+
+    case 'yaml': {
+      const envelope = {
+        schemaVersion: 1,
+        command: opts.command,
+        status: opts.status,
+        data: opts.data,
+        warnings,
+        errors,
+        meta
+      };
+      opts.ctx.stdout.write(toYaml(envelope));
+      return;
+    }
+
+    case 'ndjson': {
+      // For arrays each element is its own JSON line — ideal for
+      // `ai-primitives-hub bundle list -o ndjson | jq` pipelines that
+      // process items as a stream rather than loading everything.
+      // For non-array data we emit the value as a single JSON line so
+      // ndjson is always one-line-per-record.
+      if (Array.isArray(opts.data)) {
+        for (const item of opts.data) {
+          opts.ctx.stdout.write(`${JSON.stringify(item)}\n`);
+        }
+      } else {
+        opts.ctx.stdout.write(`${JSON.stringify(opts.data)}\n`);
+      }
+      // Warnings/errors do not have a natural place in pure ndjson
+      // output (which is item-only by convention). Push them to
+      // stderr so they remain visible without polluting the stream.
+      for (const w of warnings) {
+        opts.ctx.stderr.write(`warning: ${w}\n`);
+      }
+      for (const e of errors) {
+        opts.ctx.stderr.write(`error: ${e.code} — ${e.message}\n`);
+      }
+      return;
+    }
+
+    default: {
+      // 'text' is the only remaining variant; the default branch covers
+      // it and any future format gracefully degrades to text behavior.
+      // Warnings to stderr so a piped `... | jq .field` keeps working
+      // when textRenderer happens to emit JSON-shaped output.
+      for (const w of warnings) {
+        opts.ctx.stderr.write(`warning: ${w}\n`);
+      }
+      if (opts.quiet === true) {
+        return;
+      }
+      const renderer = opts.textRenderer ?? defaultTextRenderer;
+      opts.ctx.stdout.write(renderer(opts.data));
+    }
+  }
+};
+
+const defaultTextRenderer = <T>(data: T): string => {
+  // Non-textRenderer-supplied case: fall back to a deterministic JSON
+  // serialization so commands that haven't defined a `textRenderer`
+  // still produce *some* meaningful output. Text mode is "best-effort
+  // human"; commands wanting machine output should pass `-o json`.
+  // A null/undefined payload means nothing to render.
+  if (data === null || data === undefined) {
+    return '';
+  }
+  return `${JSON.stringify(data, null, 2)}\n`;
+};

--- a/packages/cli/src/framework/parsers.ts
+++ b/packages/cli/src/framework/parsers.ts
@@ -1,0 +1,81 @@
+/**
+ * CLI argument parsing utilities with type-safe validation.
+ *
+ * Provides typed parsers for common CLI argument patterns like CSV lists
+ * and enum validation.
+ * @module framework/parsers
+ */
+
+import type {
+  PrimitiveKind,
+} from '@ai-primitives-hub/core';
+import {
+  PRIMITIVE_KINDS,
+} from '@ai-primitives-hub/core';
+
+/**
+ * Parse a comma-separated string into an array of trimmed strings.
+ * Returns undefined if the input is undefined.
+ * @param raw - Raw CSV string or undefined.
+ * @returns Trimmed array or undefined.
+ */
+export const parseCsv = (raw: string | undefined): string[] | undefined => {
+  if (raw === undefined) {
+    return undefined;
+  }
+  return raw.split(',').map((s) => s.trim()).filter((s) => s.length > 0);
+};
+
+/**
+ * Parse a comma-separated string into an array of validated enum values.
+ * Returns undefined if the input is undefined.
+ * Throws an error if any value is not in the allowed enum values.
+ * @param raw - Raw CSV string or undefined.
+ * @param enumValues - Readonly array of allowed enum values.
+ * @param enumName - Name of the enum for error messages.
+ * @returns Array of validated enum values or undefined.
+ */
+export const parseCsvEnum = <T extends string>(
+  raw: string | undefined,
+  enumValues: readonly T[],
+  enumName: string
+): T[] | undefined => {
+  const parsed = parseCsv(raw);
+  if (parsed === undefined) {
+    return undefined;
+  }
+
+  const invalid = parsed.filter((v) => !enumValues.includes(v as T));
+  if (invalid.length > 0) {
+    throw new Error(
+      `Invalid ${enumName} value(s): ${invalid.join(', ')}. `
+      + `Valid values: ${enumValues.join(', ')}`
+    );
+  }
+
+  return parsed as T[];
+};
+
+/**
+ * Parse a comma-separated string into PrimitiveKind array.
+ * Validates that all values are valid PrimitiveKind enum values.
+ * @param raw - Raw CSV string or undefined.
+ * @returns Array of PrimitiveKind values or undefined.
+ */
+export const parseCsvKinds = (raw: string | undefined): PrimitiveKind[] | undefined => {
+  return parseCsvEnum(raw, PRIMITIVE_KINDS, 'PrimitiveKind');
+};
+
+/**
+ * Parse a comma-separated string into a non-empty array.
+ * Returns undefined if the input is undefined or results in an empty array.
+ * @param raw - Raw CSV string or undefined.
+ * @returns Non-empty array or undefined.
+ */
+export const parseCsvNonEmpty = (raw: string | undefined): string[] | undefined => {
+  const parsed = parseCsv(raw);
+  if (parsed === undefined || parsed.length === 0) {
+    return undefined;
+  }
+  return parsed;
+};

--- a/packages/cli/src/framework/production-context.ts
+++ b/packages/cli/src/framework/production-context.ts
@@ -1,0 +1,116 @@
+/**
+ * Production Context wiring.
+ *
+ * Real-world implementations of the abstractions defined in `context.ts`.
+ * fs/clock reuse `infra`'s `NodeFileSystem`/`SystemClock` ports directly
+ * (both already implement the full `FileSystem`/`Clock` surface) rather
+ * than hand-rolling a second copy, unlike the reference branch's own
+ * version of this file.
+ *
+ * net   -> global fetch (Node 18+; works on Node 20 baseline)
+ * stdio -> process.stdin/stdout/stderr
+ * env   -> Object.freeze({ ...process.env }) snapshotted once
+ * cwd   -> process.cwd
+ * exit  -> process.exit (the *only* call site to it; ESLint rule
+ *          will ban process.exit elsewhere in src/)
+ * @module framework/production-context
+ */
+import {
+  NodeFileSystem,
+  SystemClock,
+} from '@ai-primitives-hub/infra';
+import type {
+  Context,
+  InputStream,
+  NetAbstraction,
+  NetRequestInit,
+  NetResponse,
+  OutputStream,
+} from './context';
+
+const headersToRecord = (h: Headers): Record<string, string> => {
+  const out: Record<string, string> = {};
+  h.forEach((value, key) => {
+    out[key] = value;
+  });
+  return out;
+};
+
+const createProductionNet = (): NetAbstraction => ({
+  fetch: async (url: string, init?: NetRequestInit): Promise<NetResponse> => {
+    const resp = await globalThis.fetch(url, {
+      method: init?.method ?? 'GET',
+      headers: init?.headers,
+      body: init?.body
+    });
+    const headers = headersToRecord(resp.headers);
+    return {
+      status: resp.status,
+      headers,
+      text: () => resp.text(),
+      json: <T = unknown>(): Promise<T> => resp.json() as Promise<T>,
+      bytes: async (): Promise<Uint8Array> => new Uint8Array(await resp.arrayBuffer())
+    };
+  }
+});
+
+const createProductionStdout = (): OutputStream => ({
+  write: (chunk: string): void => {
+    process.stdout.write(chunk);
+  }
+});
+
+const createProductionStderr = (): OutputStream => ({
+  write: (chunk: string): void => {
+    process.stderr.write(chunk);
+  }
+});
+
+/**
+ * Production stdin reader — synchronous read of any pre-piped content.
+ * Only needs a static read(); the streaming variant for
+ * interactive prompts lands in a later iteration with the doctor stub.
+ */
+const createProductionStdin = (): InputStream => ({
+  read: (): string => '' // streaming read added in a later iteration
+});
+
+const detectColorDepth = (): number => {
+  if (process.env.NO_COLOR !== undefined) {
+    return 0;
+  }
+  if (process.stdout.isTTY) {
+    return 4; // ANSI 16 colors (clipanion only needs > 0)
+  }
+  return 0;
+};
+
+/**
+ * Build the production Context the real CLI binary uses at startup.
+ * @param overrides - Optional Context-field overrides. Added
+ *   `cwd` so the `--cwd` flag can redirect filesystem operations
+ *   without `chdir`-ing the whole process (which would corrupt
+ *   relative paths outside the command's own scope).
+ * @param overrides.cwd - Optional working directory override.
+ * @returns A `Context` whose IO surfaces are wired to real Node primitives.
+ */
+export const createProductionContext = (overrides: { cwd?: string } = {}): Context => ({
+  fs: new NodeFileSystem(),
+  net: createProductionNet(),
+  clock: new SystemClock(),
+  stdin: createProductionStdin(),
+  stdout: createProductionStdout(),
+  stderr: createProductionStderr(),
+  env: Object.freeze({ ...process.env }) as Readonly<Record<string, string>>,
+  cwd: overrides.cwd === undefined
+    ? (): string => process.cwd()
+    : (): string => overrides.cwd as string,
+  exit: (code: number): void => {
+    // This is the *only* call site for process.exit() in the codebase.
+    // The ESLint rule will ban it everywhere except
+    // here, enforcing the invariant that all IO goes through Context.
+    // eslint-disable-next-line unicorn/no-process-exit -- This is the single, intentional sink for process termination; the invariant forbids process.exit anywhere else in src/.
+    process.exit(code);
+  },
+  colorDepth: detectColorDepth()
+});

--- a/packages/cli/src/framework/suggest.ts
+++ b/packages/cli/src/framework/suggest.ts
@@ -1,0 +1,104 @@
+/**
+ * "Did you mean?" command suggestion.
+ *
+ * When a user types an unknown command, compute the Levenshtein distance
+ * against all registered command paths and suggest the closest match
+ * if the distance is within a tight threshold.
+ * @module framework/suggest
+ */
+import type {
+  Cli,
+} from 'clipanion';
+
+/**
+ * Compute Levenshtein edit distance between two strings.
+ * @param a — first string.
+ * @param b — second string.
+ * @returns Minimum number of single-character edits needed.
+ */
+function levenshtein(a: string, b: string): number {
+  const matrix: number[][] = [];
+  for (let i = 0; i <= b.length; i++) {
+    matrix[i] = [i];
+  }
+  for (let j = 0; j <= a.length; j++) {
+    matrix[0][j] = j;
+  }
+  for (let i = 1; i <= b.length; i++) {
+    for (let j = 1; j <= a.length; j++) {
+      matrix[i][j] = b[i - 1] === a[j - 1]
+        ? matrix[i - 1][j - 1]
+        : Math.min(
+          matrix[i - 1][j - 1] + 1,
+          matrix[i][j - 1] + 1,
+          matrix[i - 1][j] + 1
+        );
+    }
+  }
+  return matrix[b.length][a.length];
+}
+
+/**
+ * Suggest a command when the user types an unknown one.
+ * @param argv       — the original argv vector.
+ * @param cli        — clipanion Cli with all commands already registered.
+ * @param binaryName — e.g. "ai-primitives-hub".
+ * @returns The suggested command path, or `undefined` if nothing is close enough.
+ */
+export const suggestCommand = (
+  argv: string[],
+  cli: Cli,
+  binaryName: string
+): string | undefined => {
+  // Reconstruct candidate command prefixes from argv (stop at first flag).
+  const candidates: string[] = [];
+  const prefix: string[] = [];
+  for (const token of argv) {
+    if (token.startsWith('-')) {
+      break;
+    }
+    prefix.push(token);
+    candidates.push(prefix.join(' '));
+  }
+  if (candidates.length === 0) {
+    return undefined;
+  }
+
+  // Collect all known command paths (without binary prefix).
+  const knownPaths: string[] = [];
+  for (const def of cli.definitions()) {
+    if (!def.description) {
+      continue;
+    }
+    const binaryPrefix = `${binaryName} `;
+    const path = def.path.startsWith(binaryPrefix)
+      ? def.path.slice(binaryPrefix.length)
+      : def.path;
+    if (path === '--help' || path === '-h' || path === '--version') {
+      continue;
+    }
+    knownPaths.push(path);
+  }
+
+  // Find the closest match across all candidate prefixes.
+  let bestPath: string | undefined;
+  let bestDist = Infinity;
+  let bestLen = 0;
+  for (const candidate of candidates) {
+    const threshold = Math.min(2, Math.floor(candidate.length * 0.4));
+    for (const path of knownPaths) {
+      const dist = levenshtein(candidate, path);
+      if (dist <= threshold && (dist < bestDist || (dist === bestDist && candidate.length > bestLen))) {
+        bestDist = dist;
+        bestPath = path;
+        bestLen = candidate.length;
+      }
+    }
+  }
+
+  if (bestPath !== undefined && bestPath !== candidates.at(-1)) {
+    return bestPath;
+  }
+
+  return undefined;
+};

--- a/packages/cli/src/framework/table.ts
+++ b/packages/cli/src/framework/table.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared table renderer for CLI list commands.
+ *
+ * Produces fixed-width aligned text tables from header + row data.
+ * Used by any command that emits a list of records in text mode.
+ * @module framework/table
+ */
+
+export interface TableColumn<T = unknown> {
+  /** Column header text. */
+  header: string;
+  /** Extract cell text from a row object. */
+  get: (row: T) => string;
+  /** Optional fixed width (overrides auto-width). */
+  width?: number;
+  /** Align: 'left' (default) or 'right'. */
+  align?: 'left' | 'right';
+}
+
+export interface RenderTableOptions<T = unknown> {
+  /** Column definitions. */
+  columns: TableColumn<T>[];
+  /** Row data. */
+  rows: T[];
+  /** Gap between columns (default 2). */
+  gap?: number;
+  /** Message when rows is empty (default 'No items.\n'). */
+  emptyMessage?: string;
+}
+
+/**
+ * Render rows as a fixed-width text table.
+ * @param opts columns, rows, gap, emptyMessage.
+ * @returns Multi-line string (newline-terminated), or emptyMessage when rows is empty.
+ */
+export const renderTable = <T>(opts: RenderTableOptions<T>): string => {
+  const { columns, rows, gap = 2, emptyMessage = 'No items.\n' } = opts;
+
+  if (rows.length === 0) {
+    return emptyMessage;
+  }
+
+  // Compute width for each column.
+  const widths = columns.map((col) => {
+    if (col.width !== undefined) {
+      return col.width;
+    }
+    const headerLen = col.header.length;
+    const maxDataLen = Math.max(...rows.map((r) => col.get(r).length));
+    return Math.max(headerLen, maxDataLen);
+  });
+
+  const pad = (text: string, width: number, align: 'left' | 'right'): string =>
+    align === 'right' ? text.padStart(width) : text.padEnd(width);
+
+  const fmtRow = (cells: string[]): string =>
+    cells.map((c, i) => pad(c, widths[i], columns[i].align ?? 'left')).join(' '.repeat(gap));
+
+  const lines: string[] = [
+    fmtRow(columns.map((c) => c.header)),
+    ...rows.map((r) => fmtRow(columns.map((c) => c.get(r))))
+  ];
+
+  return lines.join('\n') + '\n';
+};

--- a/packages/cli/src/framework/target.ts
+++ b/packages/cli/src/framework/target.ts
@@ -1,0 +1,67 @@
+/**
+ * Target-related utilities for CLI commands.
+ *
+ * Centralizes target resolution logic to reduce duplication across commands.
+ * @module framework/target
+ */
+import {
+  findLockfile,
+  getLockfilePathForMode,
+  type RepositoryCommitMode,
+  resolveUserConfigPaths,
+} from '@ai-primitives-hub/app';
+import {
+  type Target,
+} from '@ai-primitives-hub/core';
+import {
+  readTargetsHierarchical,
+} from '@ai-primitives-hub/infra';
+import {
+  type Context,
+} from './context';
+
+/**
+ * Load all targets from the hierarchical target configuration.
+ * @param ctx CLI context.
+ * @returns Array of configured targets.
+ */
+export const loadTargets = async (ctx: Context): Promise<Target[]> => {
+  const userPaths = resolveUserConfigPaths(ctx.env);
+  return readTargetsHierarchical({ cwd: ctx.cwd(), fs: ctx.fs }, userPaths.userTargets);
+};
+
+/**
+ * Find the lockfile path for the current working directory.
+ * @param ctx CLI context.
+ * @returns Lockfile path or null if not found.
+ */
+export const findProjectLockfile = async (ctx: Context): Promise<string | null> => {
+  const userPaths = resolveUserConfigPaths(ctx.env);
+  return findLockfile(ctx.cwd(), ctx.fs, userPaths.userLockfile);
+};
+
+/**
+ * Resolve the lockfile path for a target's scope.
+ *
+ * `repository` scope routes through `getLockfilePathForMode`, which
+ * picks one of the two physical, extension-compatible files
+ * (`prompt-registry.lock.json` for `commit`, `prompt-registry.local.lock.json`
+ * for `local-only`) under `target.rootPath` (falling back to `ctx.cwd()`).
+ * Every other scope uses the CLI-only, single-file, non-split
+ * `resolveUserConfigPaths(env).userLockfile` — the extension has never
+ * tracked user/workspace-scope installs via a lockfile (see
+ * `stores/json-lockfile-store.ts`'s module doc), so `commitMode` is
+ * meaningless there and ignored.
+ * @param ctx CLI context.
+ * @param target Target being installed into / uninstalled from.
+ * @param commitMode Effective commit mode; only consulted for `repository` scope.
+ *   Defaults to `target.commitMode ?? 'commit'`.
+ * @returns Absolute lockfile path.
+ */
+export const lockfilePathForTarget = (ctx: Context, target: Target, commitMode?: RepositoryCommitMode): string => {
+  if (target.scope === 'repository') {
+    const mode = commitMode ?? target.commitMode ?? 'commit';
+    return getLockfilePathForMode(target.rootPath ?? ctx.cwd(), mode);
+  }
+  return resolveUserConfigPaths(ctx.env).userLockfile;
+};

--- a/packages/cli/src/framework/test-context.ts
+++ b/packages/cli/src/framework/test-context.ts
@@ -1,0 +1,167 @@
+/**
+ * In-memory Context factory for golden tests.
+ *
+ * `createTestContext()` builds a Context whose IO surfaces are entirely
+ * in-memory:
+ *   - stdout/stderr are captured into a string buffer for assertion;
+ *   - exit() records the code without terminating the process;
+ *   - clock is manually advanceable for cache-TTL/retry-backoff tests;
+ *   - env defaults to {} so tests cannot accidentally leak ambient state;
+ *   - cwd defaults to "/" so tests cannot depend on host filesystem layout.
+ *
+ * fs and net are intentionally stubbed initially (any call throws). Later
+ * wires them to memfs (fs) and undici MockAgent (net). Keeping the initial
+ * version free of those deps keeps the merge tight and avoids a long install step.
+ *
+ * Test ergonomics (golden-test runner) builds on this factory.
+ *
+ * Note on style: this module deliberately uses arrow-function factories
+ * rather than ES classes. The repo eslint config prefers arrow-function
+ * shapes over class methods (`prefer-arrow/prefer-arrow-functions`) and
+ * requires explicit accessibility modifiers on every class member, which
+ * adds noise to what is essentially a struct-of-closures.
+ * @module framework/test-context
+ */
+import type {
+  CapturedOutputStream,
+  Context,
+  FsAbstraction,
+  InputStream,
+  NetAbstraction,
+  TestClock,
+} from './context';
+
+export interface TestContextOptions {
+  /** Pre-seeded stdin content; defaults to ''. */
+  stdin?: string;
+  /** Initial epoch ms reported by ctx.clock.now(); defaults to 0. */
+  now?: number;
+  /** Frozen env map; defaults to {} (no ambient leak from process.env). */
+  env?: Record<string, string>;
+  /** Working directory reported by ctx.cwd(); defaults to '/'. */
+  cwd?: string;
+  /** Optional custom fs implementation; defaults to STUB_FS (rejects all calls). */
+  fs?: FsAbstraction;
+}
+
+/**
+ * Test-only Context type — exposes the captured output sinks and the
+ * recorded exit code so assertions can pull them out without casting.
+ */
+export interface TestContext extends Context {
+  stdout: CapturedOutputStream;
+  stderr: CapturedOutputStream;
+  exitCode(): number;
+  clock: TestClock;
+}
+
+const createCapturingStream = (): CapturedOutputStream => {
+  let buf = '';
+  return {
+    write: (chunk: string): void => {
+      buf += chunk;
+    },
+    captured: (): string => buf
+  };
+};
+
+const createStaticInput = (content: string): InputStream => ({
+  read: (): string => content
+});
+
+const createManualClock = (initial: number): TestClock => {
+  let current = initial;
+  return {
+    now: (): number => current,
+    nowIso: (): string => new Date(current).toISOString(),
+    advance: (ms: number): void => {
+      current += ms;
+    }
+  };
+};
+
+const rejectFsCall = (): Promise<never> =>
+  Promise.reject(new Error('fs not wired yet (lands in a later iteration)'));
+
+/**
+ * Initial stub fs — every call throws. Later replaces with memfs-backed
+ * implementation. The throw is descriptive so test failures point at the
+ * missing wiring rather than at a confusing undefined-property crash.
+ */
+const STUB_FS: FsAbstraction = {
+  readFile: rejectFsCall,
+  writeFile: rejectFsCall,
+  readJson: rejectFsCall,
+  writeJson: rejectFsCall,
+  exists: rejectFsCall,
+  mkdir: rejectFsCall,
+  readDir: rejectFsCall,
+  readDirEntries: rejectFsCall,
+  stat: rejectFsCall,
+  remove: rejectFsCall
+};
+
+/**
+ * Initial stub net — every call throws. Later replaces with undici-backed
+ * implementation gated by undici MockAgent in tests.
+ */
+const STUB_NET: NetAbstraction = {
+  fetch: (): Promise<never> =>
+    Promise.reject(new Error('net not wired yet (lands in a later iteration)'))
+};
+
+/**
+ * Build an in-memory Context for unit / golden tests.
+ *
+ * Defaults are chosen to make tests hermetic by construction:
+ *   - empty env (no ambient process.env leakage),
+ *   - cwd '/' (no dependence on where the runner started),
+ *   - clock at epoch 0 (deterministic timestamps in golden output),
+ *   - exit() never terminates the process; first code wins (POSIX-like
+ *     semantics where an early decision to fail can't be silently
+ *     overwritten by later cleanup work).
+ * @param options Optional overrides for stdin / clock / env / cwd.
+ * @returns A `TestContext` that exposes captured stdout/stderr sinks and
+ *          a recorded exit code accessor in addition to the standard
+ *          `Context` shape.
+ */
+export const createTestContext = (options: TestContextOptions = {}): TestContext => {
+  const stdout = createCapturingStream();
+  const stderr = createCapturingStream();
+  const stdin = createStaticInput(options.stdin ?? '');
+  const clock = createManualClock(options.now ?? 0);
+  const env: Readonly<Record<string, string>> = Object.freeze({ ...options.env });
+  const cwdValue = options.cwd ?? '/';
+
+  let recordedExit: number | null = null;
+  const exit = (code: number): void => {
+    recordedExit ??= code;
+  };
+  const exitCode = (): number => recordedExit ?? 0;
+
+  return {
+    fs: options.fs ?? STUB_FS,
+    net: STUB_NET,
+    clock,
+    stdin,
+    stdout,
+    stderr,
+    env,
+    cwd: () => cwdValue,
+    exit,
+    exitCode,
+    colorDepth: 0
+  };
+};
+
+/**
+ * Convenience type guard, mostly for documentation purposes — at runtime
+ * production and test contexts share the `Context` shape, so the only
+ * way to detect a test context is to check for the `exitCode()` accessor
+ * which production never exposes.
+ * @param ctx Any `Context` produced by either the production wiring or
+ *            the test factory.
+ * @returns `true` when `ctx` was produced by `createTestContext()`.
+ */
+export const isTestContext = (ctx: Context): ctx is TestContext =>
+  typeof (ctx as TestContext).exitCode === 'function';

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,11 @@
+/**
+ * The `@ai-primitives-hub/cli` package barrel.
+ *
+ * Thin delivery adapter over `@ai-primitives-hub/app`: argument parsing and
+ * output formatting only, never business logic. See `bin/ai-primitives-hub.js`
+ * for the actual executable entry point, which calls `run` (aliased `main`).
+ * @module cli
+ */
+export {
+  main as run,
+} from './main';

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -1,0 +1,256 @@
+#!/usr/bin/env node
+/**
+ * CLI entry point for the ai-primitives-hub CLI.
+ * @module main
+ */
+import {
+  defaultTokenProvider,
+  NodeHttpClient,
+} from '@ai-primitives-hub/infra';
+import {
+  AgentCreateCommand,
+} from './commands/agent-create';
+import {
+  ApplyCommand,
+} from './commands/apply';
+import {
+  BundleBuildCommand,
+} from './commands/bundle-build';
+import {
+  BundleManifestCommand,
+} from './commands/bundle-manifest';
+import {
+  CollectionAffectedCommand,
+} from './commands/collection-affected';
+import {
+  CollectionCreateCommand,
+} from './commands/collection-create';
+import {
+  CollectionListCommand,
+} from './commands/collection-list';
+import {
+  CollectionValidateCommand,
+} from './commands/collection-validate';
+import {
+  CompletionCommand,
+} from './commands/completion';
+import {
+  ConfigGetCommand,
+} from './commands/config-get';
+import {
+  ConfigListCommand,
+} from './commands/config-list';
+import {
+  DiscoverCommand,
+} from './commands/discover';
+import {
+  DoctorCommand,
+  DoctorDiagnosticsCommand,
+} from './commands/doctor';
+import {
+  ExplainCommand,
+} from './commands/explain';
+import {
+  HookCreateCommand,
+} from './commands/hook-create';
+import {
+  HubAddCommand,
+  HubCreateCommand,
+  HubListCommand,
+  HubRefreshCommand,
+  HubRemoveCommand,
+  HubSyncCommand,
+  HubUseCommand,
+} from './commands/hub';
+import {
+  IndexBenchCommand,
+} from './commands/index-bench';
+import {
+  IndexBuildCommand,
+} from './commands/index-build';
+import {
+  IndexEvalCommand,
+} from './commands/index-eval';
+import {
+  IndexExportCommand,
+} from './commands/index-export';
+import {
+  IndexHarvestCommand,
+} from './commands/index-harvest';
+import {
+  IndexReportCommand,
+} from './commands/index-report';
+import {
+  IndexSearchCommand,
+} from './commands/index-search';
+import {
+  IndexShortlistAddCommand,
+  IndexShortlistListCommand,
+  IndexShortlistNewCommand,
+  IndexShortlistRemoveCommand,
+} from './commands/index-shortlist';
+import {
+  IndexStatsCommand,
+} from './commands/index-stats';
+import {
+  InitCommand,
+} from './commands/init';
+import {
+  InstallCommand,
+} from './commands/install';
+import {
+  InstructionCreateCommand,
+} from './commands/instruction-create';
+import {
+  PluginCreateCommand,
+} from './commands/plugin-create';
+import {
+  PluginsListCommand,
+} from './commands/plugins-list';
+import {
+  ProfileActivateCommand,
+  ProfileCreateCommand,
+  ProfileCurrentCommand,
+  ProfileDeactivateCommand,
+  ProfileEditCommand,
+  ProfileListCommand,
+  ProfilePublishCommand,
+  ProfileShowCommand,
+} from './commands/profile';
+import {
+  PromptCreateCommand,
+} from './commands/prompt-create';
+import {
+  SkillCreateCommand,
+} from './commands/skill-create';
+import {
+  SkillNewCommand,
+} from './commands/skill-new';
+import {
+  SkillValidateCommand,
+} from './commands/skill-validate';
+import {
+  SourceAddCommand,
+  SourceListCommand,
+  SourceRemoveCommand,
+} from './commands/source';
+import {
+  StatusCommand,
+} from './commands/status';
+import {
+  TargetAddCommand,
+} from './commands/target-add';
+import {
+  TargetListCommand,
+} from './commands/target-list';
+import {
+  TargetRemoveCommand,
+} from './commands/target-remove';
+import {
+  TargetTypesCommand,
+} from './commands/target-types';
+import {
+  UninstallCommand,
+} from './commands/uninstall';
+import {
+  UpdateCommand,
+} from './commands/update';
+import {
+  VersionComputeCommand,
+} from './commands/version-compute';
+import {
+  createProductionContext,
+  runCli,
+} from './framework';
+
+/**
+ * Main entry point.
+ * @returns Process exit code.
+ */
+async function main(): Promise<number> {
+  const ctx = createProductionContext();
+  const http = new NodeHttpClient();
+  const tokens = defaultTokenProvider(ctx.env);
+
+  const commandClasses = [
+    StatusCommand,
+    InitCommand,
+    InstallCommand,
+    UninstallCommand,
+    UpdateCommand,
+    ProfileListCommand,
+    ProfileActivateCommand,
+    ProfileDeactivateCommand,
+    ProfileShowCommand,
+    ProfileCurrentCommand,
+    ProfileCreateCommand,
+    ProfileEditCommand,
+    ProfilePublishCommand,
+    HubCreateCommand,
+    HubAddCommand,
+    HubListCommand,
+    HubUseCommand,
+    HubRemoveCommand,
+    HubSyncCommand,
+    HubRefreshCommand,
+    SourceAddCommand,
+    SourceListCommand,
+    SourceRemoveCommand,
+    TargetAddCommand,
+    TargetListCommand,
+    TargetRemoveCommand,
+    TargetTypesCommand,
+    IndexBuildCommand,
+    IndexExportCommand,
+    IndexSearchCommand,
+    IndexShortlistNewCommand,
+    IndexShortlistAddCommand,
+    IndexShortlistRemoveCommand,
+    IndexShortlistListCommand,
+    IndexHarvestCommand,
+    IndexStatsCommand,
+    IndexReportCommand,
+    ExplainCommand,
+    ConfigGetCommand,
+    ConfigListCommand,
+    ApplyCommand,
+    SkillNewCommand,
+    BundleBuildCommand,
+    BundleManifestCommand,
+    VersionComputeCommand,
+    IndexEvalCommand,
+    IndexBenchCommand,
+    CollectionListCommand,
+    CollectionValidateCommand,
+    CollectionAffectedCommand,
+    CollectionCreateCommand,
+    PromptCreateCommand,
+    InstructionCreateCommand,
+    AgentCreateCommand,
+    SkillCreateCommand,
+    PluginCreateCommand,
+    HookCreateCommand,
+    DoctorCommand,
+    DoctorDiagnosticsCommand,
+    PluginsListCommand,
+    SkillValidateCommand,
+    CompletionCommand,
+    DiscoverCommand
+  ];
+
+  const exitCode = await runCli(process.argv.slice(2), {
+    ctx,
+    commands: [],
+    commandClasses,
+    name: 'ai-primitives-hub',
+    version: '1.0.0',
+    http,
+    tokens,
+    defaultOutput: 'text'
+  });
+
+  return exitCode;
+}
+
+// Export for use by index.ts and bin/ai-primitives-hub.js
+export { main };

--- a/packages/cli/src/sea-entry.ts
+++ b/packages/cli/src/sea-entry.ts
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+/**
+ * SEA binary entry point.
+ * This file is bundled into the SEA blob and executes the CLI.
+ */
+import {
+  main,
+} from './main';
+
+// Suppress the Node.js Single Executable Application experimental warning
+// so end-users never see it in production builds.
+const originalEmitWarning = process.emitWarning.bind(process) as (warning: string | Error, ...args: unknown[]) => void;
+process.emitWarning = (warning, ...args): void => {
+  const msg = typeof warning === 'string' ? warning : warning.message;
+  if (msg.includes('Single executable application')) {
+    return;
+  }
+  originalEmitWarning(warning, ...args);
+};
+
+main().then((exitCode) => {
+  process.exit(exitCode ?? 0);
+}).catch((error) => {
+  // eslint-disable-next-line no-console -- SEA fatal error; must print to stderr before exit.
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/cli/test/commands/collection-bundle.test.ts
+++ b/packages/cli/test/commands/collection-bundle.test.ts
@@ -1,0 +1,284 @@
+/**
+ * `collection-*`, `bundle manifest`, `bundle build`, `version compute`,
+ * and `skill new` command tests.
+ *
+ * Uses a real `NodeFileSystem` against a real temp directory (not
+ * `createTestContext`'s default in-memory `fs` stub, which rejects
+ * every call) since these commands do real file IO; `bundle build`
+ * additionally shells out to a real zip stream and `version compute`
+ * to a real `git` binary, neither of which can be stubbed through
+ * `Context.fs`.
+ */
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  NodeFileSystem,
+} from '@ai-primitives-hub/infra';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  BundleBuildCommand,
+} from '../../src/commands/bundle-build';
+import {
+  BundleManifestCommand,
+} from '../../src/commands/bundle-manifest';
+import {
+  CollectionAffectedCommand,
+} from '../../src/commands/collection-affected';
+import {
+  CollectionCreateCommand,
+} from '../../src/commands/collection-create';
+import {
+  CollectionListCommand,
+} from '../../src/commands/collection-list';
+import {
+  CollectionValidateCommand,
+} from '../../src/commands/collection-validate';
+import {
+  SkillNewCommand,
+} from '../../src/commands/skill-new';
+import {
+  VersionComputeCommand,
+} from '../../src/commands/version-compute';
+import {
+  runCommand,
+} from '../../src/framework';
+
+const COMMAND_CLASSES = [
+  CollectionCreateCommand,
+  CollectionListCommand,
+  CollectionValidateCommand,
+  CollectionAffectedCommand,
+  BundleManifestCommand,
+  BundleBuildCommand,
+  VersionComputeCommand,
+  SkillNewCommand
+];
+
+interface JsonEnvelope<T> {
+  status: string;
+  data: T;
+}
+
+describe('collection/bundle/version/skill commands', () => {
+  let workspace: string;
+
+  const run = (argv: string[]): ReturnType<typeof runCommand> => runCommand(argv, {
+    commandClasses: COMMAND_CLASSES,
+    context: {
+      cwd: workspace,
+      fs: new NodeFileSystem(),
+      env: {
+        HOME: workspace,
+        USERPROFILE: workspace,
+        XDG_CONFIG_HOME: path.join(workspace, 'xdg-config'),
+        XDG_CACHE_HOME: path.join(workspace, 'xdg-cache')
+      }
+    }
+  });
+
+  const parseJson = <T>(stdout: string): JsonEnvelope<T> => JSON.parse(stdout) as JsonEnvelope<T>;
+
+  beforeEach(async () => {
+    workspace = await mkdtemp(path.join(os.tmpdir(), 'cli-collection-test-'));
+    await mkdir(path.join(workspace, 'collections'), { recursive: true });
+    await mkdir(path.join(workspace, 'prompts'), { recursive: true });
+    await writeFile(path.join(workspace, 'prompts', 'hello.prompt.md'), '# Hello Prompt\n\nA test prompt.\n');
+    await writeFile(
+      path.join(workspace, 'collections', 'foo.collection.yml'),
+      `id: foo
+name: Foo Collection
+description: Test collection
+items:
+  - path: prompts/hello.prompt.md
+    kind: prompt
+`
+    );
+  });
+
+  afterEach(async () => {
+    await rm(workspace, { recursive: true, force: true });
+  });
+
+  describe('collection create', () => {
+    it('creates a new collection file', async () => {
+      const result = await run(['collection', 'create', 'bar', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ collectionId: string; path: string }>(result.stdout);
+      expect(envelope.data.collectionId).toBe('bar');
+      const content = await readFile(envelope.data.path, 'utf8');
+      expect(content).toContain('id: bar');
+    });
+
+    it('fails with a clipanion usage error (exit 64) when <id> is omitted', async () => {
+      const result = await run(['collection', 'create', '-o', 'json']);
+      expect(result.exitCode).toBe(64);
+    });
+
+    it('honors an absolute --path as-is instead of nesting it under cwd', async () => {
+      const customDir = path.join(workspace, 'custom-out');
+      const result = await run(['collection', 'create', 'bar', '--path', customDir, '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ path: string }>(result.stdout);
+      expect(envelope.data.path.startsWith(customDir)).toBe(true);
+    });
+  });
+
+  describe('collection list', () => {
+    it('lists the seeded collection', async () => {
+      const result = await run(['collection', 'list', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ id: string }[]>(result.stdout);
+      expect(envelope.data.map((c) => c.id)).toContain('foo');
+    });
+
+    it('fails with exit 1 when collections/ does not exist', async () => {
+      const freshDir = await mkdtemp(path.join(os.tmpdir(), 'cli-collection-test-nocol-'));
+      try {
+        const result = await runCommand(['collection', 'list', '-o', 'json'], {
+          commandClasses: COMMAND_CLASSES,
+          context: { cwd: freshDir, fs: new NodeFileSystem(), env: {} }
+        });
+        expect(result.exitCode).toBe(1);
+      } finally {
+        await rm(freshDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('collection validate', () => {
+    it('passes for the seeded valid collection', async () => {
+      const result = await run(['collection', 'validate', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ ok: boolean }>(result.stdout);
+      expect(envelope.data.ok).toBe(true);
+    });
+
+    it('fails for a collection missing the required id field', async () => {
+      await writeFile(
+        path.join(workspace, 'collections', 'bad.collection.yml'),
+        'name: Bad Collection\nitems: []\n'
+      );
+      const result = await run([
+        'collection', 'validate', '--collection-file', 'collections/bad.collection.yml', '-o', 'json'
+      ]);
+      expect(result.exitCode).toBe(1);
+      const envelope = parseJson<{ ok: boolean }>(result.stdout);
+      expect(envelope.data.ok).toBe(false);
+    });
+  });
+
+  describe('collection affected', () => {
+    it('reports the collection as affected when an item path changed', async () => {
+      const result = await run([
+        'collection', 'affected', '--changed-path', 'prompts/hello.prompt.md', '-o', 'json'
+      ]);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ affected: { id: string }[] }>(result.stdout);
+      expect(envelope.data.affected.map((a) => a.id)).toContain('foo');
+    });
+
+    it('reports no affected collections for an unrelated path', async () => {
+      const result = await run([
+        'collection', 'affected', '--changed-path', 'unrelated/file.md', '-o', 'json'
+      ]);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ affected: unknown[] }>(result.stdout);
+      expect(envelope.data.affected).toEqual([]);
+    });
+  });
+
+  describe('bundle manifest', () => {
+    it('generates a deployment-manifest.yml from the collection', async () => {
+      const outFile = path.join(workspace, 'deployment-manifest.yml');
+      const result = await run([
+        'bundle', 'manifest', '--version', '1.0.0', '--out-file', outFile, '-o', 'json'
+      ]);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ id: string; totalItems: number }>(result.stdout);
+      expect(envelope.data).toMatchObject({ id: 'foo', totalItems: 1 });
+      const content = await readFile(outFile, 'utf8');
+      expect(content).toContain('id: foo');
+    });
+
+    it('fails with exit 1 when collections/ does not exist and no --collection-file is given', async () => {
+      const freshDir = await mkdtemp(path.join(os.tmpdir(), 'cli-collection-test-nocol-'));
+      try {
+        const result = await runCommand(['bundle', 'manifest', '--version', '1.0.0', '-o', 'json'], {
+          commandClasses: COMMAND_CLASSES,
+          context: { cwd: freshDir, fs: new NodeFileSystem(), env: {} }
+        });
+        expect(result.exitCode).toBe(1);
+      } finally {
+        await rm(freshDir, { recursive: true, force: true });
+      }
+    });
+
+    it('writes the default deployment-manifest.yml under ctx.cwd(), not process.cwd()', async () => {
+      const result = await run(['bundle', 'manifest', '--version', '1.0.0', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ outFile: string }>(result.stdout);
+      expect(envelope.data.outFile).toBe(path.join(workspace, 'deployment-manifest.yml'));
+      const content = await readFile(path.join(workspace, 'deployment-manifest.yml'), 'utf8');
+      expect(content).toContain('id: foo');
+      await expect(readFile(path.join(process.cwd(), 'deployment-manifest.yml'), 'utf8')).rejects.toThrow();
+    });
+  });
+
+  describe('bundle build', () => {
+    it('builds a non-trivial, reproducible bundle zip', async () => {
+      const result = await run([
+        'bundle', 'build', '--version', '1.0.0', '--collection-file', 'collections/foo.collection.yml', '-o', 'json'
+      ]);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ zipAsset: string; manifestAsset: string }>(result.stdout);
+      const zipStat = await stat(envelope.data.zipAsset);
+      expect(zipStat.size).toBeGreaterThan(0);
+    });
+  });
+
+  describe('version compute', () => {
+    beforeEach(async () => {
+      await run(['bundle', 'manifest', '--version', '1.0.0', '-o', 'json']);
+    });
+
+    it('computes 1.0.0 as the initial version with no existing git tags', async () => {
+      const result = await run([
+        'version', 'compute', '--collection-file', 'collections/foo.collection.yml', '-o', 'json'
+      ]);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ collectionId: string; nextVersion: string; tag: string }>(result.stdout);
+      expect(envelope.data).toMatchObject({ collectionId: 'foo', nextVersion: '1.0.0', tag: 'foo-v1.0.0' });
+    });
+  });
+
+  describe('skill new', () => {
+    it('creates a new skill folder with SKILL.md', async () => {
+      const result = await run([
+        'skill', 'new', '--skill-name', 'my-skill', '--description', 'A test skill', '-o', 'json'
+      ]);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ path: string }>(result.stdout);
+      const content = await readFile(path.join(envelope.data.path, 'SKILL.md'), 'utf8');
+      expect(content.length).toBeGreaterThan(0);
+    });
+
+    it('fails with exit 1 when --skill-name is omitted', async () => {
+      const result = await run(['skill', 'new', '--description', 'A test skill', '-o', 'json']);
+      expect(result.exitCode).toBe(1);
+    });
+  });
+});

--- a/packages/cli/test/commands/completion.test.ts
+++ b/packages/cli/test/commands/completion.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Tests for `ai-primitives-hub completion`.
+ *
+ * Generates bash/zsh completion scripts and validates shell argument handling.
+ * @module test/commands/completion
+ */
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  CompletionCommand,
+} from '../../src/commands/completion';
+import {
+  runCommand,
+} from '../../src/framework';
+
+const run = (argv: string[]): ReturnType<typeof runCommand> =>
+  runCommand(argv, { commandClasses: [CompletionCommand] });
+
+describe('completion command', () => {
+  it('generates a bash completion script', async () => {
+    const result = await run(['completion', '--shell', 'bash']);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('complete -F _ai_primitives_hub_completion ai-primitives-hub');
+    expect(result.stdout).toContain('_ai_primitives_hub_completion()');
+  });
+
+  it('generates a zsh completion script', async () => {
+    const result = await run(['completion', '--shell', 'zsh']);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('#compdef ai-primitives-hub');
+    expect(result.stdout).toContain('_ai_primitives_hub()');
+  });
+
+  it('fails when --shell is omitted', async () => {
+    const result = await run(['completion']);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('--shell is required');
+  });
+
+  it('fails for an unsupported shell', async () => {
+    const result = await run(['completion', '--shell', 'fish']);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('Unsupported shell "fish"');
+  });
+});

--- a/packages/cli/test/commands/discover.test.ts
+++ b/packages/cli/test/commands/discover.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Tests for `ai-primitives-hub discover`.
+ *
+ * The command detects project context, searches a primitive index, and
+ * returns ranked recommendations. The AI and interactive flags are
+ * reserved and currently fail with structured errors.
+ * @module test/commands/discover
+ */
+import {
+  mkdir,
+  mkdtemp,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type {
+  Primitive,
+} from '@ai-primitives-hub/core';
+import {
+  PrimitiveIndex,
+  saveIndex,
+} from '@ai-primitives-hub/infra';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  DiscoverCommand,
+} from '../../src/commands/discover';
+import {
+  runCommand,
+} from '../../src/framework';
+
+interface JsonEnvelope<T> {
+  status: string;
+  data: T;
+}
+
+const run = (argv: string[], workspace: string): ReturnType<typeof runCommand> =>
+  runCommand(argv, {
+    commandClasses: [DiscoverCommand],
+    context: {
+      cwd: workspace,
+      env: {
+        HOME: workspace,
+        XDG_CACHE_HOME: workspace,
+        USERPROFILE: workspace
+      }
+    }
+  });
+
+const parseJson = <T>(stdout: string): JsonEnvelope<T> => JSON.parse(stdout) as JsonEnvelope<T>;
+
+describe('discover command', () => {
+  let workspace: string;
+
+  beforeEach(async () => {
+    workspace = await mkdtemp(path.join(os.tmpdir(), 'cli-discover-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(workspace, { recursive: true, force: true });
+  });
+
+  const createIndex = (indexPath: string): void => {
+    const primitive: Primitive = {
+      id: 'ts/prompt',
+      bundle: {
+        sourceId: 'local',
+        sourceType: 'local',
+        bundleId: 'ts-bundle',
+        bundleVersion: '1.0.0',
+        installed: false
+      },
+      kind: 'prompt',
+      title: 'TypeScript prompt',
+      description: 'A prompt for TypeScript projects',
+      path: 'prompt.md',
+      tags: ['typescript'],
+      bodyPreview: 'typescript best practices',
+      contentHash: 'abc123'
+    };
+
+    const idx = PrimitiveIndex.fromPrimitives([primitive]);
+    saveIndex(idx, indexPath);
+  };
+
+  const writePackageJson = async (): Promise<void> => {
+    const pkg = JSON.stringify({ dependencies: { typescript: '5.0.0' } });
+    await writeFile(path.join(workspace, 'package.json'), pkg, 'utf8');
+  };
+
+  it('returns ranked recommendations from the index', async () => {
+    const indexPath = path.join(workspace, 'index.json');
+    createIndex(indexPath);
+    await writePackageJson();
+
+    const result = await run(['discover', '--index', indexPath], workspace);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Detected Context:');
+    expect(result.stdout).toContain('Languages: TypeScript');
+    expect(result.stdout).toContain('Recommendations (1):');
+    expect(result.stdout).toContain('TypeScript prompt');
+  });
+
+  it('returns results as JSON', async () => {
+    const indexPath = path.join(workspace, 'index.json');
+    createIndex(indexPath);
+    await writePackageJson();
+
+    const result = await run(['discover', '--index', indexPath, '-o', 'json'], workspace);
+    expect(result.exitCode).toBe(0);
+    const envelope = parseJson<{ results: { primitive: { title: string } }[] }>(result.stdout);
+    expect(envelope.status).toBe('ok');
+    expect(envelope.data.results).toHaveLength(1);
+    expect(envelope.data.results[0].primitive.title).toBe('TypeScript prompt');
+  });
+
+  it('filters by primitive kind', async () => {
+    const indexPath = path.join(workspace, 'index.json');
+    createIndex(indexPath);
+    await writePackageJson();
+
+    const result = await run(['discover', '--index', indexPath, '-o', 'json', '--kinds', 'prompt'], workspace);
+    expect(result.exitCode).toBe(0);
+    const envelope = parseJson<{ results: { primitive: { title: string } }[] }>(result.stdout);
+    expect(envelope.data.results).toHaveLength(1);
+    expect(envelope.data.results[0].primitive.title).toBe('TypeScript prompt');
+
+    const noMatch = await run(['discover', '--index', indexPath, '-o', 'json', '--kinds', 'skill'], workspace);
+    expect(noMatch.exitCode).toBe(0);
+    const noMatchEnvelope = parseJson<{ results: { primitive: { title: string } }[] }>(noMatch.stdout);
+    expect(noMatchEnvelope.data.results).toHaveLength(0);
+  });
+
+  it('limits the number of results', async () => {
+    const indexPath = path.join(workspace, 'index.json');
+    const primitives: Primitive[] = [
+      {
+        id: 'ts/prompt',
+        bundle: { sourceId: 'local', sourceType: 'local', bundleId: 'ts-bundle', bundleVersion: '1.0.0', installed: false },
+        kind: 'prompt',
+        title: 'TypeScript prompt',
+        description: 'First prompt',
+        path: 'prompt1.md',
+        tags: ['typescript'],
+        bodyPreview: 'typescript first',
+        contentHash: 'abc1'
+      },
+      {
+        id: 'ts/prompt2',
+        bundle: { sourceId: 'local', sourceType: 'local', bundleId: 'ts-bundle', bundleVersion: '1.0.0', installed: false },
+        kind: 'prompt',
+        title: 'TypeScript second',
+        description: 'Second prompt',
+        path: 'prompt2.md',
+        tags: ['typescript'],
+        bodyPreview: 'typescript second',
+        contentHash: 'abc2'
+      }
+    ];
+    const idx = PrimitiveIndex.fromPrimitives(primitives);
+    saveIndex(idx, indexPath);
+    await writePackageJson();
+
+    const result = await run(['discover', '--index', indexPath, '-o', 'json', '--limit', '1'], workspace);
+    expect(result.exitCode).toBe(0);
+    const envelope = parseJson<{ results: unknown[] }>(result.stdout);
+    expect(envelope.data.results.length).toBeLessThanOrEqual(1);
+  });
+
+  it('fails when --ai is provided', async () => {
+    const result = await run(['discover', '--ai'], workspace);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('USAGE.AI_NOT_IMPLEMENTED');
+  });
+
+  it('fails when --interactive is provided', async () => {
+    const result = await run(['discover', '--interactive'], workspace);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('USAGE.INTERACTIVE_NOT_IMPLEMENTED');
+  });
+
+  it('fails for an invalid index file', async () => {
+    const result = await run(['discover', '--index', path.join(workspace, 'missing.json')], workspace);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('INDEX.NOT_FOUND');
+  });
+
+  it('fails for invalid --kinds values', async () => {
+    const indexPath = path.join(workspace, 'index.json');
+    createIndex(indexPath);
+    await writePackageJson();
+
+    const result = await run(['discover', '--index', indexPath, '--kinds', 'not-a-kind'], workspace);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('USAGE.INVALID_FLAG');
+  });
+
+  it('uses the default index path when --index is omitted', async () => {
+    const defaultIndexDir = path.join(workspace, 'ai-primitives-hub');
+    const defaultIndexPath = path.join(defaultIndexDir, 'primitive-index.json');
+    await mkdir(defaultIndexDir, { recursive: true });
+    createIndex(defaultIndexPath);
+    await writePackageJson();
+
+    const result = await run(['discover'], workspace);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('TypeScript prompt');
+  });
+});

--- a/packages/cli/test/commands/doctor-status-init-update.test.ts
+++ b/packages/cli/test/commands/doctor-status-init-update.test.ts
@@ -1,0 +1,270 @@
+/**
+ * `doctor`, `doctor diagnostics`, `status`, `init`, and `update`
+ * command tests.
+ *
+ * Uses a real `NodeFileSystem` against a real temp directory (not
+ * `createTestContext`'s default in-memory `fs` stub, which rejects
+ * every call) since these commands do real file IO. Network-touching
+ * paths (`doctor`'s github-api check, `update`'s remote-source
+ * resolution) are avoided via `AI_PRIMITIVES_HUB_SKIP_NETWORK=1` and by
+ * only exercising local-source lockfiles, matching the established
+ * approach in install.test.ts/uninstall.test.ts.
+ */
+import {
+  mkdir,
+  mkdtemp,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  NodeFileSystem,
+} from '@ai-primitives-hub/infra';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  DoctorCommand,
+  DoctorDiagnosticsCommand,
+} from '../../src/commands/doctor';
+import {
+  InitCommand,
+} from '../../src/commands/init';
+import {
+  InstallCommand,
+} from '../../src/commands/install';
+import {
+  StatusCommand,
+} from '../../src/commands/status';
+import {
+  TargetAddCommand,
+} from '../../src/commands/target-add';
+import {
+  UpdateCommand,
+} from '../../src/commands/update';
+import {
+  runCommand,
+} from '../../src/framework';
+
+const COMMAND_CLASSES = [
+  DoctorCommand,
+  DoctorDiagnosticsCommand,
+  StatusCommand,
+  InitCommand,
+  UpdateCommand,
+  TargetAddCommand,
+  InstallCommand
+];
+
+interface JsonEnvelope<T> {
+  status: string;
+  data: T;
+}
+
+describe('doctor/status/init/update commands', () => {
+  let workspace: string;
+
+  const run = (argv: string[]): ReturnType<typeof runCommand> => runCommand(argv, {
+    commandClasses: COMMAND_CLASSES,
+    context: {
+      cwd: workspace,
+      fs: new NodeFileSystem(),
+      env: {
+        HOME: workspace,
+        USERPROFILE: workspace,
+        XDG_CONFIG_HOME: path.join(workspace, 'xdg-config'),
+        XDG_CACHE_HOME: path.join(workspace, 'xdg-cache'),
+        AI_PRIMITIVES_HUB_SKIP_NETWORK: '1'
+      }
+    }
+  });
+
+  const parseJson = <T>(stdout: string): JsonEnvelope<T> => JSON.parse(stdout) as JsonEnvelope<T>;
+
+  beforeEach(async () => {
+    workspace = await mkdtemp(path.join(os.tmpdir(), 'cli-doctor-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(workspace, { recursive: true, force: true });
+  });
+
+  describe('doctor', () => {
+    it('runs every check and exits 0 with zero failures', async () => {
+      const result = await run(['doctor', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ checks: { name: string; status: string }[]; summary: { ok: number; warn: number; fail: number } }>(result.stdout);
+      expect(envelope.data.checks.length).toBe(11);
+      expect(envelope.data.summary.fail).toBe(0);
+    });
+
+    it('-v includes per-check logs', async () => {
+      const result = await run(['doctor', '-v', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ checks: { logs?: unknown[] }[] }>(result.stdout);
+      expect(envelope.data.checks.some((c) => (c.logs?.length ?? 0) > 0)).toBe(true);
+    });
+  });
+
+  describe('doctor diagnostics', () => {
+    it('runs the full self-contained smoke test successfully', async () => {
+      const result = await run(['doctor', 'diagnostics', '-o', 'json']);
+      const envelope = parseJson<{ ok: boolean; steps: { name: string; exitCode: number }[] }>(result.stdout);
+      const failed = envelope.data.steps.filter((s) => s.exitCode !== 0);
+      expect(failed).toEqual([]);
+      expect(envelope.data.ok).toBe(true);
+      expect(result.exitCode).toBe(0);
+    }, 60_000);
+  });
+
+  describe('status', () => {
+    it('reports empty state for a fresh workspace', async () => {
+      const result = await run(['status', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{
+        configPath: string | null;
+        targets: unknown[];
+        activeHubId: string | null;
+        index: unknown;
+        lockfile: unknown;
+      }>(result.stdout);
+      expect(envelope.data).toMatchObject({
+        configPath: null,
+        targets: [],
+        activeHubId: null,
+        index: null,
+        lockfile: null
+      });
+    });
+
+    it('reflects a configured target + installed bundle', async () => {
+      const bundleDir = path.join(workspace, 'bundle');
+      const targetDir = path.join(workspace, 'target');
+      await mkdir(path.join(bundleDir, 'prompts'), { recursive: true });
+      await mkdir(targetDir, { recursive: true });
+      await writeFile(
+        path.join(bundleDir, 'deployment-manifest.yml'),
+        'id: local-foo\nversion: 1.0.0\nname: Local Foo\nitems:\n  - path: prompts/hello.prompt.md\n    kind: prompt\n'
+      );
+      await writeFile(path.join(bundleDir, 'prompts', 'hello.prompt.md'), '# Hello Prompt\n');
+
+      await run(['target', 'add', 'copilot', '--type', 'copilot-cli', '--path', targetDir, '-o', 'json']);
+      await run(['install', 'local-foo', '--from', bundleDir, '--target', 'copilot', '-o', 'json']);
+
+      const result = await run(['status', '--verbose', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{
+        targets: { name: string; type: string }[];
+        lockfile: { entries: number; bundles?: { bundleId: string }[] } | null;
+      }>(result.stdout);
+      expect(envelope.data.targets).toContainEqual(expect.objectContaining({ name: 'copilot', type: 'copilot-cli' }));
+      expect(envelope.data.lockfile?.entries).toBe(1);
+      expect(envelope.data.lockfile?.bundles?.map((b) => b.bundleId)).toContain('local-foo');
+    });
+  });
+
+  describe('init', () => {
+    it('creates a target non-interactively', async () => {
+      const result = await run(['init', '--target-name', 'copilot', '--target-type', 'copilot-cli', '--yes', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ target: { name: string; type: string; created: boolean } }>(result.stdout);
+      expect(envelope.data.target).toMatchObject({ name: 'copilot', type: 'copilot-cli', created: true });
+    });
+
+    it('is idempotent: re-running with the same target reports created: false', async () => {
+      await run(['init', '--target-name', 'copilot', '--target-type', 'copilot-cli', '--yes', '-o', 'json']);
+      const result = await run(['init', '--target-name', 'copilot', '--target-type', 'copilot-cli', '--yes', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ target: { created: boolean } }>(result.stdout);
+      expect(envelope.data.target.created).toBe(false);
+    });
+
+    it('fails with exit 1 for an unknown --target-type', async () => {
+      const result = await run(['init', '--target-type', 'totally-bogus', '--yes', '-o', 'json']);
+      expect(result.exitCode).toBe(1);
+    });
+
+    it('imports and syncs a local hub when --hub/--hub-type local are given', async () => {
+      const hubConfigFile = path.join(workspace, 'hub-config.yml');
+      const hubSourceDir = path.join(workspace, 'hub-source');
+      await mkdir(hubSourceDir, { recursive: true });
+      await writeFile(
+        hubConfigFile,
+        `version: 1.0.0
+metadata:
+  name: Test Hub
+  description: Test hub
+  maintainer: test
+  updatedAt: '2026-01-01T00:00:00Z'
+sources:
+  - id: local-foo-src
+    name: Local Foo Source
+    type: local
+    url: ${hubSourceDir}
+    enabled: true
+    priority: 0
+    hubId: test-hub
+profiles: []
+`
+      );
+      const result = await run([
+        'init', '--target-name', 'copilot', '--target-type', 'copilot-cli',
+        '--hub', hubConfigFile, '--hub-type', 'local', '--yes', '-o', 'json'
+      ]);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ hub: { id: string } | null }>(result.stdout);
+      expect(envelope.data.hub).not.toBeNull();
+    });
+  });
+
+  describe('update', () => {
+    it('fails with exit 1 when no lockfile is found', async () => {
+      await run(['target', 'add', 'copilot', '--type', 'copilot-cli', '--path', path.join(workspace, 'target'), '-o', 'json']);
+      const result = await run(['update', '-o', 'json']);
+      expect(result.exitCode).toBe(1);
+    });
+
+    it('reports up to date for a lockfile with only local-source bundles (no network needed)', async () => {
+      const bundleDir = path.join(workspace, 'bundle');
+      const targetDir = path.join(workspace, 'target');
+      await mkdir(path.join(bundleDir, 'prompts'), { recursive: true });
+      await mkdir(targetDir, { recursive: true });
+      await writeFile(
+        path.join(bundleDir, 'deployment-manifest.yml'),
+        'id: local-foo\nversion: 1.0.0\nname: Local Foo\nitems:\n  - path: prompts/hello.prompt.md\n    kind: prompt\n'
+      );
+      await writeFile(path.join(bundleDir, 'prompts', 'hello.prompt.md'), '# Hello Prompt\n');
+      await run(['target', 'add', 'copilot', '--type', 'copilot-cli', '--path', targetDir, '-o', 'json']);
+      await run(['install', 'local-foo', '--from', bundleDir, '--target', 'copilot', '-o', 'json']);
+
+      const result = await run(['update', '--target', 'copilot', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ checked: number; updated: number }>(result.stdout);
+      expect(envelope.data).toMatchObject({ checked: 1, updated: 0 });
+    });
+
+    it('--dry-run reports the same up-to-date result without applying anything', async () => {
+      const bundleDir = path.join(workspace, 'bundle');
+      const targetDir = path.join(workspace, 'target');
+      await mkdir(path.join(bundleDir, 'prompts'), { recursive: true });
+      await mkdir(targetDir, { recursive: true });
+      await writeFile(
+        path.join(bundleDir, 'deployment-manifest.yml'),
+        'id: local-foo\nversion: 1.0.0\nname: Local Foo\nitems:\n  - path: prompts/hello.prompt.md\n    kind: prompt\n'
+      );
+      await writeFile(path.join(bundleDir, 'prompts', 'hello.prompt.md'), '# Hello Prompt\n');
+      await run(['target', 'add', 'copilot', '--type', 'copilot-cli', '--path', targetDir, '-o', 'json']);
+      await run(['install', 'local-foo', '--from', bundleDir, '--target', 'copilot', '-o', 'json']);
+
+      const result = await run(['update', '--target', 'copilot', '--dry-run', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ dryRun: boolean; updated: number }>(result.stdout);
+      expect(envelope.data).toMatchObject({ dryRun: true, updated: 0 });
+    });
+  });
+});

--- a/packages/cli/test/commands/hub.test.ts
+++ b/packages/cli/test/commands/hub.test.ts
@@ -1,0 +1,263 @@
+/**
+ * `hub` command tests.
+ *
+ * Uses a real `NodeFileSystem` against a real temp directory (not
+ * `createTestContext`'s default in-memory `fs` stub, which rejects
+ * every call) since these commands do real file IO (hub-config.yml
+ * scaffolding, user-scope hub store reads/writes).
+ */
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  NodeFileSystem,
+} from '@ai-primitives-hub/infra';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  HubAddCommand,
+  HubCreateCommand,
+  HubListCommand,
+  HubRefreshCommand,
+  HubRemoveCommand,
+  HubSyncCommand,
+  HubUseCommand,
+} from '../../src/commands/hub';
+import {
+  runCommand,
+} from '../../src/framework';
+
+const COMMAND_CLASSES = [
+  HubAddCommand,
+  HubCreateCommand,
+  HubListCommand,
+  HubRefreshCommand,
+  HubRemoveCommand,
+  HubSyncCommand,
+  HubUseCommand
+];
+
+interface JsonEnvelope<T> {
+  status: string;
+  data: T;
+}
+
+describe('hub commands', () => {
+  let workspace: string;
+  let bundleDir: string;
+  let hubConfigFile: string;
+
+  const run = (argv: string[]): ReturnType<typeof runCommand> => runCommand(argv, {
+    commandClasses: COMMAND_CLASSES,
+    context: {
+      cwd: workspace,
+      fs: new NodeFileSystem(),
+      env: {
+        HOME: workspace,
+        USERPROFILE: workspace,
+        XDG_CONFIG_HOME: path.join(workspace, 'xdg-config'),
+        XDG_CACHE_HOME: path.join(workspace, 'xdg-cache')
+      }
+    }
+  });
+
+  const parseJson = <T>(stdout: string): JsonEnvelope<T> => JSON.parse(stdout) as JsonEnvelope<T>;
+
+  beforeEach(async () => {
+    workspace = await mkdtemp(path.join(os.tmpdir(), 'cli-hub-test-'));
+    bundleDir = path.join(workspace, 'bundle');
+    hubConfigFile = path.join(workspace, 'hub-config.yml');
+
+    await mkdir(bundleDir, { recursive: true });
+    await writeFile(
+      hubConfigFile,
+      `version: 1.0.0
+metadata:
+  name: Test Hub
+  description: Test hub
+  maintainer: test
+  updatedAt: '2026-01-01T00:00:00Z'
+sources:
+  - id: local-foo-src
+    name: Local Foo Source
+    type: local
+    url: ${bundleDir}
+    enabled: true
+    priority: 0
+    hubId: test-hub
+profiles: []
+`
+    );
+  });
+
+  afterEach(async () => {
+    await rm(workspace, { recursive: true, force: true });
+  });
+
+  describe('hub create', () => {
+    it('scaffolds a hub-config.yml in the given --out dir', async () => {
+      const outDir = path.join(workspace, 'scaffolded');
+      const result = await run(['hub', 'create', '--name', 'My Hub', '--out', outDir, '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ path: string; name: string; outDir: string }>(result.stdout);
+      expect(envelope.data.name).toBe('My Hub');
+      expect(envelope.data.path).toBe(path.join(outDir, 'hub-config.yml'));
+
+      const content = await readFile(envelope.data.path, 'utf8');
+      expect(content).toContain('name: "My Hub"');
+      expect(content).toContain('profiles: []');
+    });
+
+    it('fails with exit 1 when --name is missing', async () => {
+      const result = await run(['hub', 'create', '-o', 'json']);
+      expect(result.exitCode).toBe(1);
+    });
+  });
+
+  describe('hub add', () => {
+    it('imports a local hub and auto-uses + auto-syncs it by default', async () => {
+      const result = await run([
+        'hub', 'add', '--type', 'local', '--location', hubConfigFile, '--id', 'test-hub', '-o', 'json'
+      ]);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ id: string; used: boolean; synced: boolean }>(result.stdout);
+      expect(envelope.data).toMatchObject({ id: 'test-hub', used: true, synced: true });
+
+      const listResult = await run(['hub', 'list', '-o', 'json']);
+      const listEnvelope = parseJson<{ hubs: { id: string }[]; activeId: string | null }>(listResult.stdout);
+      expect(listEnvelope.data.activeId).toBe('test-hub');
+      expect(listEnvelope.data.hubs.map((h) => h.id)).toContain('test-hub');
+    });
+
+    it('honors --no-use and --no-sync', async () => {
+      const result = await run([
+        'hub', 'add', '--type', 'local', '--location', hubConfigFile, '--id', 'test-hub',
+        '--no-use', '--no-sync', '-o', 'json'
+      ]);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ used: boolean; synced: boolean }>(result.stdout);
+      expect(envelope.data).toMatchObject({ used: false, synced: false });
+
+      const listResult = await run(['hub', 'list', '-o', 'json']);
+      const listEnvelope = parseJson<{ activeId: string | null }>(listResult.stdout);
+      expect(listEnvelope.data.activeId).toBeNull();
+    });
+
+    it('fails with exit 1 when --location is missing', async () => {
+      const result = await run(['hub', 'add', '--type', 'local', '-o', 'json']);
+      expect(result.exitCode).toBe(1);
+    });
+  });
+
+  describe('hub list --check', () => {
+    it('reports reachability per hub', async () => {
+      await run(['hub', 'add', '--type', 'local', '--location', hubConfigFile, '--id', 'test-hub', '-o', 'json']);
+
+      const result = await run(['hub', 'list', '--check', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ hubs: { id: string; check?: { status: string } }[] }>(result.stdout);
+      const hub = envelope.data.hubs.find((h) => h.id === 'test-hub');
+      expect(hub?.check?.status).toBe('ok');
+    });
+  });
+
+  describe('hub use', () => {
+    beforeEach(async () => {
+      await run([
+        'hub', 'add', '--type', 'local', '--location', hubConfigFile, '--id', 'test-hub', '--no-use', '-o', 'json'
+      ]);
+    });
+
+    it('sets the active hub', async () => {
+      const result = await run(['hub', 'use', 'test-hub', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ activeId: string }>(result.stdout);
+      expect(envelope.data.activeId).toBe('test-hub');
+    });
+
+    it('clears the active hub with --clear', async () => {
+      await run(['hub', 'use', 'test-hub', '-o', 'json']);
+      const result = await run(['hub', 'use', '--clear', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ activeId: null }>(result.stdout);
+      expect(envelope.data.activeId).toBeNull();
+    });
+
+    it('fails with exit 1 when neither an id nor --clear is given', async () => {
+      const result = await run(['hub', 'use', '-o', 'json']);
+      expect(result.exitCode).toBe(1);
+    });
+  });
+
+  describe('hub remove', () => {
+    beforeEach(async () => {
+      await run(['hub', 'add', '--type', 'local', '--location', hubConfigFile, '--id', 'test-hub', '-o', 'json']);
+    });
+
+    it('removes a hub', async () => {
+      const result = await run(['hub', 'remove', 'test-hub', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+
+      const listResult = await run(['hub', 'list', '-o', 'json']);
+      const listEnvelope = parseJson<{ hubs: { id: string }[] }>(listResult.stdout);
+      expect(listEnvelope.data.hubs.map((h) => h.id)).not.toContain('test-hub');
+    });
+
+    it('fails with exit 1 when no id is given', async () => {
+      const result = await run(['hub', 'remove', '-o', 'json']);
+      expect(result.exitCode).toBe(1);
+    });
+  });
+
+  describe('hub sync / hub refresh', () => {
+    beforeEach(async () => {
+      await run([
+        'hub', 'add', '--type', 'local', '--location', hubConfigFile, '--id', 'test-hub', '--no-sync', '-o', 'json'
+      ]);
+    });
+
+    it('hub sync <id> syncs the given hub', async () => {
+      const result = await run(['hub', 'sync', 'test-hub', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ id: string }>(result.stdout);
+      expect(envelope.data.id).toBe('test-hub');
+    });
+
+    it('hub sync (no id) syncs the active hub', async () => {
+      const result = await run(['hub', 'sync', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ id: string }>(result.stdout);
+      expect(envelope.data.id).toBe('test-hub');
+    });
+
+    it('hub sync (no id, no active hub) fails with exit 1', async () => {
+      await run(['hub', 'use', '--clear', '-o', 'json']);
+      const result = await run(['hub', 'sync', '-o', 'json']);
+      expect(result.exitCode).toBe(1);
+    });
+
+    it('hub refresh syncs the active hub', async () => {
+      const result = await run(['hub', 'refresh', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ id: string }>(result.stdout);
+      expect(envelope.data.id).toBe('test-hub');
+    });
+
+    it('hub refresh (no active hub) fails with exit 1', async () => {
+      await run(['hub', 'use', '--clear', '-o', 'json']);
+      const result = await run(['hub', 'refresh', '-o', 'json']);
+      expect(result.exitCode).toBe(1);
+    });
+  });
+});

--- a/packages/cli/test/commands/index.test.ts
+++ b/packages/cli/test/commands/index.test.ts
@@ -1,0 +1,304 @@
+/**
+ * `index *` command tests (build/stats/search/shortlist/export/eval/
+ * bench/report/harvest).
+ *
+ * Uses a real `NodeFileSystem` against a real temp directory (not
+ * `createTestContext`'s default in-memory `fs` stub, which rejects
+ * every call) since these commands read/write real index/shortlist/
+ * profile/report files. Fixture mirrors `doctor/diagnostics.ts`'s
+ * already-proven bundle fixture.
+ */
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  NodeFileSystem,
+} from '@ai-primitives-hub/infra';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  IndexBenchCommand,
+} from '../../src/commands/index-bench';
+import {
+  IndexBuildCommand,
+} from '../../src/commands/index-build';
+import {
+  IndexEvalCommand,
+} from '../../src/commands/index-eval';
+import {
+  IndexExportCommand,
+} from '../../src/commands/index-export';
+import {
+  IndexHarvestCommand,
+} from '../../src/commands/index-harvest';
+import {
+  IndexReportCommand,
+} from '../../src/commands/index-report';
+import {
+  IndexSearchCommand,
+} from '../../src/commands/index-search';
+import {
+  IndexShortlistAddCommand,
+  IndexShortlistListCommand,
+  IndexShortlistNewCommand,
+  IndexShortlistRemoveCommand,
+} from '../../src/commands/index-shortlist';
+import {
+  IndexStatsCommand,
+} from '../../src/commands/index-stats';
+import {
+  runCommand,
+} from '../../src/framework';
+
+const COMMAND_CLASSES = [
+  IndexBuildCommand,
+  IndexStatsCommand,
+  IndexSearchCommand,
+  IndexShortlistNewCommand,
+  IndexShortlistAddCommand,
+  IndexShortlistListCommand,
+  IndexShortlistRemoveCommand,
+  IndexExportCommand,
+  IndexEvalCommand,
+  IndexBenchCommand,
+  IndexReportCommand,
+  IndexHarvestCommand
+];
+
+interface JsonEnvelope<T> {
+  status: string;
+  data: T;
+}
+
+describe('index commands', () => {
+  let workspace: string;
+  let bundleDir: string;
+  let indexFile: string;
+
+  const run = (argv: string[]): ReturnType<typeof runCommand> => runCommand(argv, {
+    commandClasses: COMMAND_CLASSES,
+    context: {
+      cwd: workspace,
+      fs: new NodeFileSystem(),
+      env: {
+        HOME: workspace,
+        USERPROFILE: workspace,
+        XDG_CONFIG_HOME: path.join(workspace, 'xdg-config'),
+        XDG_CACHE_HOME: path.join(workspace, 'xdg-cache')
+      }
+    }
+  });
+
+  const parseJson = <T>(stdout: string): JsonEnvelope<T> => JSON.parse(stdout) as JsonEnvelope<T>;
+
+  beforeEach(async () => {
+    workspace = await mkdtemp(path.join(os.tmpdir(), 'cli-index-test-'));
+    bundleDir = path.join(workspace, 'bundle');
+    indexFile = path.join(workspace, 'primitive-index.json');
+
+    const localFooDir = path.join(bundleDir, 'local-foo');
+    await mkdir(path.join(localFooDir, 'prompts'), { recursive: true });
+    await writeFile(
+      path.join(localFooDir, 'deployment-manifest.yml'),
+      'id: local-foo\nversion: 1.0.0\nname: Local Foo\nitems:\n  - path: prompts/hello.prompt.md\n    kind: prompt\n'
+    );
+    await writeFile(path.join(localFooDir, 'prompts', 'hello.prompt.md'), '# Hello Prompt\n\nA diagnostic prompt.\n');
+
+    expect((await run([
+      'index', 'build', '--root', bundleDir, '--out', indexFile, '--source-id', 'local-foo-src', '-o', 'json'
+    ])).exitCode).toBe(0);
+  });
+
+  afterEach(async () => {
+    await rm(workspace, { recursive: true, force: true });
+  });
+
+  describe('index build', () => {
+    it('builds an index file with the expected stats', async () => {
+      const content = JSON.parse(await readFile(indexFile, 'utf8')) as unknown;
+      expect(content).toBeTruthy();
+    });
+
+    it('fails with exit 1 when --root is missing', async () => {
+      const result = await run(['index', 'build', '-o', 'json']);
+      expect(result.exitCode).toBe(1);
+    });
+  });
+
+  describe('index stats', () => {
+    it('reports primitives/bundles counts', async () => {
+      const result = await run(['index', 'stats', '--index', indexFile, '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ primitives: number; bundles: number }>(result.stdout);
+      expect(envelope.data.primitives).toBe(1);
+      expect(envelope.data.bundles).toBe(1);
+    });
+
+    it('fails with exit 1 for a missing index file', async () => {
+      const result = await run(['index', 'stats', '--index', path.join(workspace, 'no-such-index.json'), '-o', 'json']);
+      expect(result.exitCode).toBe(1);
+    });
+  });
+
+  describe('index search', () => {
+    it('finds the seeded prompt by query text', async () => {
+      const result = await run(['index', 'search', '--query', 'hello', '--index', indexFile, '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ hits: { primitive: { id: string } }[] }>(result.stdout);
+      expect(envelope.data.hits.length).toBeGreaterThan(0);
+    });
+
+    it('returns zero hits for a non-matching query', async () => {
+      const result = await run(['index', 'search', '--query', 'zzz-no-match-zzz', '--index', indexFile, '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ hits: unknown[] }>(result.stdout);
+      expect(envelope.data.hits).toEqual([]);
+    });
+  });
+
+  describe('index shortlist', () => {
+    it('supports the full new/add/list/remove lifecycle', async () => {
+      const newResult = await run(['index', 'shortlist', 'new', '--name', 'My List', '--index', indexFile, '-o', 'json']);
+      expect(newResult.exitCode).toBe(0);
+      const newEnvelope = parseJson<{ shortlist: { id: string } }>(newResult.stdout);
+      const shortlistId = newEnvelope.data.shortlist.id;
+
+      const searchResult = await run(['index', 'search', '--query', 'hello', '--index', indexFile, '-o', 'json']);
+      const searchEnvelope = parseJson<{ hits: { primitive: { id: string } }[] }>(searchResult.stdout);
+      const primitiveId = searchEnvelope.data.hits[0].primitive.id;
+
+      const addResult = await run([
+        'index', 'shortlist', 'add', '--id', shortlistId, '--primitive', primitiveId, '--index', indexFile, '-o', 'json'
+      ]);
+      expect(addResult.exitCode).toBe(0);
+
+      const listResult = await run(['index', 'shortlist', 'list', '--index', indexFile, '-o', 'json']);
+      expect(listResult.exitCode).toBe(0);
+      const listEnvelope = parseJson<{ shortlists: { id: string; primitiveIds: string[] }[] }>(listResult.stdout);
+      const sl = listEnvelope.data.shortlists.find((s) => s.id === shortlistId);
+      expect(sl?.primitiveIds).toContain(primitiveId);
+
+      const removeResult = await run([
+        'index', 'shortlist', 'remove', '--id', shortlistId, '--primitive', primitiveId, '--index', indexFile, '-o', 'json'
+      ]);
+      expect(removeResult.exitCode).toBe(0);
+      const removeEnvelope = parseJson<{ shortlist: { primitiveIds: string[] } }>(removeResult.stdout);
+      expect(removeEnvelope.data.shortlist.primitiveIds).not.toContain(primitiveId);
+    });
+
+    it('fails with exit 1 for an unknown shortlist id', async () => {
+      const result = await run([
+        'index', 'shortlist', 'add', '--id', 'does-not-exist', '--primitive', 'foo', '--index', indexFile, '-o', 'json'
+      ]);
+      expect(result.exitCode).toBe(1);
+    });
+  });
+
+  describe('index export', () => {
+    it('exports a shortlist as a profile YAML', async () => {
+      const newResult = await run(['index', 'shortlist', 'new', '--name', 'Export List', '--index', indexFile, '-o', 'json']);
+      const newEnvelope = parseJson<{ shortlist: { id: string } }>(newResult.stdout);
+      const shortlistId = newEnvelope.data.shortlist.id;
+
+      const exportDir = path.join(workspace, 'exports');
+      const result = await run([
+        'index', 'export', '--shortlist', shortlistId, '--profile-id', 'exported-profile',
+        '--out-dir', exportDir, '--index', indexFile, '-o', 'json'
+      ]);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ profileFile: string }>(result.stdout);
+      const content = await readFile(envelope.data.profileFile, 'utf8');
+      expect(content).toContain('exported-profile');
+    });
+
+    it('fails with exit 1 for an unknown shortlist', async () => {
+      const result = await run([
+        'index', 'export', '--shortlist', 'does-not-exist', '--profile-id', 'x', '--index', indexFile, '-o', 'json'
+      ]);
+      expect(result.exitCode).toBe(1);
+    });
+  });
+
+  describe('index eval', () => {
+    it('exits 0 when every gold case matches', async () => {
+      const goldFile = path.join(workspace, 'gold-pass.json');
+      await writeFile(goldFile, JSON.stringify({
+        cases: [{ id: 'case-1', query: { q: 'hello' }, mustMatch: [{ bundleId: 'local-foo' }] }]
+      }));
+      const result = await run(['index', 'eval', '--gold', goldFile, '--index', indexFile, '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ aggregate: { failed: number } }>(result.stdout);
+      expect(envelope.data.aggregate.failed).toBe(0);
+    });
+
+    it('exits 1 when a gold case fails to match', async () => {
+      const goldFile = path.join(workspace, 'gold-fail.json');
+      await writeFile(goldFile, JSON.stringify({
+        cases: [{ id: 'case-1', query: { q: 'hello' }, mustMatch: [{ bundleId: 'does-not-exist' }] }]
+      }));
+      const result = await run(['index', 'eval', '--gold', goldFile, '--index', indexFile, '-o', 'json']);
+      expect(result.exitCode).toBe(1);
+      const envelope = parseJson<{ aggregate: { failed: number } }>(result.stdout);
+      expect(envelope.data.aggregate.failed).toBeGreaterThan(0);
+    });
+
+    it('fails with exit 1 when --gold is missing', async () => {
+      const result = await run(['index', 'eval', '--index', indexFile, '-o', 'json']);
+      expect(result.exitCode).toBe(1);
+    });
+  });
+
+  describe('index bench', () => {
+    it('reports a benchmark summary', async () => {
+      const goldFile = path.join(workspace, 'gold-bench.json');
+      await writeFile(goldFile, JSON.stringify({
+        cases: [{ id: 'case-1', query: { q: 'hello' } }]
+      }));
+      const result = await run(['index', 'bench', '--gold', goldFile, '--index', indexFile, '--iterations', '5', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ perCase: unknown[] }>(result.stdout);
+      expect(envelope.data.perCase.length).toBe(1);
+    });
+  });
+
+  describe('index report', () => {
+    it('reports an empty summary for a not-yet-created progress file', async () => {
+      const progressFile = path.join(workspace, 'progress.jsonl');
+      const result = await run(['index', 'report', '--progress-file', progressFile, '--cache-dir', '', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ summary: { done: number; error: number; skip: number } }>(result.stdout);
+      expect(envelope.data.summary).toMatchObject({ done: 0, error: 0, skip: 0 });
+    });
+  });
+
+  describe('index harvest', () => {
+    it('fails with exit 1 when no hub ref is configured', async () => {
+      const result = await run(['index', 'harvest', '-o', 'json']);
+      expect(result.exitCode).toBe(1);
+    });
+
+    it('--no-hub-config with zero sources completes offline with zero totals', async () => {
+      const result = await run([
+        'index', 'harvest', '--no-hub-config',
+        '--out-file', path.join(workspace, 'harvest-index.json'),
+        '--progress-file', path.join(workspace, 'harvest-progress.jsonl'),
+        '--cache-dir', path.join(workspace, 'harvest-cache'),
+        '-o', 'json'
+      ]);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ totals: { done: number; error: number } }>(result.stdout);
+      expect(envelope.data.totals).toMatchObject({ done: 0, error: 0 });
+    });
+  });
+});

--- a/packages/cli/test/commands/install.test.ts
+++ b/packages/cli/test/commands/install.test.ts
@@ -1,0 +1,143 @@
+/**
+ * `install` command tests (local `--from` mode — no network required).
+ *
+ * Uses a real `NodeFileSystem` against a real temp directory (not
+ * `createTestContext`'s default in-memory `fs` stub, which rejects
+ * every call) since install does real file writes + lockfile IO.
+ */
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  NodeFileSystem,
+} from '@ai-primitives-hub/infra';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  InstallCommand,
+} from '../../src/commands/install';
+import {
+  TargetAddCommand,
+} from '../../src/commands/target-add';
+import {
+  runCommand,
+} from '../../src/framework';
+
+const COMMAND_CLASSES = [
+  TargetAddCommand,
+  InstallCommand
+];
+
+interface JsonEnvelope<T> {
+  status: string;
+  data: T;
+}
+
+describe('install command (local --from mode)', () => {
+  let workspace: string;
+  let bundleDir: string;
+  let targetDir: string;
+
+  const run = (argv: string[]): ReturnType<typeof runCommand> => runCommand(argv, {
+    commandClasses: COMMAND_CLASSES,
+    context: {
+      cwd: workspace,
+      fs: new NodeFileSystem(),
+      env: {
+        HOME: workspace,
+        USERPROFILE: workspace,
+        XDG_CONFIG_HOME: path.join(workspace, 'xdg-config'),
+        XDG_CACHE_HOME: path.join(workspace, 'xdg-cache')
+      }
+    }
+  });
+
+  const parseJson = <T>(stdout: string): JsonEnvelope<T> => JSON.parse(stdout) as JsonEnvelope<T>;
+
+  beforeEach(async () => {
+    workspace = await mkdtemp(path.join(os.tmpdir(), 'cli-install-test-'));
+    bundleDir = path.join(workspace, 'bundle');
+    targetDir = path.join(workspace, 'target');
+
+    await mkdir(path.join(bundleDir, 'prompts'), { recursive: true });
+    await mkdir(targetDir, { recursive: true });
+    await writeFile(
+      path.join(bundleDir, 'deployment-manifest.yml'),
+      'id: local-foo\nversion: 1.0.0\nname: Local Foo\nitems:\n  - path: prompts/hello.prompt.md\n    kind: prompt\n'
+    );
+    await writeFile(path.join(bundleDir, 'prompts', 'hello.prompt.md'), '# Hello Prompt\n');
+
+    expect((await run([
+      'target', 'add', 'copilot', '--type', 'copilot-cli', '--path', targetDir, '-o', 'json'
+    ])).exitCode).toBe(0);
+  });
+
+  afterEach(async () => {
+    await rm(workspace, { recursive: true, force: true });
+  });
+
+  it('installs a local bundle: writes files and records a lockfile entry', async () => {
+    const result = await run([
+      'install', 'local-foo', '--from', bundleDir, '--target', 'copilot', '-o', 'json'
+    ]);
+    expect(result.exitCode).toBe(0);
+    const envelope = parseJson<{
+      bundle: { id: string; version: string };
+      written: string[];
+      lockfile: string;
+    }>(result.stdout);
+    expect(envelope.data.bundle).toEqual({ id: 'local-foo', version: '1.0.0' });
+    expect(envelope.data.written.length).toBeGreaterThan(0);
+
+    const installed = await readFile(path.join(targetDir, 'prompts', 'hello.prompt.md'), 'utf8');
+    expect(installed).toContain('Hello Prompt');
+
+    const lockContent = await readFile(envelope.data.lockfile, 'utf8');
+    expect(lockContent).toContain('local-foo');
+  });
+
+  it('dry-run: reports the plan but writes nothing', async () => {
+    const result = await run([
+      'install', 'local-foo', '--from', bundleDir, '--target', 'copilot', '--dry-run', '-o', 'json'
+    ]);
+    expect(result.exitCode).toBe(0);
+    const envelope = parseJson<{ dryRun: boolean; bundle: { id: string } }>(result.stdout);
+    expect(envelope.data.dryRun).toBe(true);
+    expect(envelope.data.bundle.id).toBe('local-foo');
+
+    await expect(readFile(path.join(targetDir, 'prompts', 'hello.prompt.md'), 'utf8')).rejects.toThrow();
+  });
+
+  it('is idempotent: installing the same bundle twice still exits 0 with one lockfile entry', async () => {
+    await run(['install', 'local-foo', '--from', bundleDir, '--target', 'copilot', '-o', 'json']);
+    const result = await run(['install', 'local-foo', '--from', bundleDir, '--target', 'copilot', '-o', 'json']);
+    expect(result.exitCode).toBe(0);
+
+    const envelope = parseJson<{ lockfile: string }>(result.stdout);
+    const lockContent = JSON.parse(await readFile(envelope.data.lockfile, 'utf8')) as { bundles: Record<string, unknown> };
+    expect(Object.keys(lockContent.bundles)).toEqual(['local-foo']);
+  });
+
+  it('fails with exit 1 when neither <bundle>, --lockfile, --from, nor --source is given', async () => {
+    const result = await run(['install', '--target', 'copilot', '-o', 'json']);
+    expect(result.exitCode).toBe(1);
+  });
+
+  it('fails with exit 1 for an unknown --target', async () => {
+    const result = await run([
+      'install', 'local-foo', '--from', bundleDir, '--target', 'does-not-exist', '-o', 'json'
+    ]);
+    expect(result.exitCode).toBe(1);
+  });
+});

--- a/packages/cli/test/commands/misc.test.ts
+++ b/packages/cli/test/commands/misc.test.ts
@@ -1,0 +1,320 @@
+/**
+ * Tests for the command files that were missed from the original
+ * command-test-group breakdown: `apply`, `explain`, `config get`,
+ * `config list`, `plugins list`, `skill validate`.
+ *
+ * Uses a real `NodeFileSystem` against a real temp directory (not
+ * `createTestContext`'s default in-memory `fs` stub, which rejects
+ * every call) since several of these commands do real file IO.
+ */
+import {
+  mkdir,
+  mkdtemp,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  NodeFileSystem,
+} from '@ai-primitives-hub/infra';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  ApplyCommand,
+} from '../../src/commands/apply';
+import {
+  ConfigGetCommand,
+} from '../../src/commands/config-get';
+import {
+  ConfigListCommand,
+} from '../../src/commands/config-list';
+import {
+  ExplainCommand,
+} from '../../src/commands/explain';
+import {
+  HubAddCommand,
+  HubSyncCommand,
+  HubUseCommand,
+} from '../../src/commands/hub';
+import {
+  PluginsListCommand,
+} from '../../src/commands/plugins-list';
+import {
+  ProfileActivateCommand,
+} from '../../src/commands/profile';
+import {
+  SkillNewCommand,
+} from '../../src/commands/skill-new';
+import {
+  SkillValidateCommand,
+} from '../../src/commands/skill-validate';
+import {
+  TargetAddCommand,
+} from '../../src/commands/target-add';
+import {
+  runCommand,
+} from '../../src/framework';
+
+const COMMAND_CLASSES = [
+  TargetAddCommand,
+  HubAddCommand,
+  HubUseCommand,
+  HubSyncCommand,
+  ProfileActivateCommand,
+  ApplyCommand,
+  ExplainCommand,
+  ConfigGetCommand,
+  ConfigListCommand,
+  PluginsListCommand,
+  SkillNewCommand,
+  SkillValidateCommand
+];
+
+interface JsonEnvelope<T> {
+  status: string;
+  data: T;
+}
+
+describe('apply/explain/config/plugins-list/skill-validate commands', () => {
+  let workspace: string;
+
+  const run = (argv: string[], env: Record<string, string> = {}): ReturnType<typeof runCommand> => runCommand(argv, {
+    commandClasses: COMMAND_CLASSES,
+    context: {
+      cwd: workspace,
+      fs: new NodeFileSystem(),
+      env: {
+        HOME: workspace,
+        USERPROFILE: workspace,
+        XDG_CONFIG_HOME: path.join(workspace, 'xdg-config'),
+        XDG_CACHE_HOME: path.join(workspace, 'xdg-cache'),
+        ...env
+      }
+    }
+  });
+
+  const parseJson = <T>(stdout: string): JsonEnvelope<T> => JSON.parse(stdout) as JsonEnvelope<T>;
+
+  beforeEach(async () => {
+    workspace = await mkdtemp(path.join(os.tmpdir(), 'cli-misc-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(workspace, { recursive: true, force: true });
+  });
+
+  describe('apply', () => {
+    let bundleDir: string;
+    let targetDir: string;
+    let hubConfigFile: string;
+
+    beforeEach(async () => {
+      bundleDir = path.join(workspace, 'bundle');
+      targetDir = path.join(workspace, 'target');
+      hubConfigFile = path.join(workspace, 'hub-config.yml');
+
+      await mkdir(path.join(bundleDir, 'prompts'), { recursive: true });
+      await mkdir(targetDir, { recursive: true });
+      await writeFile(
+        path.join(bundleDir, 'deployment-manifest.yml'),
+        'id: local-foo\nversion: 1.0.0\nname: Local Foo\nitems:\n  - path: prompts/hello.prompt.md\n    kind: prompt\n'
+      );
+      await writeFile(path.join(bundleDir, 'prompts', 'hello.prompt.md'), '# Hello Prompt\n');
+      await writeFile(
+        hubConfigFile,
+        `version: 1.0.0
+metadata:
+  name: Test Hub
+  description: Test hub for apply
+  maintainer: test
+  updatedAt: '2026-01-01T00:00:00Z'
+sources:
+  - id: local-foo-src
+    name: Local Foo Source
+    type: local
+    url: ${bundleDir}
+    enabled: true
+    priority: 0
+    hubId: test-hub
+profiles:
+  - id: backend
+    name: Backend Developer
+    description: Test profile
+    bundles:
+      - id: local-foo
+        version: 1.0.0
+        source: local-foo-src
+        required: true
+`
+      );
+      expect((await run(['target', 'add', 'copilot', '--type', 'copilot-cli', '--path', targetDir, '-o', 'json'])).exitCode).toBe(0);
+      expect((await run(['hub', 'add', '--type', 'local', '--location', hubConfigFile, '--id', 'test-hub', '-o', 'json'])).exitCode).toBe(0);
+      expect((await run(['hub', 'use', 'test-hub', '-o', 'json'])).exitCode).toBe(0);
+      expect((await run(['hub', 'sync', 'test-hub', '-o', 'json'])).exitCode).toBe(0);
+    });
+
+    it('fails with exit 1 when no profile is active', async () => {
+      const result = await run(['apply', '-o', 'json']);
+      expect(result.exitCode).toBe(1);
+    });
+
+    it('re-syncs the hub and re-activates the currently active profile', async () => {
+      expect((await run(['profile', 'activate', 'backend', '--target', 'copilot', '-o', 'json'])).exitCode).toBe(0);
+
+      const result = await run(['apply', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ hubId: string; profileId: string; synced: boolean }>(result.stdout);
+      expect(envelope.data).toMatchObject({ hubId: 'test-hub', profileId: 'backend', synced: true });
+    });
+
+    it('--no-sync skips the hub sync step', async () => {
+      expect((await run(['profile', 'activate', 'backend', '--target', 'copilot', '-o', 'json'])).exitCode).toBe(0);
+
+      const result = await run(['apply', '--no-sync', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ synced: boolean }>(result.stdout);
+      expect(envelope.data.synced).toBe(false);
+    });
+  });
+
+  describe('explain', () => {
+    it('returns the documented catalog entry for a known code', async () => {
+      const result = await run(['explain', 'BUNDLE.NOT_FOUND', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ code: string; namespace: string; summary: string }>(result.stdout);
+      expect(envelope.data).toMatchObject({ code: 'BUNDLE.NOT_FOUND', namespace: 'BUNDLE' });
+      expect(envelope.data.summary.length).toBeGreaterThan(0);
+    });
+
+    it('returns a generic entry for a recognized namespace with no catalog entry yet', async () => {
+      const result = await run(['explain', 'HUB.ACCESS_DENIED', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ namespace: string; docsUrl: string | null }>(result.stdout);
+      expect(envelope.data.namespace).toBe('HUB');
+    });
+
+    it('fails with exit 1 for an unknown namespace', async () => {
+      const result = await run(['explain', 'BOGUS.CODE', '-o', 'json']);
+      expect(result.exitCode).toBe(1);
+    });
+
+    it('fails with a clipanion usage error (exit 64) when the code is omitted', async () => {
+      const result = await run(['explain', '-o', 'json']);
+      expect(result.exitCode).toBe(64);
+    });
+  });
+
+  describe('config get', () => {
+    it('reads a default value when no config file exists', async () => {
+      const result = await run(['config', 'get', 'output', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ key: string; value: unknown }>(result.stdout);
+      expect(envelope.data).toEqual({ key: 'output', value: 'text' });
+    });
+
+    it('project config overrides the default', async () => {
+      await writeFile(path.join(workspace, 'ai-primitives-hub.yml'), 'output: json\n');
+      const result = await run(['config', 'get', 'output', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ value: unknown }>(result.stdout);
+      expect(envelope.data.value).toBe('json');
+    });
+
+    it('an AI_PRIMITIVES_HUB_* env var overrides the project config', async () => {
+      const result = await run(['config', 'get', 'verbose', '-o', 'json'], { AI_PRIMITIVES_HUB_VERBOSE: 'true' });
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ value: unknown }>(result.stdout);
+      expect(envelope.data.value).toBe(true);
+    });
+
+    it('fails with a clipanion usage error (exit 64) when the key is omitted', async () => {
+      const result = await run(['config', 'get', '-o', 'json']);
+      expect(result.exitCode).toBe(64);
+    });
+  });
+
+  describe('config list', () => {
+    it('dumps the resolved config defaults as JSON', async () => {
+      const result = await run(['config', 'list', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ version: number; output: string }>(result.stdout);
+      expect(envelope.data).toMatchObject({ version: 1, output: 'text' });
+    });
+
+    it('renders a human-readable summary in text mode', async () => {
+      const result = await run(['config', 'list']);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('AI Primitives Hub Configuration');
+    });
+  });
+
+  describe('plugins list', () => {
+    it('reports no plugins when nothing on $PATH matches', async () => {
+      const emptyBinDir = path.join(workspace, 'empty-bin');
+      await mkdir(emptyBinDir, { recursive: true });
+      const result = await run(['plugins', 'list', '-o', 'json'], { PATH: emptyBinDir });
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<unknown[]>(result.stdout);
+      expect(envelope.data).toEqual([]);
+    });
+
+    it('discovers an ai-primitives-hub-<name> executable on $PATH', async () => {
+      const binDir = path.join(workspace, 'bin');
+      await mkdir(binDir, { recursive: true });
+      await writeFile(path.join(binDir, 'ai-primitives-hub-hello'), '#!/bin/sh\necho hi\n');
+      const result = await run(['plugins', 'list', '-o', 'json'], { PATH: binDir });
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ name: string }[]>(result.stdout);
+      expect(envelope.data.map((p) => p.name)).toContain('hello');
+    });
+
+    it('flags a shadowed plugin found in two PATH directories as a warning', async () => {
+      const binDir1 = path.join(workspace, 'bin1');
+      const binDir2 = path.join(workspace, 'bin2');
+      await mkdir(binDir1, { recursive: true });
+      await mkdir(binDir2, { recursive: true });
+      await writeFile(path.join(binDir1, 'ai-primitives-hub-hello'), '#!/bin/sh\necho hi\n');
+      await writeFile(path.join(binDir2, 'ai-primitives-hub-hello'), '#!/bin/sh\necho hi\n');
+      const result = await run(['plugins', 'list', '-o', 'json'], { PATH: `${binDir1}${path.delimiter}${binDir2}` });
+      expect(result.exitCode).toBe(0);
+      const envelope = JSON.parse(result.stdout) as { status: string; warnings: string[] };
+      expect(envelope.status).toBe('warning');
+      expect(envelope.warnings.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('skill validate', () => {
+    it('reports a fresh workspace with no skills/ dir as valid (nothing to check)', async () => {
+      const result = await run(['skill', 'validate', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ valid: boolean; totalSkills: number }>(result.stdout);
+      expect(envelope.data).toMatchObject({ valid: true, totalSkills: 0 });
+    });
+
+    it('validates a real skill created via `skill new` as valid', async () => {
+      expect((await run([
+        'skill', 'new', '--skill-name', 'my-skill', '--description', 'A valid test skill', '-o', 'json'
+      ])).exitCode).toBe(0);
+
+      const result = await run(['skill', 'validate', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ valid: boolean; validSkills: number; invalidSkills: number }>(result.stdout);
+      expect(envelope.data).toMatchObject({ valid: true, validSkills: 1, invalidSkills: 0 });
+    });
+
+    it('fails exit 1 for a skill folder missing SKILL.md', async () => {
+      await mkdir(path.join(workspace, 'skills', 'broken'), { recursive: true });
+      const result = await run(['skill', 'validate', '-o', 'json']);
+      expect(result.exitCode).toBe(1);
+      const envelope = parseJson<{ valid: boolean; skills: { valid: boolean; errors: string[] }[] }>(result.stdout);
+      expect(envelope.data.valid).toBe(false);
+      expect(envelope.data.skills[0].errors).toContain('Missing SKILL.md file');
+    });
+  });
+});

--- a/packages/cli/test/commands/profile.test.ts
+++ b/packages/cli/test/commands/profile.test.ts
@@ -1,0 +1,213 @@
+/**
+ * `profile activate`/`profile deactivate` end-to-end tests.
+ *
+ * Uses a real `NodeFileSystem` against a real temp directory (not
+ * `createTestContext`'s default in-memory `fs` stub, which rejects every
+ * call — see `framework/test-context.ts`'s module doc) because
+ * activate/deactivate exercise real file writes/removals across a hub
+ * config, a target directory, and the user-scope profile-activation
+ * store. Mirrors the fixture/command-sequence already proven correct by
+ * `doctor diagnostics`' steps 1-9 and 20-21.
+ */
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  NodeFileSystem,
+} from '@ai-primitives-hub/infra';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  HubAddCommand,
+  HubSyncCommand,
+  HubUseCommand,
+} from '../../src/commands/hub';
+import {
+  ProfileActivateCommand,
+  ProfileCurrentCommand,
+  ProfileDeactivateCommand,
+  ProfileListCommand,
+  ProfileShowCommand,
+} from '../../src/commands/profile';
+import {
+  TargetAddCommand,
+} from '../../src/commands/target-add';
+import {
+  runCommand,
+} from '../../src/framework';
+
+const COMMAND_CLASSES = [
+  TargetAddCommand,
+  HubAddCommand,
+  HubUseCommand,
+  HubSyncCommand,
+  ProfileListCommand,
+  ProfileShowCommand,
+  ProfileCurrentCommand,
+  ProfileActivateCommand,
+  ProfileDeactivateCommand
+];
+
+interface JsonEnvelope<T> {
+  status: string;
+  data: T;
+}
+
+describe('profile activate/deactivate', () => {
+  let workspace: string;
+  let bundleDir: string;
+  let targetDir: string;
+  let hubConfigFile: string;
+
+  const run = (argv: string[]): ReturnType<typeof runCommand> => runCommand(argv, {
+    commandClasses: COMMAND_CLASSES,
+    context: {
+      cwd: workspace,
+      fs: new NodeFileSystem(),
+      env: {
+        HOME: workspace,
+        USERPROFILE: workspace,
+        XDG_CONFIG_HOME: path.join(workspace, 'xdg-config'),
+        XDG_CACHE_HOME: path.join(workspace, 'xdg-cache')
+      }
+    }
+  });
+
+  const parseJson = <T>(stdout: string): JsonEnvelope<T> => JSON.parse(stdout) as JsonEnvelope<T>;
+
+  beforeEach(async () => {
+    workspace = await mkdtemp(path.join(os.tmpdir(), 'cli-profile-test-'));
+    bundleDir = path.join(workspace, 'bundle');
+    targetDir = path.join(workspace, 'target');
+    hubConfigFile = path.join(workspace, 'hub-config.yml');
+
+    await mkdir(path.join(bundleDir, 'prompts'), { recursive: true });
+    await mkdir(targetDir, { recursive: true });
+
+    await writeFile(
+      path.join(bundleDir, 'deployment-manifest.yml'),
+      'id: local-foo\nversion: 1.0.0\nname: Local Foo\nitems:\n  - path: prompts/hello.prompt.md\n    kind: prompt\n'
+    );
+    await writeFile(path.join(bundleDir, 'prompts', 'hello.prompt.md'), '# Hello Prompt\n');
+    await writeFile(
+      hubConfigFile,
+      `version: 1.0.0
+metadata:
+  name: Test Hub
+  description: Test hub for profile activate/deactivate
+  maintainer: test
+  updatedAt: '2026-01-01T00:00:00Z'
+sources:
+  - id: local-foo-src
+    name: Local Foo Source
+    type: local
+    url: ${bundleDir}
+    enabled: true
+    priority: 0
+    hubId: test-hub
+profiles:
+  - id: backend
+    name: Backend Developer
+    description: Test profile
+    bundles:
+      - id: local-foo
+        version: 1.0.0
+        source: local-foo-src
+        required: true
+`
+    );
+
+    expect((await run([
+      'target', 'add', 'copilot', '--type', 'copilot-cli', '--path', targetDir, '-o', 'json'
+    ])).exitCode).toBe(0);
+    expect((await run([
+      'hub', 'add', '--type', 'local', '--location', hubConfigFile, '--id', 'test-hub', '-o', 'json'
+    ])).exitCode).toBe(0);
+    expect((await run(['hub', 'use', 'test-hub', '-o', 'json'])).exitCode).toBe(0);
+    expect((await run(['hub', 'sync', 'test-hub', '-o', 'json'])).exitCode).toBe(0);
+  });
+
+  afterEach(async () => {
+    await rm(workspace, { recursive: true, force: true });
+  });
+
+  it('lists the seeded profile', async () => {
+    const result = await run(['profile', 'list', '-o', 'json']);
+    expect(result.exitCode).toBe(0);
+    const envelope = parseJson<{ profiles: { id: string; name: string }[] }>(result.stdout);
+    expect(envelope.data.profiles.map((p) => p.id)).toContain('backend');
+  });
+
+  it('shows profile details', async () => {
+    const result = await run(['profile', 'show', 'backend', '-o', 'json']);
+    expect(result.exitCode).toBe(0);
+    const envelope = parseJson<{ profile: { id: string; bundles: { id: string }[] } }>(result.stdout);
+    expect(envelope.data.profile.id).toBe('backend');
+    expect(envelope.data.profile.bundles.map((b) => b.id)).toContain('local-foo');
+  });
+
+  it('reports no active profile before activation', async () => {
+    const result = await run(['profile', 'current', '-o', 'json']);
+    expect(result.exitCode).toBe(0);
+    const envelope = parseJson<{ active: null }>(result.stdout);
+    expect(envelope.data.active).toBeNull();
+  });
+
+  it('activates a profile: installs bundle files to the target and records it as current', async () => {
+    const activateResult = await run(['profile', 'activate', 'backend', '--target', 'copilot', '-o', 'json']);
+    expect(activateResult.exitCode).toBe(0);
+    const activateEnvelope = parseJson<{ hubId: string; profileId: string }>(activateResult.stdout);
+    expect(activateEnvelope.data.profileId).toBe('backend');
+    expect(activateEnvelope.data.hubId).toBe('test-hub');
+
+    const installed = await readFile(path.join(targetDir, 'prompts', 'hello.prompt.md'), 'utf8');
+    expect(installed).toContain('Hello Prompt');
+
+    const currentResult = await run(['profile', 'current', '-o', 'json']);
+    expect(currentResult.exitCode).toBe(0);
+    const currentEnvelope = parseJson<{ active: { hubId: string; profileId: string } }>(currentResult.stdout);
+    expect(currentEnvelope.data.active).toEqual({ hubId: 'test-hub', profileId: 'backend' });
+  });
+
+  it('deactivates a profile: removes installed files and clears the active profile', async () => {
+    expect((await run(['profile', 'activate', 'backend', '--target', 'copilot', '-o', 'json'])).exitCode).toBe(0);
+
+    const deactivateResult = await run(['profile', 'deactivate', '-o', 'json']);
+    expect(deactivateResult.exitCode).toBe(0);
+    const deactivateEnvelope = parseJson<{ deactivated: { hubId: string; profileId: string } }>(deactivateResult.stdout);
+    expect(deactivateEnvelope.data.deactivated).toEqual({ hubId: 'test-hub', profileId: 'backend' });
+
+    await expect(readFile(path.join(targetDir, 'prompts', 'hello.prompt.md'), 'utf8')).rejects.toThrow();
+
+    const currentResult = await run(['profile', 'current', '-o', 'json']);
+    const currentEnvelope = parseJson<{ active: null }>(currentResult.stdout);
+    expect(currentEnvelope.data.active).toBeNull();
+  });
+
+  it('deactivating with no active profile is a no-op that succeeds', async () => {
+    const result = await run(['profile', 'deactivate', '-o', 'json']);
+    expect(result.exitCode).toBe(0);
+    const envelope = parseJson<{ deactivated: null }>(result.stdout);
+    expect(envelope.data.deactivated).toBeNull();
+  });
+
+  it('is idempotent across repeated activate/deactivate cycles: leaves no residue', async () => {
+    for (let i = 0; i < 2; i += 1) {
+      expect((await run(['profile', 'activate', 'backend', '--target', 'copilot', '-o', 'json'])).exitCode).toBe(0);
+      expect((await run(['profile', 'deactivate', '-o', 'json'])).exitCode).toBe(0);
+    }
+
+    await expect(readFile(path.join(targetDir, 'prompts', 'hello.prompt.md'), 'utf8')).rejects.toThrow();
+  });
+});

--- a/packages/cli/test/commands/scaffolding.test.ts
+++ b/packages/cli/test/commands/scaffolding.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Scaffolding generator command tests: `agent create`, `instruction
+ * create`, `prompt create`, `skill create`, `plugin create`, `hook
+ * create`.
+ *
+ * All six share an identical TemplateEngine-backed structure (see each
+ * command file's module doc), so the common behavior — create with
+ * description substitution, --collection integration, --collection
+ * pointing at a missing file, and the required <name> positional — is
+ * exercised once per command via a small data table instead of
+ * duplicating the same four tests six times. Each command's unique
+ * extra flag (skill's --author, plugin's --version, hook's --type) gets
+ * its own dedicated test afterward.
+ *
+ * Uses a real `NodeFileSystem` against a real temp directory (not
+ * `createTestContext`'s default in-memory `fs` stub, which rejects
+ * every call) since these commands do real file IO.
+ */
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  NodeFileSystem,
+} from '@ai-primitives-hub/infra';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  AgentCreateCommand,
+} from '../../src/commands/agent-create';
+import {
+  HookCreateCommand,
+} from '../../src/commands/hook-create';
+import {
+  InstructionCreateCommand,
+} from '../../src/commands/instruction-create';
+import {
+  PluginCreateCommand,
+} from '../../src/commands/plugin-create';
+import {
+  PromptCreateCommand,
+} from '../../src/commands/prompt-create';
+import {
+  SkillCreateCommand,
+} from '../../src/commands/skill-create';
+import {
+  runCommand,
+} from '../../src/framework';
+
+const COMMAND_CLASSES = [
+  AgentCreateCommand,
+  InstructionCreateCommand,
+  PromptCreateCommand,
+  SkillCreateCommand,
+  PluginCreateCommand,
+  HookCreateCommand
+];
+
+interface JsonEnvelope<T> {
+  status: string;
+  data: T;
+}
+
+interface ScaffoldData {
+  name: string;
+  path: string;
+  createdFiles: string[];
+  collection?: string;
+}
+
+interface ScaffoldSpec {
+  label: string;
+  createArgs: string[];
+  defaultDir: string;
+}
+
+const SPECS: ScaffoldSpec[] = [
+  { label: 'agent', createArgs: ['agent', 'create'], defaultDir: 'agents' },
+  { label: 'instruction', createArgs: ['instruction', 'create'], defaultDir: 'instructions' },
+  { label: 'prompt', createArgs: ['prompt', 'create'], defaultDir: 'prompts' },
+  { label: 'skill', createArgs: ['skill', 'create'], defaultDir: 'skills' },
+  { label: 'plugin', createArgs: ['plugin', 'create'], defaultDir: 'plugins' },
+  { label: 'hook', createArgs: ['hook', 'create'], defaultDir: 'hooks' }
+];
+
+describe('scaffolding generator commands', () => {
+  let workspace: string;
+
+  const run = (argv: string[]): ReturnType<typeof runCommand> => runCommand(argv, {
+    commandClasses: COMMAND_CLASSES,
+    context: { cwd: workspace, fs: new NodeFileSystem(), env: {} }
+  });
+
+  const parseJson = <T>(stdout: string): JsonEnvelope<T> => JSON.parse(stdout) as JsonEnvelope<T>;
+
+  beforeEach(async () => {
+    workspace = await mkdtemp(path.join(os.tmpdir(), 'cli-scaffold-test-'));
+    await mkdir(path.join(workspace, 'collections'), { recursive: true });
+    await writeFile(path.join(workspace, 'collections', 'foo.collection.yml'), 'id: foo\nname: Foo\nitems: []\n');
+  });
+
+  afterEach(async () => {
+    await rm(workspace, { recursive: true, force: true });
+  });
+
+  describe.each(SPECS)('$label create', (spec) => {
+    it('creates the file under the default directory with the description embedded', async () => {
+      const result = await run([...spec.createArgs, 'my-thing', '--description', 'A test description', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<ScaffoldData>(result.stdout);
+      expect(envelope.data.path.startsWith(path.join(workspace, spec.defaultDir))).toBe(true);
+      const content = await readFile(envelope.data.path, 'utf8');
+      expect(content).toContain('A test description');
+    });
+
+    it('honors --path to override the output directory', async () => {
+      const customDir = path.join(workspace, 'custom-out');
+      const result = await run([...spec.createArgs, 'my-thing', '--path', customDir, '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<ScaffoldData>(result.stdout);
+      expect(envelope.data.path.startsWith(customDir)).toBe(true);
+    });
+
+    it('adds an item to an existing collection when --collection is given', async () => {
+      const result = await run([...spec.createArgs, 'my-thing', '--collection', 'foo', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const collectionContent = await readFile(path.join(workspace, 'collections', 'foo.collection.yml'), 'utf8');
+      expect(collectionContent).toContain('my-thing');
+    });
+
+    it('fails with exit 1 when --collection points to a nonexistent collection', async () => {
+      const result = await run([...spec.createArgs, 'my-thing', '--collection', 'does-not-exist', '-o', 'json']);
+      expect(result.exitCode).toBe(1);
+    });
+
+    it('fails with a clipanion usage error (exit 64) when <name> is omitted', async () => {
+      const result = await run([...spec.createArgs, '-o', 'json']);
+      expect(result.exitCode).toBe(64);
+    });
+  });
+
+  describe('skill create --author', () => {
+    it('embeds the author in SKILL.md', async () => {
+      const result = await run(['skill', 'create', 'my-skill', '--author', 'Jane Doe', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<ScaffoldData>(result.stdout);
+      const content = await readFile(envelope.data.path, 'utf8');
+      expect(content).toContain('Jane Doe');
+    });
+  });
+
+  describe('plugin create --version', () => {
+    it('embeds the version in plugin.json', async () => {
+      const result = await run(['plugin', 'create', 'my-plugin', '--version', '2.3.4', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<ScaffoldData>(result.stdout);
+      const content = await readFile(envelope.data.path, 'utf8');
+      expect(content).toContain('2.3.4');
+    });
+  });
+
+  describe('hook create --type', () => {
+    it('embeds the type in hook.json', async () => {
+      const result = await run(['hook', 'create', 'my-hook', '--type', 'pre-commit', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<ScaffoldData>(result.stdout);
+      const content = await readFile(envelope.data.path, 'utf8');
+      expect(content).toContain('pre-commit');
+    });
+  });
+});

--- a/packages/cli/test/commands/source.test.ts
+++ b/packages/cli/test/commands/source.test.ts
@@ -1,0 +1,122 @@
+/**
+ * `source` command tests.
+ *
+ * Uses a real `NodeFileSystem` against a real temp directory (not
+ * `createTestContext`'s default in-memory `fs` stub, which rejects
+ * every call) since these commands do real file IO against the
+ * default-local hub's user-scope store.
+ */
+import {
+  mkdir,
+  mkdtemp,
+  rm,
+} from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  NodeFileSystem,
+} from '@ai-primitives-hub/infra';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  SourceAddCommand,
+  SourceListCommand,
+  SourceRemoveCommand,
+} from '../../src/commands/source';
+import {
+  runCommand,
+} from '../../src/framework';
+
+const COMMAND_CLASSES = [
+  SourceAddCommand,
+  SourceListCommand,
+  SourceRemoveCommand
+];
+
+interface JsonEnvelope<T> {
+  status: string;
+  data: T;
+}
+
+describe('source commands', () => {
+  let workspace: string;
+  let localDir: string;
+
+  const run = (argv: string[]): ReturnType<typeof runCommand> => runCommand(argv, {
+    commandClasses: COMMAND_CLASSES,
+    context: {
+      cwd: workspace,
+      fs: new NodeFileSystem(),
+      env: {
+        HOME: workspace,
+        USERPROFILE: workspace,
+        XDG_CONFIG_HOME: path.join(workspace, 'xdg-config'),
+        XDG_CACHE_HOME: path.join(workspace, 'xdg-cache')
+      }
+    }
+  });
+
+  const parseJson = <T>(stdout: string): JsonEnvelope<T> => JSON.parse(stdout) as JsonEnvelope<T>;
+
+  beforeEach(async () => {
+    workspace = await mkdtemp(path.join(os.tmpdir(), 'cli-source-test-'));
+    localDir = path.join(workspace, 'local-skills');
+    await mkdir(localDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(workspace, { recursive: true, force: true });
+  });
+
+  describe('source add', () => {
+    it('adds a detached source to the default-local hub', async () => {
+      const result = await run([
+        'source', 'add', '--type', 'local', '--url', localDir, '--id', 'local-skills', '-o', 'json'
+      ]);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ source: { id: string; type: string; url: string } }>(result.stdout);
+      expect(envelope.data.source).toMatchObject({ id: 'local-skills', type: 'local', url: localDir });
+
+      const listResult = await run(['source', 'list', '-o', 'json']);
+      const listEnvelope = parseJson<{ sources: { id: string }[] }>(listResult.stdout);
+      expect(listEnvelope.data.sources.map((s) => s.id)).toContain('local-skills');
+    });
+
+    it('fails with a non-zero exit code when --url is missing', async () => {
+      const result = await run(['source', 'add', '--type', 'local', '-o', 'json']);
+      expect(result.exitCode).not.toBe(0);
+    });
+  });
+
+  describe('source list', () => {
+    it('returns an empty list when no sources exist', async () => {
+      const result = await run(['source', 'list', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ sources: unknown[] }>(result.stdout);
+      expect(envelope.data.sources).toEqual([]);
+    });
+  });
+
+  describe('source remove', () => {
+    it('removes an existing detached source', async () => {
+      await run(['source', 'add', '--type', 'local', '--url', localDir, '--id', 'local-skills', '-o', 'json']);
+
+      const result = await run(['source', 'remove', 'local-skills', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+
+      const listResult = await run(['source', 'list', '-o', 'json']);
+      const listEnvelope = parseJson<{ sources: { id: string }[] }>(listResult.stdout);
+      expect(listEnvelope.data.sources.map((s) => s.id)).not.toContain('local-skills');
+    });
+
+    it('fails with a non-zero exit code when the source does not exist', async () => {
+      const result = await run(['source', 'remove', 'does-not-exist', '-o', 'json']);
+      expect(result.exitCode).not.toBe(0);
+    });
+  });
+});

--- a/packages/cli/test/commands/target.test.ts
+++ b/packages/cli/test/commands/target.test.ts
@@ -1,0 +1,183 @@
+/**
+ * `target add`/`target list`/`target remove`/`target types` command tests.
+ *
+ * Uses a real `NodeFileSystem` against a real temp directory (not
+ * `createTestContext`'s default in-memory `fs` stub, which rejects
+ * every call) since these commands read/write a real project config file.
+ */
+import {
+  mkdtemp,
+  rm,
+} from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  NodeFileSystem,
+} from '@ai-primitives-hub/infra';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  TargetAddCommand,
+} from '../../src/commands/target-add';
+import {
+  TargetListCommand,
+} from '../../src/commands/target-list';
+import {
+  TargetRemoveCommand,
+} from '../../src/commands/target-remove';
+import {
+  TargetTypesCommand,
+} from '../../src/commands/target-types';
+import {
+  runCommand,
+} from '../../src/framework';
+
+const COMMAND_CLASSES = [
+  TargetAddCommand,
+  TargetListCommand,
+  TargetRemoveCommand,
+  TargetTypesCommand
+];
+
+interface JsonEnvelope<T> {
+  status: string;
+  data: T;
+}
+
+describe('target commands', () => {
+  let workspace: string;
+
+  const run = (argv: string[]): ReturnType<typeof runCommand> => runCommand(argv, {
+    commandClasses: COMMAND_CLASSES,
+    context: {
+      cwd: workspace,
+      fs: new NodeFileSystem(),
+      env: {
+        HOME: workspace,
+        USERPROFILE: workspace,
+        XDG_CONFIG_HOME: path.join(workspace, 'xdg-config'),
+        XDG_CACHE_HOME: path.join(workspace, 'xdg-cache')
+      }
+    }
+  });
+
+  const parseJson = <T>(stdout: string): JsonEnvelope<T> => JSON.parse(stdout) as JsonEnvelope<T>;
+
+  beforeEach(async () => {
+    workspace = await mkdtemp(path.join(os.tmpdir(), 'cli-target-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(workspace, { recursive: true, force: true });
+  });
+
+  describe('target types', () => {
+    it('lists every supported type with a non-empty description', async () => {
+      const result = await run(['target', 'types', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ type: string; description: string }[]>(result.stdout);
+      const types = envelope.data.map((t) => t.type);
+      expect(types).toEqual(
+        expect.arrayContaining(['vscode', 'vscode-insiders', 'copilot-cli', 'kiro', 'windsurf', 'claude-code'])
+      );
+      for (const entry of envelope.data) {
+        expect(entry.description.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe('target add', () => {
+    it('registers a new target', async () => {
+      const result = await run(['target', 'add', 'my-vscode', '--type', 'vscode', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ target: { name: string; type: string; scope: string }; created: boolean }>(result.stdout);
+      expect(envelope.data.target).toMatchObject({ name: 'my-vscode', type: 'vscode', scope: 'user' });
+      expect(envelope.data.created).toBe(true);
+    });
+
+    it('force-scopes copilot-cli targets to user regardless of --scope', async () => {
+      const result = await run([
+        'target', 'add', 'my-copilot', '--type', 'copilot-cli', '--scope', 'repository', '-o', 'json'
+      ]);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ target: { scope: string } }>(result.stdout);
+      expect(envelope.data.target.scope).toBe('user');
+    });
+
+    it('honors --scope repository and --workspace-root for non-copilot-cli types', async () => {
+      const result = await run([
+        'target', 'add', 'ws-prompts', '--type', 'vscode', '--scope', 'repository',
+        '--workspace-root', workspace, '-o', 'json'
+      ]);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ target: { scope: string; rootPath?: string } }>(result.stdout);
+      expect(envelope.data.target.scope).toBe('repository');
+      expect(envelope.data.target.rootPath).toBe(workspace);
+    });
+
+    it('fails with exit 1 for an unknown --type', async () => {
+      const result = await run(['target', 'add', 'bad', '--type', 'not-a-real-type', '-o', 'json']);
+      expect(result.exitCode).toBe(1);
+    });
+
+    it('fails with exit 1 when adding a duplicate name', async () => {
+      await run(['target', 'add', 'dup', '--type', 'vscode', '-o', 'json']);
+      const result = await run(['target', 'add', 'dup', '--type', 'vscode', '-o', 'json']);
+      expect(result.exitCode).toBe(1);
+    });
+
+    it('fails with a clipanion usage error (exit 64) when <name> is omitted', async () => {
+      const result = await run(['target', 'add', '--type', 'vscode', '-o', 'json']);
+      expect(result.exitCode).toBe(64);
+    });
+  });
+
+  describe('target list', () => {
+    it('returns an empty list when no targets are configured', async () => {
+      const result = await run(['target', 'list', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<unknown[]>(result.stdout);
+      expect(envelope.data).toEqual([]);
+    });
+
+    it('lists every configured target', async () => {
+      await run(['target', 'add', 'a', '--type', 'vscode', '-o', 'json']);
+      await run(['target', 'add', 'b', '--type', 'copilot-cli', '-o', 'json']);
+
+      const result = await run(['target', 'list', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ name: string }[]>(result.stdout);
+      expect(envelope.data.map((t) => t.name).toSorted()).toEqual(['a', 'b']);
+    });
+  });
+
+  describe('target remove', () => {
+    beforeEach(async () => {
+      await run(['target', 'add', 'to-remove', '--type', 'vscode', '-o', 'json']);
+    });
+
+    it('removes a configured target', async () => {
+      const result = await run(['target', 'remove', 'to-remove', '-o', 'json']);
+      expect(result.exitCode).toBe(0);
+
+      const listResult = await run(['target', 'list', '-o', 'json']);
+      const listEnvelope = parseJson<{ name: string }[]>(listResult.stdout);
+      expect(listEnvelope.data.map((t) => t.name)).not.toContain('to-remove');
+    });
+
+    it('fails with exit 1 when the target does not exist', async () => {
+      const result = await run(['target', 'remove', 'does-not-exist', '-o', 'json']);
+      expect(result.exitCode).toBe(1);
+    });
+
+    it('fails with a clipanion usage error (exit 64) when <name> is omitted', async () => {
+      const result = await run(['target', 'remove', '-o', 'json']);
+      expect(result.exitCode).toBe(64);
+    });
+  });
+});

--- a/packages/cli/test/commands/uninstall.test.ts
+++ b/packages/cli/test/commands/uninstall.test.ts
@@ -1,0 +1,168 @@
+/**
+ * `uninstall` command tests (symmetric with install.test.ts's local
+ * `--from` mode — no network required).
+ *
+ * Uses a real `NodeFileSystem` against a real temp directory (not
+ * `createTestContext`'s default in-memory `fs` stub, which rejects
+ * every call) since uninstall does real file removals + lockfile IO.
+ */
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  NodeFileSystem,
+} from '@ai-primitives-hub/infra';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  InstallCommand,
+} from '../../src/commands/install';
+import {
+  TargetAddCommand,
+} from '../../src/commands/target-add';
+import {
+  UninstallCommand,
+} from '../../src/commands/uninstall';
+import {
+  runCommand,
+} from '../../src/framework';
+
+const COMMAND_CLASSES = [
+  TargetAddCommand,
+  InstallCommand,
+  UninstallCommand
+];
+
+interface JsonEnvelope<T> {
+  status: string;
+  data: T;
+}
+
+describe('uninstall command', () => {
+  let workspace: string;
+  let bundleDir: string;
+  let targetDir: string;
+  const installedFile = (): string => path.join(targetDir, 'prompts', 'hello.prompt.md');
+
+  const run = (argv: string[]): ReturnType<typeof runCommand> => runCommand(argv, {
+    commandClasses: COMMAND_CLASSES,
+    context: {
+      cwd: workspace,
+      fs: new NodeFileSystem(),
+      env: {
+        HOME: workspace,
+        USERPROFILE: workspace,
+        XDG_CONFIG_HOME: path.join(workspace, 'xdg-config'),
+        XDG_CACHE_HOME: path.join(workspace, 'xdg-cache')
+      }
+    }
+  });
+
+  const parseJson = <T>(stdout: string): JsonEnvelope<T> => JSON.parse(stdout) as JsonEnvelope<T>;
+
+  beforeEach(async () => {
+    workspace = await mkdtemp(path.join(os.tmpdir(), 'cli-uninstall-test-'));
+    bundleDir = path.join(workspace, 'bundle');
+    targetDir = path.join(workspace, 'target');
+
+    await mkdir(path.join(bundleDir, 'prompts'), { recursive: true });
+    await mkdir(targetDir, { recursive: true });
+    await writeFile(
+      path.join(bundleDir, 'deployment-manifest.yml'),
+      'id: local-foo\nversion: 1.0.0\nname: Local Foo\nitems:\n  - path: prompts/hello.prompt.md\n    kind: prompt\n'
+    );
+    await writeFile(path.join(bundleDir, 'prompts', 'hello.prompt.md'), '# Hello Prompt\n');
+
+    expect((await run([
+      'target', 'add', 'copilot', '--type', 'copilot-cli', '--path', targetDir, '-o', 'json'
+    ])).exitCode).toBe(0);
+    expect((await run([
+      'install', 'local-foo', '--from', bundleDir, '--target', 'copilot', '-o', 'json'
+    ])).exitCode).toBe(0);
+  });
+
+  afterEach(async () => {
+    await rm(workspace, { recursive: true, force: true });
+  });
+
+  it('uninstalls an installed bundle: removes files and clears the lockfile entry', async () => {
+    const result = await run(['uninstall', '--bundle', 'local-foo', '--target', 'copilot', '-o', 'json']);
+    expect(result.exitCode).toBe(0);
+    const envelope = parseJson<{ removed: string[]; lockfile: string }>(result.stdout);
+    expect(envelope.data.removed.length).toBeGreaterThan(0);
+
+    await expect(readFile(installedFile(), 'utf8')).rejects.toThrow();
+
+    const lockContent = JSON.parse(await readFile(envelope.data.lockfile, 'utf8')) as { bundles: Record<string, unknown> };
+    expect(lockContent.bundles).toEqual({});
+  });
+
+  it('is a warning no-op (exit 0) when the bundle is not installed', async () => {
+    await run(['uninstall', '--bundle', 'local-foo', '--target', 'copilot', '-o', 'json']);
+    const result = await run(['uninstall', '--bundle', 'local-foo', '--target', 'copilot', '-o', 'json']);
+    expect(result.exitCode).toBe(0);
+    const envelope = parseJson<{ reason: string }>(result.stdout);
+    expect(envelope.status).toBe('warning');
+    expect(envelope.data.reason).toBe('not found in lockfile');
+  });
+
+  it('dry-run: previews removal without deleting files', async () => {
+    const result = await run(['uninstall', '--bundle', 'local-foo', '--target', 'copilot', '--dry-run', '-o', 'json']);
+    expect(result.exitCode).toBe(0);
+    const envelope = parseJson<{ dryRun: boolean; files: string[] }>(result.stdout);
+    expect(envelope.data.dryRun).toBe(true);
+    expect(envelope.data.files.length).toBeGreaterThan(0);
+
+    const stillInstalled = await readFile(installedFile(), 'utf8');
+    expect(stillInstalled).toContain('Hello Prompt');
+  });
+
+  it('--all removes every installed bundle for the target', async () => {
+    const result = await run(['uninstall', '--all', '--target', 'copilot', '-o', 'json']);
+    expect(result.exitCode).toBe(0);
+    const envelope = parseJson<{ uninstalled: number }>(result.stdout);
+    expect(envelope.data.uninstalled).toBe(1);
+
+    await expect(readFile(installedFile(), 'utf8')).rejects.toThrow();
+  });
+
+  it('fails with exit 1 when neither --bundle, --lockfile, nor --all is given (and no lockfile is discoverable)', async () => {
+    const freshWorkspace = await mkdtemp(path.join(os.tmpdir(), 'cli-uninstall-test-fresh-'));
+    try {
+      const freshTargetDir = path.join(freshWorkspace, 'target');
+      await mkdir(freshTargetDir, { recursive: true });
+      const freshRun = (argv: string[]): ReturnType<typeof runCommand> => runCommand(argv, {
+        commandClasses: COMMAND_CLASSES,
+        context: {
+          cwd: freshWorkspace,
+          fs: new NodeFileSystem(),
+          env: {
+            HOME: freshWorkspace,
+            USERPROFILE: freshWorkspace,
+            XDG_CONFIG_HOME: path.join(freshWorkspace, 'xdg-config'),
+            XDG_CACHE_HOME: path.join(freshWorkspace, 'xdg-cache')
+          }
+        }
+      });
+      expect((await freshRun([
+        'target', 'add', 'copilot', '--type', 'copilot-cli', '--path', freshTargetDir, '-o', 'json'
+      ])).exitCode).toBe(0);
+
+      const result = await freshRun(['uninstall', '--target', 'copilot', '-o', 'json']);
+      expect(result.exitCode).toBe(1);
+    } finally {
+      await rm(freshWorkspace, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cli/test/framework/cli.test.ts
+++ b/packages/cli/test/framework/cli.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Tests for `framework/cli.ts`.
+ *
+ * `runCli` is the clipanion wrapper: it should dispatch argv, inject the
+ * Context into command classes, handle --help/--version, return the right
+ * exit codes for usage vs internal errors, and apply `defaultOutput`.
+ */
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  Command,
+  type Context,
+  createTestContext,
+  defineCommand,
+  Option,
+  runCli,
+} from '../../src/framework';
+
+class EchoCommand extends Command {
+  public static readonly paths = [['echo']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Echo a value',
+    category: 'Test'
+  });
+
+  public message = Option.String();
+  public commandContext!: { ctx: Context };
+
+  public execute(): Promise<number | void> {
+    const { ctx } = this.commandContext;
+    ctx.stdout.write(`echo:${this.message}`);
+    return Promise.resolve(0);
+  }
+}
+
+class FailCommand extends Command {
+  public static readonly paths = [['fail']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Fail with a command-specific exit code',
+    category: 'Test'
+  });
+
+  public code = Option.String('-c,--code');
+  public commandContext!: { ctx: Context };
+
+  public execute(): Promise<number | void> {
+    return Promise.resolve(Number(this.code ?? 1));
+  }
+}
+
+class BoomCommand extends Command {
+  public static readonly paths = [['boom']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Throw an error',
+    category: 'Test'
+  });
+
+  public commandContext!: { ctx: Context };
+
+  public execute(): Promise<number | void> {
+    throw new Error('boom');
+  }
+}
+
+class OutputCommand extends Command {
+  public static readonly paths = [['out']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Use default output',
+    category: 'Test'
+  });
+
+  public output = Option.String('-o,--output');
+  public commandContext!: { ctx: Context };
+
+  public execute(): Promise<number | void> {
+    const { ctx } = this.commandContext;
+    ctx.stdout.write(`out=${this.output}`);
+    return Promise.resolve(0);
+  }
+}
+
+describe('defineCommand', () => {
+  it('freezes and returns the command definition', () => {
+    const def = defineCommand({
+      path: ['ping'],
+      description: 'ping',
+      run: ({ ctx }): number => {
+        ctx.stdout.write('pong');
+        return 0;
+      }
+    });
+    expect(Object.isFrozen(def)).toBe(true);
+    expect(def.path).toEqual(['ping']);
+  });
+});
+
+describe('runCli', () => {
+  it('runs a native command class and returns its exit code', async () => {
+    const ctx = createTestContext();
+    const exitCode = await runCli(['echo', 'hello'], {
+      ctx,
+      name: 'test-cli',
+      version: '0.0.0-test',
+      commands: [],
+      commandClasses: [EchoCommand]
+    });
+    expect(exitCode).toBe(0);
+    expect(ctx.stdout.captured()).toBe('echo:hello');
+  });
+
+  it('runs a declarative command definition', async () => {
+    const ctx = createTestContext();
+    const exitCode = await runCli(['ping'], {
+      ctx,
+      name: 'test-cli',
+      version: '0.0.0-test',
+      commands: [defineCommand({
+        path: ['ping'],
+        description: 'ping',
+        run: ({ ctx: cmdCtx }: { ctx: Context }): number => {
+          cmdCtx.stdout.write('pong');
+          return 0;
+        }
+      })]
+    });
+    expect(exitCode).toBe(0);
+    expect(ctx.stdout.captured()).toBe('pong');
+  });
+
+  it('returns 0 for bare invocation and renders global help', async () => {
+    const ctx = createTestContext();
+    const exitCode = await runCli([], {
+      ctx,
+      name: 'test-cli',
+      version: '0.0.0-test',
+      commands: [],
+      commandClasses: [EchoCommand]
+    });
+    expect(exitCode).toBe(0);
+    expect(ctx.stdout.captured()).toContain('Quick Start');
+  });
+
+  it('returns 0 for --help and renders global help', async () => {
+    const ctx = createTestContext();
+    const exitCode = await runCli(['--help'], {
+      ctx,
+      name: 'test-cli',
+      version: '0.0.0-test',
+      commands: [],
+      commandClasses: [EchoCommand]
+    });
+    expect(exitCode).toBe(0);
+    expect(ctx.stdout.captured()).toContain('Quick Start');
+  });
+
+  it('returns 0 for --version and prints the binary version', async () => {
+    const ctx = createTestContext();
+    const exitCode = await runCli(['--version'], {
+      ctx,
+      name: 'test-cli',
+      version: '1.2.3',
+      commands: [],
+      commandClasses: [EchoCommand]
+    });
+    expect(exitCode).toBe(0);
+    expect(ctx.stdout.captured()).toContain('test-cli 1.2.3');
+  });
+
+  it('returns 64 for an unknown command and prints a suggestion', async () => {
+    const ctx = createTestContext();
+    const exitCode = await runCli(['echoo', 'hello'], {
+      ctx,
+      name: 'test-cli',
+      version: '0.0.0-test',
+      commands: [],
+      commandClasses: [EchoCommand]
+    });
+    expect(exitCode).toBe(64);
+    expect(ctx.stderr.captured()).toContain('echoo');
+    expect(ctx.stderr.captured()).toContain('Did you mean');
+  });
+
+  it('returns 64 for a missing required positional argument', async () => {
+    const ctx = createTestContext();
+    const exitCode = await runCli(['echo'], {
+      ctx,
+      name: 'test-cli',
+      version: '0.0.0-test',
+      commands: [],
+      commandClasses: [EchoCommand]
+    });
+    expect(exitCode).toBe(64);
+    expect(ctx.stderr.captured().length).toBeGreaterThan(0);
+  });
+
+  it('returns the command-declared exit code', async () => {
+    const ctx = createTestContext();
+    const exitCode = await runCli(['fail', '--code', '42'], {
+      ctx,
+      name: 'test-cli',
+      version: '0.0.0-test',
+      commands: [],
+      commandClasses: [FailCommand]
+    });
+    expect(exitCode).toBe(42);
+  });
+
+  it('returns 70 when a command throws a non-UsageError', async () => {
+    const ctx = createTestContext();
+    const exitCode = await runCli(['boom'], {
+      ctx,
+      name: 'test-cli',
+      version: '0.0.0-test',
+      commands: [],
+      commandClasses: [BoomCommand]
+    });
+    expect(exitCode).toBe(70);
+    expect(ctx.stderr.captured()).toContain('boom');
+  });
+
+  it('returns 0 and prints per-command help for `command -h`', async () => {
+    const ctx = createTestContext();
+    const exitCode = await runCli(['echo', '-h'], {
+      ctx,
+      name: 'test-cli',
+      version: '0.0.0-test',
+      commands: [],
+      commandClasses: [EchoCommand]
+    });
+    expect(exitCode).toBe(0);
+    expect(ctx.stdout.captured()).toContain('Echo a value');
+  });
+
+  it('applies defaultOutput when no explicit output flag is passed', async () => {
+    const ctx = createTestContext();
+    const exitCode = await runCli(['out'], {
+      ctx,
+      name: 'test-cli',
+      version: '0.0.0-test',
+      commands: [],
+      commandClasses: [OutputCommand],
+      defaultOutput: 'json'
+    });
+    expect(exitCode).toBe(0);
+    expect(ctx.stdout.captured()).toBe('out=json');
+  });
+});

--- a/packages/cli/test/framework/command-class.test.ts
+++ b/packages/cli/test/framework/command-class.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Tests for `framework/command-class.ts`.
+ *
+ * `copyCommandPrototype` copies prototype property descriptors from a base
+ * command class to a dynamically-created subclass so clipanion can discover
+ * inherited options and static metadata.
+ */
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  copyCommandPrototype,
+} from '../../src/framework';
+
+describe('copyCommandPrototype', () => {
+  it('copies prototype descriptors from the base class to the subclass', () => {
+    class BaseCommand {
+      public static paths = [['base']];
+
+      public static usage = { description: 'Base command' };
+
+      public greet = 'hello';
+    }
+
+    class SubCommand {}
+
+    copyCommandPrototype(BaseCommand, SubCommand);
+
+    expect((SubCommand.prototype as unknown as { greet: string }).greet).toBe('hello');
+
+    expect((SubCommand as unknown as { paths: string[][] }).paths).toEqual([['base']]);
+
+    expect((SubCommand as unknown as { usage: { description: string } }).usage).toEqual({ description: 'Base command' });
+  });
+
+  it('does not copy the constructor', () => {
+    class BaseCommand {
+      public static usage = {};
+    }
+
+    class SubCommand {
+      public prop = 1;
+    }
+
+    copyCommandPrototype(BaseCommand, SubCommand);
+
+    expect(new SubCommand().prop).toBe(1);
+  });
+});

--- a/packages/cli/test/framework/config.test.ts
+++ b/packages/cli/test/framework/config.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Tests for `framework/config.ts`.
+ *
+ * `loadConfig` implements the layered precedence chain (defaults, user
+ * config, project config, env vars, explicit --config file). These tests
+ * use a hand-rolled in-memory `ConfigFs` so the loader is exercised in
+ * isolation without touching real disk.
+ */
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  loadConfig,
+  resolveProjectConfigPath,
+} from '../../src/framework';
+
+interface Inode {
+  [path: string]: string;
+}
+
+const makeFs = (files: Inode) => {
+  const map = new Map<string, string>(Object.entries(files));
+  return {
+    readFile: (p: string): Promise<string> => {
+      const content = map.get(p);
+      if (content === undefined) {
+        return Promise.reject(new Error(`ENOENT: ${p}`));
+      }
+      return Promise.resolve(content);
+    },
+    exists: (p: string): Promise<boolean> => Promise.resolve(map.has(p))
+  };
+};
+
+describe('loadConfig', () => {
+  it('returns built-in defaults when no config files exist', async () => {
+    const config = await loadConfig({
+      cwd: '/workspace',
+      env: {},
+      fs: makeFs({})
+    });
+    expect(config).toEqual({
+      version: 1,
+      output: 'text',
+      verbose: false,
+      quiet: false
+    });
+  });
+
+  it('loads a project config from cwd', async () => {
+    const config = await loadConfig({
+      cwd: '/workspace',
+      env: {},
+      fs: makeFs({
+        '/workspace/ai-primitives-hub.yml': 'output: json\nfoo: bar\n'
+      })
+    });
+    expect(config).toMatchObject({
+      version: 1,
+      output: 'json',
+      foo: 'bar'
+    });
+  });
+
+  it('walks upward Cargo-style to find a project config', async () => {
+    const config = await loadConfig({
+      cwd: '/workspace/packages/cli',
+      env: {},
+      fs: makeFs({
+        '/workspace/ai-primitives-hub.yml': 'output: yaml\n'
+      })
+    });
+    expect(config.output).toBe('yaml');
+  });
+
+  it('prefers the .yaml filename over .yml when both are present', async () => {
+    const config = await loadConfig({
+      cwd: '/workspace',
+      env: {},
+      fs: makeFs({
+        '/workspace/ai-primitives-hub.yml': 'output: yml\n',
+        '/workspace/ai-primitives-hub.yaml': 'output: yaml\n'
+      })
+    });
+    expect(config.output).toBe('yaml');
+  });
+
+  it('loads a user config from XDG_CONFIG_HOME', async () => {
+    const config = await loadConfig({
+      cwd: '/workspace',
+      env: { XDG_CONFIG_HOME: '/home/user/.config' },
+      fs: makeFs({
+        '/home/user/.config/ai-primitives-hub/config.yml': 'output: json\nverbose: true\n'
+      })
+    });
+    expect(config.output).toBe('json');
+    expect(config.verbose).toBe(true);
+  });
+
+  it('project config overrides user config', async () => {
+    const config = await loadConfig({
+      cwd: '/workspace',
+      env: { XDG_CONFIG_HOME: '/home/user/.config' },
+      fs: makeFs({
+        '/home/user/.config/ai-primitives-hub/config.yml': 'output: json\n',
+        '/workspace/ai-primitives-hub.yml': 'output: yaml\n'
+      })
+    });
+    expect(config.output).toBe('yaml');
+  });
+
+  it('env vars override project config and coerce booleans/numbers', async () => {
+    const config = await loadConfig({
+      cwd: '/workspace',
+      env: {
+        XDG_CONFIG_HOME: '/home/user/.config',
+        AI_PRIMITIVES_HUB_OUTPUT: 'ndjson',
+        AI_PRIMITIVES_HUB_VERBOSE: 'true',
+        AI_PRIMITIVES_HUB_INDEX__TTL: '120'
+      },
+      fs: makeFs({
+        '/home/user/.config/ai-primitives-hub/config.yml': 'output: json\nverbose: false\n'
+      })
+    });
+    expect(config.output).toBe('ndjson');
+    expect(config.verbose).toBe(true);
+    expect(config.index).toEqual({ ttl: 120 });
+  });
+
+  it('camelCases single-underscore env keys and treats double underscores as nested paths', async () => {
+    const config = await loadConfig({
+      cwd: '/workspace',
+      env: {
+        AI_PRIMITIVES_HUB_CACHE_PATH: '/tmp',
+        AI_PRIMITIVES_HUB_HUB__TIMEOUT: '30'
+      },
+      fs: makeFs({})
+    });
+    expect(config.cachePath).toBe('/tmp');
+    expect(config.hub).toEqual({ timeout: 30 });
+  });
+
+  it('explicit --config file overrides all earlier layers', async () => {
+    const config = await loadConfig({
+      cwd: '/workspace',
+      env: { AI_PRIMITIVES_HUB_OUTPUT: 'ndjson' },
+      configFile: '/workspace/override.yml',
+      fs: makeFs({
+        '/workspace/ai-primitives-hub.yml': 'output: json\n',
+        '/workspace/override.yml': 'output: text\nquiet: true\n'
+      })
+    });
+    expect(config.output).toBe('text');
+    expect(config.quiet).toBe(true);
+  });
+
+  it('throws when an explicit --config file does not exist', async () => {
+    await expect(loadConfig({
+      cwd: '/workspace',
+      env: {},
+      configFile: '/workspace/missing.yml',
+      fs: makeFs({})
+    })).rejects.toThrow('Config file not found');
+  });
+
+  it('deep-merges nested objects instead of replacing them', async () => {
+    const config = await loadConfig({
+      cwd: '/workspace',
+      env: {},
+      fs: makeFs({
+        '/workspace/ai-primitives-hub.yml': 'github:\n  token: abc\n  timeout: 5\n'
+      })
+    });
+    expect(config.github).toEqual({ token: 'abc', timeout: 5 });
+  });
+
+  it('later nested layers override leaves while preserving siblings', async () => {
+    const config = await loadConfig({
+      cwd: '/workspace',
+      env: { AI_PRIMITIVES_HUB_GITHUB__TIMEOUT: '10' },
+      fs: makeFs({
+        '/workspace/ai-primitives-hub.yml': 'github:\n  token: abc\n  timeout: 5\n'
+      })
+    });
+    expect(config.github).toEqual({ token: 'abc', timeout: 10 });
+  });
+});
+
+describe('resolveProjectConfigPath', () => {
+  it('returns undefined when no project config exists', async () => {
+    const result = await resolveProjectConfigPath({
+      cwd: '/workspace',
+      env: {},
+      fs: makeFs({})
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it('returns the absolute path to the first found config file', async () => {
+    const result = await resolveProjectConfigPath({
+      cwd: '/workspace',
+      env: {},
+      fs: makeFs({
+        '/workspace/ai-primitives-hub.yml': 'output: json\n'
+      })
+    });
+    expect(result).toBe('/workspace/ai-primitives-hub.yml');
+  });
+});

--- a/packages/cli/test/framework/error.test.ts
+++ b/packages/cli/test/framework/error.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Tests for `framework/error.ts`.
+ *
+ * These helpers format and route RegistryError values through the Context
+ * streams and encapsulate common target/hub resolution logic.
+ */
+import {
+  mkdir,
+  mkdtemp,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  NodeFileSystem,
+} from '@ai-primitives-hub/infra';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  createTestContext,
+  failWith,
+  generateTargetHint,
+  getCommandContext,
+  RegistryError,
+  renderError,
+  requireActiveHub,
+  requireActiveHubOrFail,
+  resolveTarget,
+  resolveTargetName,
+  throwTargetNotFoundError,
+  validateInputs,
+} from '../../src/framework';
+
+describe('renderError', () => {
+  it('writes a RegistryError to stderr with code, message, hint, and docs', () => {
+    const ctx = createTestContext();
+    const err = new RegistryError({
+      code: 'USAGE.MISSING_FLAG',
+      message: 'missing flag',
+      hint: 'pass --target',
+      docsUrl: 'https://example.com'
+    });
+    renderError(err, ctx);
+    expect(ctx.stderr.captured()).toContain('error[USAGE.MISSING_FLAG]: missing flag');
+    expect(ctx.stderr.captured()).toContain('pass --target');
+    expect(ctx.stderr.captured()).toContain('https://example.com');
+  });
+
+  it('wraps non-RegistryError values as INTERNAL.UNEXPECTED', () => {
+    const ctx = createTestContext();
+    renderError('raw string', ctx);
+    expect(ctx.stderr.captured()).toContain('error[INTERNAL.UNEXPECTED]: raw string');
+  });
+});
+
+describe('failWith', () => {
+  it('returns 1 and renders to stderr in text mode', () => {
+    const ctx = createTestContext();
+    const err = new RegistryError({
+      code: 'BUNDLE.NOT_FOUND',
+      message: 'not found'
+    });
+    const code = failWith(ctx, 'text', 'install', err);
+    expect(code).toBe(1);
+    expect(ctx.stderr.captured()).toContain('BUNDLE.NOT_FOUND');
+  });
+
+  it('returns 1 and emits a structured JSON error envelope', () => {
+    const ctx = createTestContext();
+    const err = new RegistryError({
+      code: 'BUNDLE.NOT_FOUND',
+      message: 'not found'
+    });
+    const code = failWith(ctx, 'json', 'install', err);
+    expect(code).toBe(1);
+    const envelope = JSON.parse(ctx.stdout.captured()) as { status: string; errors: unknown[] };
+    expect(envelope.status).toBe('error');
+    expect(envelope.errors).toHaveLength(1);
+  });
+});
+
+describe('generateTargetHint', () => {
+  it('lists multiple configured targets', () => {
+    const hint = generateTargetHint([{ name: 'copilot' }, { name: 'kiro' }]);
+    expect(hint).toContain('copilot, kiro');
+    expect(hint).toContain('--target');
+  });
+
+  it('prompts to add a target when none exist', () => {
+    const hint = generateTargetHint([]);
+    expect(hint).toContain('target add');
+  });
+});
+
+describe('throwTargetNotFoundError', () => {
+  it('throws a USAGE.MISSING_FLAG RegistryError', () => {
+    expect(() => throwTargetNotFoundError('install', 'missing', [])).toThrow(RegistryError);
+  });
+});
+
+describe('resolveTargetName', () => {
+  let workspace: string;
+
+  beforeEach(async () => {
+    workspace = await mkdtemp(path.join(os.tmpdir(), 'cli-error-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(workspace, { recursive: true, force: true });
+  });
+
+  it('returns the provided target name when present', async () => {
+    const result = await resolveTargetName('copilot', 'install', createTestContext(), () => Promise.resolve([]));
+    expect(result).toBe('copilot');
+  });
+
+  it('falls back to the last used target from the project state file', async () => {
+    const stateDir = path.join(workspace, '.ai-primitives-hub');
+    await mkdir(stateDir, { recursive: true });
+    await writeFile(
+      path.join(stateDir, 'target-state.json'),
+      JSON.stringify({
+        targets: {
+          copilot: { targetName: 'copilot', lastInstalledBundles: [], lastUsedAt: '2026-01-01T00:00:00Z' }
+        }
+      })
+    );
+    const ctx = createTestContext({ fs: new NodeFileSystem(), cwd: workspace });
+    const result = await resolveTargetName(undefined, 'install', ctx, () => Promise.resolve([]));
+    expect(result).toBe('copilot');
+  });
+
+  it('throws USAGE.MISSING_FLAG when no target and no last used target exists', async () => {
+    const ctx = createTestContext({ fs: new NodeFileSystem(), cwd: workspace });
+    await expect(resolveTargetName(undefined, 'install', ctx, () => Promise.resolve([]))).rejects.toThrow(RegistryError);
+  });
+});
+
+describe('resolveTarget', () => {
+  it('returns the matching target', async () => {
+    const target = { name: 'copilot', type: 'copilot-cli' as const };
+    const result = await resolveTarget('copilot', 'install', createTestContext(), () => Promise.resolve([target]));
+    expect(result).toEqual(target);
+  });
+
+  it('throws when the target is not configured', async () => {
+    await expect(resolveTarget('missing', 'install', createTestContext(), () => Promise.resolve([]))).rejects.toThrow(RegistryError);
+  });
+});
+
+describe('validateInputs', () => {
+  it('flags missing string and boolean flags', () => {
+    const result = validateInputs({ target: '', source: 'foo', interactive: true, verbose: false }, {
+      flags: ['target', 'source', 'interactive', 'verbose']
+    });
+    expect(result.target).toBe(true);
+    expect(result.source).toBe(false);
+    expect(result.interactive).toBe(false);
+    expect(result.verbose).toBe(true);
+  });
+
+  it('flags missing flags of any type', () => {
+    const result = validateInputs({ name: undefined }, { flags: ['name'] });
+    expect(result.name).toBe(true);
+  });
+});
+
+describe('getCommandContext', () => {
+  it('returns the context from a command instance', () => {
+    const ctx = createTestContext();
+    const cmd = { commandContext: { ctx } };
+    expect(getCommandContext(cmd)).toBe(ctx);
+  });
+
+  it('throws when no context is available', () => {
+    expect(() => getCommandContext({})).toThrow('CommandContext not available');
+  });
+});
+
+describe('requireActiveHub', () => {
+  it('returns the active hub when the id matches', async () => {
+    const mgr = { getActiveHub: () => Promise.resolve({ id: 'hub-1', config: { url: 'x' } }) };
+    const result = await requireActiveHub(mgr, 'hub-1', 'sync');
+    expect(result.id).toBe('hub-1');
+  });
+
+  it('throws HUB.NOT_FOUND when no hub is active', async () => {
+    const mgr = { getActiveHub: () => Promise.resolve(null) };
+    await expect(requireActiveHub(mgr, 'hub-1', 'sync')).rejects.toThrow(RegistryError);
+  });
+
+  it('throws HUB.NOT_FOUND when the requested hub is not active', async () => {
+    const mgr = { getActiveHub: () => Promise.resolve({ id: 'hub-2', config: {} }) };
+    await expect(requireActiveHub(mgr, 'hub-1', 'sync')).rejects.toThrow(RegistryError);
+  });
+});
+
+describe('requireActiveHubOrFail', () => {
+  it('returns the active hub when the id matches', async () => {
+    const ctx = createTestContext();
+    const mgr = { getActiveHub: () => Promise.resolve({ id: 'hub-1', config: { url: 'x' } }) };
+    const result = await requireActiveHubOrFail(mgr, 'hub-1', 'sync', ctx, 'text');
+    expect(result).toEqual({ id: 'hub-1', config: { url: 'x' } });
+  });
+
+  it('returns exit code 1 via failWith when no hub is active', async () => {
+    const ctx = createTestContext();
+    const mgr = { getActiveHub: () => Promise.resolve(null) };
+    const result = await requireActiveHubOrFail(mgr, 'hub-1', 'sync', ctx, 'text');
+    expect(result).toBe(1);
+    expect(ctx.stderr.captured()).toContain('no active hub');
+  });
+});

--- a/packages/cli/test/framework/golden.test.ts
+++ b/packages/cli/test/framework/golden.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests for `framework/golden.ts`.
+ *
+ * `runCommand` is the thin wrapper used by the command test suites. It
+ * should wire `createTestContext` and `runCli` together and return the
+ * captured output plus exit code.
+ */
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  Command,
+  type Context,
+  Option,
+  runCommand,
+} from '../../src/framework';
+
+class HelloCommand extends Command {
+  public static readonly paths = [['hello']];
+
+  public static readonly usage = Command.Usage({
+    description: 'Say hello',
+    category: 'Test'
+  });
+
+  public name = Option.String();
+  public commandContext!: { ctx: Context };
+
+  public execute(): Promise<number | void> {
+    const { ctx } = this.commandContext;
+    ctx.stdout.write(`hello ${this.name}`);
+    return Promise.resolve(0);
+  }
+}
+
+describe('runCommand', () => {
+  it('runs a native command class and returns the captured result', async () => {
+    const result = await runCommand(['hello', 'world'], {
+      commandClasses: [HelloCommand]
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe('hello world');
+    expect(result.stderr).toBe('');
+  });
+
+  it('passes context overrides through to createTestContext', async () => {
+    const result = await runCommand(['hello', 'world'], {
+      commandClasses: [HelloCommand],
+      context: {
+        env: { GREETING: 'hi' },
+        cwd: '/tmp'
+      }
+    });
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('can run declarative command definitions', async () => {
+    const result = await runCommand(['greet'], {
+      commands: [{
+        path: ['greet'],
+        description: 'Greet the test runner',
+        category: 'Test',
+        run: ({ ctx }): number => {
+          ctx.stdout.write('greetings');
+          return 0;
+        }
+      }]
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe('greetings');
+  });
+
+  it('uses the provided binary name and version in --version output', async () => {
+    const result = await runCommand(['--version'], {
+      commandClasses: [HelloCommand],
+      name: 'test-bin',
+      version: '1.2.3'
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('test-bin 1.2.3');
+  });
+});

--- a/packages/cli/test/framework/help-renderer.test.ts
+++ b/packages/cli/test/framework/help-renderer.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests for `framework/help-renderer.ts`.
+ *
+ * `renderGlobalHelp` produces a landing-page help string from clipanion
+ * command definitions, grouped by category.
+ */
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  renderGlobalHelp,
+} from '../../src/framework';
+
+interface FakeDefinition {
+  path: string;
+  description: string;
+  category?: string;
+}
+
+const fakeCli = (defs: FakeDefinition[]) => ({
+  definitions: ({ colored: _colored }: { colored?: boolean }) => defs.map((d) => ({
+    path: d.path,
+    description: d.description,
+    category: d.category,
+    usage: '',
+    options: []
+  }))
+});
+
+describe('renderGlobalHelp', () => {
+  it('renders the binary name and version', () => {
+    const cli = fakeCli([]);
+    const out = renderGlobalHelp(cli as unknown as Parameters<typeof renderGlobalHelp>[0], 'ai', '1.0.0');
+    expect(out).toContain('ai 1.0.0');
+  });
+
+  it('renders the quick start section', () => {
+    const cli = fakeCli([]);
+    const out = renderGlobalHelp(cli as unknown as Parameters<typeof renderGlobalHelp>[0], 'ai', '1.0.0');
+    expect(out).toContain('Quick Start');
+    expect(out).toContain('target add');
+  });
+
+  it('groups commands by category and strips the binary prefix', () => {
+    const cli = fakeCli([
+      { path: 'ai index search', description: 'Search index', category: 'Index & Search' },
+      { path: 'ai index build', description: 'Build index', category: 'Index & Search' },
+      { path: 'ai hub add', description: 'Add a hub', category: 'Hub & Discovery' }
+    ]);
+    const out = renderGlobalHelp(cli as unknown as Parameters<typeof renderGlobalHelp>[0], 'ai', '1.0.0');
+    expect(out).toContain('Index & Search');
+    expect(out).toContain('index search');
+    expect(out).toContain('index build');
+    expect(out).toContain('Hub & Discovery');
+    expect(out).toContain('hub add');
+  });
+
+  it('skips built-ins and definitions without descriptions', () => {
+    const cli = fakeCli([
+      { path: 'ai --help', description: 'Show help' },
+      { path: 'ai --version', description: 'Show version' },
+      { path: 'ai hub add', description: 'Add a hub', category: 'Hub' },
+      { path: 'ai hidden', description: '', category: 'Hub' }
+    ]);
+    const out = renderGlobalHelp(cli as unknown as Parameters<typeof renderGlobalHelp>[0], 'ai', '1.0.0');
+    expect(out).not.toContain('--help');
+    expect(out).not.toContain('--version');
+    expect(out).not.toContain('hidden');
+  });
+
+  it('alphabetically sorts commands within a category', () => {
+    const cli = fakeCli([
+      { path: 'ai zebra', description: 'Z', category: 'Test' },
+      { path: 'ai alpha', description: 'A', category: 'Test' }
+    ]);
+    const out = renderGlobalHelp(cli as unknown as Parameters<typeof renderGlobalHelp>[0], 'ai', '1.0.0');
+    const alphaIndex = out.indexOf('alpha');
+    const zebraIndex = out.indexOf('zebra');
+    expect(alphaIndex).toBeLessThan(zebraIndex);
+  });
+});

--- a/packages/cli/test/framework/hub-manager.test.ts
+++ b/packages/cli/test/framework/hub-manager.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Tests for `framework/hub-manager.ts`.
+ *
+ * The factory wires the default `HubManager` (HTTP client, token provider,
+ * resolvers, stores) that hub and profile commands use.
+ */
+import {
+  mkdtemp,
+  rm,
+} from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  NodeFileSystem,
+} from '@ai-primitives-hub/infra';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  createHttpClientAndTokens,
+  createHubManager,
+  createTestContext,
+} from '../../src/framework';
+
+describe('createHubManager', () => {
+  let workspace: string;
+
+  beforeEach(async () => {
+    workspace = await mkdtemp(path.join(os.tmpdir(), 'cli-hub-manager-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(workspace, { recursive: true, force: true });
+  });
+
+  it('creates a HubManager with default dependencies', () => {
+    const ctx = createTestContext({
+      fs: new NodeFileSystem(),
+      env: { XDG_CONFIG_HOME: path.join(workspace, '.config') }
+    });
+    const mgr = createHubManager({ ctx });
+    expect(mgr).toBeDefined();
+    expect(typeof mgr.getHub).toBe('function');
+  });
+
+  it('uses provided http client and token provider when given', () => {
+    const ctx = createTestContext({
+      fs: new NodeFileSystem(),
+      env: { XDG_CONFIG_HOME: path.join(workspace, '.config') }
+    });
+    const http = { fetch: () => Promise.resolve({ status: 200, text: () => Promise.resolve('') }) } as unknown as import('@ai-primitives-hub/core').HttpClient;
+    const tokens = { getToken: () => Promise.resolve('token') } as unknown as import('@ai-primitives-hub/core').TokenProvider;
+    const mgr = createHubManager({ ctx, http, tokens });
+    expect(mgr).toBeDefined();
+  });
+});
+
+describe('createHttpClientAndTokens', () => {
+  it('returns the provided http and token providers when present', () => {
+    const http = { fetch: () => Promise.resolve({ status: 200, text: () => Promise.resolve('') }) } as unknown as import('@ai-primitives-hub/core').HttpClient;
+    const tokens = { getToken: () => Promise.resolve('token') } as unknown as import('@ai-primitives-hub/core').TokenProvider;
+    const [resultHttp, resultTokens] = createHttpClientAndTokens(http, createTestContext(), tokens);
+    expect(resultHttp).toBe(http);
+    expect(resultTokens).toBe(tokens);
+  });
+
+  it('creates NodeHttpClient and EnvTokenProvider when none are provided', () => {
+    const ctx = createTestContext({ env: { GITHUB_TOKEN: 'abc' } });
+    const [http, tokens] = createHttpClientAndTokens(undefined, ctx, undefined);
+    expect(http).toBeDefined();
+    expect(tokens).toBeDefined();
+  });
+});

--- a/packages/cli/test/framework/index.test.ts
+++ b/packages/cli/test/framework/index.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for the public `framework` barrel.
+ *
+ * The barrel is the only import path command code should use. This test
+ * guards against accidental loss of exported framework helpers.
+ */
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  Command,
+  copyCommandPrototype,
+  createHubManager,
+  createProductionContext,
+  createTestContext,
+  defineCommand,
+  failWith,
+  findProjectLockfile,
+  formatOutput,
+  generateTargetHint,
+  getCommandContext,
+  isTestContext,
+  loadConfig,
+  loadTargets,
+  lockfilePathForTarget,
+  Option,
+  parseCsv,
+  parseCsvEnum,
+  parseCsvKinds,
+  parseCsvNonEmpty,
+  RegistryError,
+  renderError,
+  renderGlobalHelp,
+  renderTable,
+  requireActiveHub,
+  requireActiveHubOrFail,
+  resolveProjectConfigPath,
+  resolveTarget,
+  resolveTargetName,
+  runCli,
+  runCommand as runCommandAlias,
+  suggestCommand,
+  throwTargetNotFoundError,
+  validateInputs,
+} from '../../src/framework';
+
+describe('framework barrel', () => {
+  it('exports the core types and factories', () => {
+    expect(typeof createTestContext).toBe('function');
+    expect(typeof createProductionContext).toBe('function');
+    expect(typeof isTestContext).toBe('function');
+    expect(typeof runCli).toBe('function');
+    expect(typeof defineCommand).toBe('function');
+    expect(typeof runCommandAlias).toBe('function');
+    expect(typeof loadConfig).toBe('function');
+    expect(typeof resolveProjectConfigPath).toBe('function');
+    expect(typeof formatOutput).toBe('function');
+    expect(typeof RegistryError).toBe('function');
+    expect(typeof renderError).toBe('function');
+    expect(typeof failWith).toBe('function');
+    expect(typeof generateTargetHint).toBe('function');
+    expect(typeof resolveTargetName).toBe('function');
+    expect(typeof resolveTarget).toBe('function');
+    expect(typeof throwTargetNotFoundError).toBe('function');
+    expect(typeof validateInputs).toBe('function');
+    expect(typeof getCommandContext).toBe('function');
+    expect(typeof requireActiveHub).toBe('function');
+    expect(typeof requireActiveHubOrFail).toBe('function');
+    expect(typeof createHubManager).toBe('function');
+    expect(typeof loadTargets).toBe('function');
+    expect(typeof findProjectLockfile).toBe('function');
+    expect(typeof lockfilePathForTarget).toBe('function');
+    expect(typeof copyCommandPrototype).toBe('function');
+    expect(typeof renderTable).toBe('function');
+    expect(typeof parseCsv).toBe('function');
+    expect(typeof parseCsvEnum).toBe('function');
+    expect(typeof parseCsvKinds).toBe('function');
+    expect(typeof parseCsvNonEmpty).toBe('function');
+    expect(typeof renderGlobalHelp).toBe('function');
+    expect(typeof suggestCommand).toBe('function');
+  });
+
+  it('exports clipanion primitives', () => {
+    expect(typeof Command).toBe('function');
+    expect(typeof Option).toBe('object');
+    expect(typeof Option.String).toBe('function');
+  });
+});

--- a/packages/cli/test/framework/output.test.ts
+++ b/packages/cli/test/framework/output.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Tests for `framework/output.ts`.
+ *
+ * `formatOutput` serializes the command payload into text, json, yaml, or
+ * ndjson and writes to the Context streams. It also handles warnings and
+ * `quiet` suppression.
+ */
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  createTestContext,
+  formatOutput,
+} from '../../src/framework';
+
+describe('formatOutput', () => {
+  it('emits a JSON envelope by default for json output', () => {
+    const ctx = createTestContext();
+    formatOutput({
+      ctx,
+      command: 'test.cmd',
+      output: 'json',
+      status: 'ok',
+      data: { id: 1 }
+    });
+    const envelope = JSON.parse(ctx.stdout.captured()) as { status: string; data: unknown };
+    expect(envelope.status).toBe('ok');
+    expect(envelope.data).toEqual({ id: 1 });
+  });
+
+  it('puts warnings and errors into the JSON envelope', () => {
+    const ctx = createTestContext();
+    formatOutput({
+      ctx,
+      command: 'test.cmd',
+      output: 'json',
+      status: 'warning',
+      data: null,
+      warnings: ['one'],
+      errors: [{ code: 'X.Y', message: 'err' }]
+    });
+    const envelope = JSON.parse(ctx.stdout.captured()) as { warnings: string[]; errors: unknown[] };
+    expect(envelope.warnings).toEqual(['one']);
+    expect(envelope.errors).toHaveLength(1);
+  });
+
+  it('emits YAML for yaml output', () => {
+    const ctx = createTestContext();
+    formatOutput({
+      ctx,
+      command: 'test.cmd',
+      output: 'yaml',
+      status: 'ok',
+      data: { id: 1 }
+    });
+    expect(ctx.stdout.captured()).toContain('command: test.cmd');
+    expect(ctx.stdout.captured()).toContain('status: ok');
+  });
+
+  it('renders one JSON line per array item for ndjson output', () => {
+    const ctx = createTestContext();
+    formatOutput({
+      ctx,
+      command: 'test.cmd',
+      output: 'ndjson',
+      status: 'ok',
+      data: [{ id: 1 }, { id: 2 }]
+    });
+    const lines = ctx.stdout.captured().trim().split('\n');
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0])).toEqual({ id: 1 });
+    expect(JSON.parse(lines[1])).toEqual({ id: 2 });
+  });
+
+  it('emits non-array data as a single ndjson line', () => {
+    const ctx = createTestContext();
+    formatOutput({
+      ctx,
+      command: 'test.cmd',
+      output: 'ndjson',
+      status: 'ok',
+      data: { id: 1 }
+    });
+    expect(JSON.parse(ctx.stdout.captured())).toEqual({ id: 1 });
+  });
+
+  it('writes ndjson warnings/errors to stderr', () => {
+    const ctx = createTestContext();
+    formatOutput({
+      ctx,
+      command: 'test.cmd',
+      output: 'ndjson',
+      status: 'warning',
+      data: [],
+      warnings: ['oops'],
+      errors: [{ code: 'X.Y', message: 'bad' }]
+    });
+    expect(ctx.stderr.captured()).toContain('warning: oops');
+    expect(ctx.stderr.captured()).toContain('error: X.Y');
+  });
+
+  it('uses the custom textRenderer in text mode', () => {
+    const ctx = createTestContext();
+    formatOutput({
+      ctx,
+      command: 'test.cmd',
+      output: 'text',
+      status: 'ok',
+      data: { id: 1 },
+      textRenderer: (d) => `id=${(d).id}\n`
+    });
+    expect(ctx.stdout.captured()).toBe('id=1\n');
+  });
+
+  it('falls back to pretty-printed JSON when no textRenderer is supplied', () => {
+    const ctx = createTestContext();
+    formatOutput({
+      ctx,
+      command: 'test.cmd',
+      output: 'text',
+      status: 'ok',
+      data: { id: 1 }
+    });
+    expect(ctx.stdout.captured()).toBe('{\n  "id": 1\n}\n');
+  });
+
+  it('writes warnings to stderr in text mode', () => {
+    const ctx = createTestContext();
+    formatOutput({
+      ctx,
+      command: 'test.cmd',
+      output: 'text',
+      status: 'warning',
+      data: null,
+      warnings: ['look out']
+    });
+    expect(ctx.stderr.captured()).toContain('warning: look out');
+    expect(ctx.stdout.captured()).toBe('');
+  });
+
+  it('suppresses stdout in text mode when quiet is true', () => {
+    const ctx = createTestContext();
+    formatOutput({
+      ctx,
+      command: 'test.cmd',
+      output: 'text',
+      status: 'ok',
+      data: { id: 1 },
+      quiet: true,
+      textRenderer: (d) => `id=${(d).id}\n`
+    });
+    expect(ctx.stdout.captured()).toBe('');
+  });
+
+  it('does not suppress JSON output when quiet is true', () => {
+    const ctx = createTestContext();
+    formatOutput({
+      ctx,
+      command: 'test.cmd',
+      output: 'json',
+      status: 'ok',
+      data: { id: 1 },
+      quiet: true
+    });
+    expect(JSON.parse(ctx.stdout.captured()).data).toEqual({ id: 1 });
+  });
+});

--- a/packages/cli/test/framework/parsers.test.ts
+++ b/packages/cli/test/framework/parsers.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Tests for `framework/parsers.ts`.
+ *
+ * CSV and enum parsing helpers used by command classes for `--kinds`,
+ * `--source`, and similar flags.
+ */
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  parseCsv,
+  parseCsvEnum,
+  parseCsvKinds,
+  parseCsvNonEmpty,
+} from '../../src/framework';
+
+describe('parseCsv', () => {
+  it('returns undefined for undefined input', () => {
+    expect(parseCsv(undefined)).toBeUndefined();
+  });
+
+  it('splits, trims, and filters empty tokens', () => {
+    expect(parseCsv(' a, b, ,c ')).toEqual(['a', 'b', 'c']);
+  });
+});
+
+describe('parseCsvEnum', () => {
+  it('returns undefined for undefined input', () => {
+    expect(parseCsvEnum(undefined, ['one', 'two'], 'Kind')).toBeUndefined();
+  });
+
+  it('returns valid enum values', () => {
+    expect(parseCsvEnum('one, two', ['one', 'two', 'three'], 'Kind')).toEqual(['one', 'two']);
+  });
+
+  it('throws an error listing invalid values', () => {
+    expect(() => parseCsvEnum('bad', ['one', 'two'], 'Kind')).toThrow('Invalid Kind value(s): bad');
+  });
+});
+
+describe('parseCsvKinds', () => {
+  it('returns undefined for undefined input', () => {
+    expect(parseCsvKinds(undefined)).toBeUndefined();
+  });
+
+  it('parses valid primitive kinds', () => {
+    expect(parseCsvKinds('prompt,agent')).toEqual(['prompt', 'agent']);
+  });
+
+  it('rejects invalid kinds', () => {
+    expect(() => parseCsvKinds('prompt,not-a-kind')).toThrow('PrimitiveKind');
+  });
+});
+
+describe('parseCsvNonEmpty', () => {
+  it('returns undefined for undefined or empty results', () => {
+    expect(parseCsvNonEmpty(undefined)).toBeUndefined();
+    expect(parseCsvNonEmpty('   ')).toBeUndefined();
+  });
+
+  it('returns non-empty arrays', () => {
+    expect(parseCsvNonEmpty('a')).toEqual(['a']);
+  });
+});

--- a/packages/cli/test/framework/production-context.test.ts
+++ b/packages/cli/test/framework/production-context.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Tests for `framework/production-context.ts`.
+ *
+ * `createProductionContext` wires real Node primitives. We avoid calling
+ * `ctx.exit()` (which would terminate the process) and verify the other
+ * seams are correctly connected.
+ */
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  createProductionContext,
+} from '../../src/framework';
+
+describe('createProductionContext', () => {
+  it('wires a real NodeFileSystem and SystemClock', () => {
+    const ctx = createProductionContext({ cwd: '/tmp' });
+    expect(typeof ctx.fs.readFile).toBe('function');
+    expect(typeof ctx.clock.now).toBe('function');
+    expect(ctx.cwd()).toBe('/tmp');
+  });
+
+  it('defaults cwd to process.cwd() when not overridden', () => {
+    const ctx = createProductionContext();
+    expect(ctx.cwd()).toBe(process.cwd());
+  });
+
+  it('freezes env from process.env', () => {
+    const ctx = createProductionContext();
+    expect(Object.isFrozen(ctx.env)).toBe(true);
+  });
+
+  it('exposes stdout/stderr write methods', () => {
+    const ctx = createProductionContext();
+    expect(typeof ctx.stdout.write).toBe('function');
+    expect(typeof ctx.stderr.write).toBe('function');
+  });
+
+  it('reads stdin via the read method', () => {
+    const ctx = createProductionContext();
+    expect(typeof ctx.stdin.read).toBe('function');
+    expect(ctx.stdin.read()).toBe('');
+  });
+
+  it('exposes a net.fetch that calls globalThis.fetch', async () => {
+    const ctx = createProductionContext();
+    const original = globalThis.fetch;
+    const response = {
+      status: 200,
+      headers: new Headers(),
+      text: (): Promise<string> => Promise.resolve('ok'),
+      json: (): Promise<unknown> => Promise.resolve({ ok: true }),
+      arrayBuffer: (): Promise<ArrayBuffer> => Promise.resolve(new ArrayBuffer(0))
+    };
+    globalThis.fetch = (): Promise<Response> => Promise.resolve(response as unknown as Response);
+    try {
+      const result = await ctx.net.fetch('https://example.com');
+      expect(result.status).toBe(200);
+      expect(await result.text()).toBe('ok');
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  it('sets colorDepth to 0 when NO_COLOR is set', () => {
+    const original = process.env.NO_COLOR;
+    process.env.NO_COLOR = '1';
+    try {
+      const ctx = createProductionContext();
+      expect(ctx.colorDepth).toBe(0);
+    } finally {
+      if (original === undefined) {
+        delete process.env.NO_COLOR;
+      } else {
+        process.env.NO_COLOR = original;
+      }
+    }
+  });
+});

--- a/packages/cli/test/framework/suggest.test.ts
+++ b/packages/cli/test/framework/suggest.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Tests for `framework/suggest.ts`.
+ *
+ * `suggestCommand` returns a "Did you mean: ..." string when the user
+ * types something close to a known command path.
+ */
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  suggestCommand,
+} from '../../src/framework';
+
+interface FakeDefinition {
+  path: string;
+  description: string;
+}
+
+const fakeCli = (defs: FakeDefinition[]): { definitions: () => FakeDefinition[] } => ({
+  definitions: () => defs
+});
+
+describe('suggestCommand', () => {
+  it('suggests the closest known command for a typo', () => {
+    const cli = fakeCli([
+      { path: 'ai hub add', description: 'Add a hub' },
+      { path: 'ai hub list', description: 'List hubs' }
+    ]);
+    const result = suggestCommand(['hubb', 'add'], cli as unknown as Parameters<typeof suggestCommand>[1], 'ai');
+    expect(result).toBe('hub add');
+  });
+
+  it('returns undefined for an empty or very different input', () => {
+    const cli = fakeCli([
+      { path: 'ai hub add', description: 'Add a hub' }
+    ]);
+    expect(suggestCommand(['xyz'], cli as unknown as Parameters<typeof suggestCommand>[1], 'ai')).toBeUndefined();
+    expect(suggestCommand([], cli as unknown as Parameters<typeof suggestCommand>[1], 'ai')).toBeUndefined();
+  });
+
+  it('ignores built-in flags and definitions with no description', () => {
+    const cli = fakeCli([
+      { path: 'ai --help', description: 'Show help' },
+      { path: 'ai --version', description: 'Show version' },
+      { path: 'ai hub add', description: 'Add a hub' },
+      { path: 'ai hub', description: '' }
+    ]);
+    const result = suggestCommand(['hubb', 'add'], cli as unknown as Parameters<typeof suggestCommand>[1], 'ai');
+    expect(result).toBe('hub add');
+  });
+
+  it('stops at the first flag when reconstructing the attempted command', () => {
+    const cli = fakeCli([
+      { path: 'ai index search', description: 'Search index' }
+    ]);
+    const result = suggestCommand(['index', 'serch', '--verbose'], cli as unknown as Parameters<typeof suggestCommand>[1], 'ai');
+    expect(result).toBe('index search');
+  });
+});

--- a/packages/cli/test/framework/table.test.ts
+++ b/packages/cli/test/framework/table.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for `framework/table.ts`.
+ *
+ * `renderTable` produces fixed-width, newline-terminated text tables from
+ * column definitions and row data.
+ */
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  renderTable,
+} from '../../src/framework';
+
+interface Row {
+  name: string;
+  count: number;
+}
+
+describe('renderTable', () => {
+  it('renders a fixed-width table with headers and rows', () => {
+    const out = renderTable<Row>({
+      columns: [
+        { header: 'Name', get: (r) => r.name },
+        { header: 'Count', get: (r) => String(r.count), align: 'right' }
+      ],
+      rows: [
+        { name: 'prompts', count: 3 },
+        { name: 'skills', count: 42 }
+      ]
+    });
+    const lines = out.split('\n').filter((line) => line.length > 0);
+    expect(lines[0]).toContain('Name');
+    expect(lines[1]).toContain('prompts');
+    expect(lines[2]).toContain('42');
+  });
+
+  it('honors fixed column widths', () => {
+    const out = renderTable<Row>({
+      columns: [
+        { header: 'Name', get: (r) => r.name, width: 12 },
+        { header: 'Count', get: (r) => String(r.count), width: 5 }
+      ],
+      rows: [{ name: 'x', count: 1 }]
+    });
+    const [header] = out.split('\n');
+    expect(header).toBe('Name          Count');
+  });
+
+  it('right-aligns columns', () => {
+    const out = renderTable<Row>({
+      columns: [
+        { header: 'Count', get: (r) => String(r.count), align: 'right' }
+      ],
+      rows: [{ name: 'x', count: 7 }]
+    });
+    const [, data] = out.split('\n');
+    expect(data).toMatch(/^\s+7$/);
+  });
+
+  it('returns the empty message when there are no rows', () => {
+    const out = renderTable<Row>({
+      columns: [{ header: 'Name', get: (r) => r.name }],
+      rows: []
+    });
+    expect(out).toBe('No items.\n');
+  });
+
+  it('honors a custom empty message', () => {
+    const out = renderTable<Row>({
+      columns: [{ header: 'Name', get: (r) => r.name }],
+      rows: [],
+      emptyMessage: 'Nothing here.\n'
+    });
+    expect(out).toBe('Nothing here.\n');
+  });
+});

--- a/packages/cli/test/framework/target.test.ts
+++ b/packages/cli/test/framework/target.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Tests for `framework/target.ts`.
+ *
+ * Target resolution helpers (`loadTargets`, `findProjectLockfile`,
+ * `lockfilePathForTarget`) route through the `app` and `infra` layers.
+ * These tests use a real `NodeFileSystem` and temporary directories to
+ * verify the wiring without in-memory doubles.
+ */
+import {
+  mkdir,
+  mkdtemp,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  getLockfilePathForMode,
+} from '@ai-primitives-hub/app';
+import {
+  NodeFileSystem,
+} from '@ai-primitives-hub/infra';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  createTestContext,
+  findProjectLockfile,
+  loadTargets,
+  lockfilePathForTarget,
+} from '../../src/framework';
+
+const makeTarget = (name: string, type: 'vscode' | 'copilot-cli' | 'kiro', scope: 'user' | 'workspace' | 'repository' = 'user'): import('@ai-primitives-hub/core').Target => ({
+  name,
+  type,
+  scope
+});
+
+describe('loadTargets', () => {
+  let workspace: string;
+
+  beforeEach(async () => {
+    workspace = await mkdtemp(path.join(os.tmpdir(), 'cli-target-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(workspace, { recursive: true, force: true });
+  });
+
+  it('loads targets from the nearest project config', async () => {
+    await writeFile(
+      path.join(workspace, 'ai-primitives-hub.yml'),
+      'targets:\n  - name: copilot\n    type: copilot-cli\n    scope: user\n'
+    );
+    const ctx = createTestContext({ fs: new NodeFileSystem(), cwd: workspace });
+    const targets = await loadTargets(ctx);
+    expect(targets).toHaveLength(1);
+    expect(targets[0]?.name).toBe('copilot');
+  });
+
+  it('returns an empty array when no project config or user config exists', async () => {
+    const ctx = createTestContext({
+      fs: new NodeFileSystem(),
+      cwd: workspace,
+      env: { XDG_CONFIG_HOME: path.join(workspace, '.config') }
+    });
+    const targets = await loadTargets(ctx);
+    expect(targets).toEqual([]);
+  });
+});
+
+describe('findProjectLockfile', () => {
+  let workspace: string;
+
+  beforeEach(async () => {
+    workspace = await mkdtemp(path.join(os.tmpdir(), 'cli-lockfile-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(workspace, { recursive: true, force: true });
+  });
+
+  it('finds a project lockfile in cwd', async () => {
+    const lockfile = path.join(workspace, 'prompt-registry.lock.json');
+    await writeFile(lockfile, '{}');
+    const ctx = createTestContext({ fs: new NodeFileSystem(), cwd: workspace });
+    const found = await findProjectLockfile(ctx);
+    expect(found).toBe(lockfile);
+  });
+
+  it('walks upward to find a lockfile', async () => {
+    const nested = path.join(workspace, 'packages', 'cli');
+    await mkdir(nested, { recursive: true });
+    const lockfile = path.join(workspace, 'prompt-registry.lock.json');
+    await writeFile(lockfile, '{}');
+    const ctx = createTestContext({ fs: new NodeFileSystem(), cwd: nested });
+    const found = await findProjectLockfile(ctx);
+    expect(found).toBe(lockfile);
+  });
+
+  it('returns null when no lockfile is found', async () => {
+    const ctx = createTestContext({
+      fs: new NodeFileSystem(),
+      cwd: workspace,
+      env: { XDG_CONFIG_HOME: path.join(workspace, '.config') }
+    });
+    const found = await findProjectLockfile(ctx);
+    expect(found).toBeNull();
+  });
+});
+
+describe('lockfilePathForTarget', () => {
+  it('returns the user lockfile for non-repository scopes', () => {
+    const ctx = createTestContext({ env: { XDG_CONFIG_HOME: '/home/user/.config' } });
+    const target = makeTarget('copilot', 'copilot-cli', 'user');
+    expect(lockfilePathForTarget(ctx, target)).toBe('/home/user/.config/ai-primitives-hub/ai-primitives-hub.lock.json');
+  });
+
+  it('uses the repository lockfile path for repository scope', () => {
+    const ctx = createTestContext({ cwd: '/workspace' });
+    const target = makeTarget('vscode', 'vscode', 'repository');
+    expect(lockfilePathForTarget(ctx, target)).toBe(getLockfilePathForMode('/workspace', 'commit'));
+  });
+
+  it('honors the commitMode override for repository scope', () => {
+    const ctx = createTestContext({ cwd: '/workspace' });
+    const target = makeTarget('vscode', 'vscode', 'repository');
+    expect(lockfilePathForTarget(ctx, target, 'local-only')).toBe(getLockfilePathForMode('/workspace', 'local-only'));
+  });
+});

--- a/packages/cli/test/framework/test-context.test.ts
+++ b/packages/cli/test/framework/test-context.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests for `framework/test-context.ts`.
+ *
+ * `createTestContext` is the hermetic fixture factory most command tests
+ * rely on. Verify it defaults to an isolated in-memory environment and
+ * exposes the captured output / exit code accessors the golden-test runner
+ * consumes.
+ */
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  createProductionContext,
+  createTestContext,
+  type FsAbstraction,
+  isTestContext,
+} from '../../src/framework';
+
+describe('createTestContext', () => {
+  it('defaults to an isolated, empty environment and cwd "/"', () => {
+    const ctx = createTestContext();
+    expect(ctx.cwd()).toBe('/');
+    expect(ctx.env).toEqual({});
+    expect(ctx.colorDepth).toBe(0);
+  });
+
+  it('captures stdout/stderr writes', () => {
+    const ctx = createTestContext();
+    ctx.stdout.write('hello stdout\n');
+    ctx.stderr.write('hello stderr\n');
+    expect(ctx.stdout.captured()).toBe('hello stdout\n');
+    expect(ctx.stderr.captured()).toBe('hello stderr\n');
+  });
+
+  it('records the first exit code and defaults to 0', () => {
+    const ctx = createTestContext();
+    expect(ctx.exitCode()).toBe(0);
+    ctx.exit(7);
+    expect(ctx.exitCode()).toBe(7);
+    ctx.exit(3); // first wins
+    expect(ctx.exitCode()).toBe(7);
+  });
+
+  it('respects overrides for stdin, clock, env, and cwd', () => {
+    const ctx = createTestContext({
+      stdin: 'piped',
+      now: 1_234_567_890_000,
+      env: { FOO: 'bar' },
+      cwd: '/workspace'
+    });
+    expect(ctx.stdin.read()).toBe('piped');
+    expect(ctx.clock.now()).toBe(1_234_567_890_000);
+    expect(ctx.clock.nowIso()).toBe(new Date(1_234_567_890_000).toISOString());
+    ctx.clock.advance(1000);
+    expect(ctx.clock.now()).toBe(1_234_567_891_000);
+    expect(ctx.env).toEqual({ FOO: 'bar' });
+    expect(ctx.cwd()).toBe('/workspace');
+  });
+
+  it('freezes env so tests cannot accidentally mutate shared state', () => {
+    const ctx = createTestContext({ env: { FOO: 'bar' } });
+    expect(() => {
+      (ctx.env as Record<string, string>).FOO = 'baz';
+    }).toThrow();
+  });
+
+  it('stubs fs and net so callers get descriptive errors', async () => {
+    const ctx = createTestContext();
+    await expect(ctx.fs.readFile('/foo')).rejects.toThrow('fs not wired yet');
+    await expect(ctx.net.fetch('https://example.com')).rejects.toThrow('net not wired yet');
+  });
+
+  it('can accept a custom fs implementation', async () => {
+    const customFs: FsAbstraction = {
+      readFile: (): Promise<string> => Promise.resolve('custom'),
+      exists: (): Promise<boolean> => Promise.resolve(false),
+      readJson: <T>(): Promise<T> => Promise.resolve(JSON.parse('{}') as T),
+      writeFile: (): Promise<void> => Promise.resolve(),
+      writeJson: (): Promise<void> => Promise.resolve(),
+      mkdir: (): Promise<void> => Promise.resolve(),
+      readDir: (): Promise<string[]> => Promise.resolve([]),
+      readDirEntries: (): Promise<{ name: string; isDirectory: boolean }[]> => Promise.resolve([]),
+      stat: (): Promise<{ isFile: boolean; isDirectory: boolean; size: number; mtimeMs: number }> => Promise.resolve({
+        isFile: false,
+        isDirectory: false,
+        size: 0,
+        mtimeMs: 0
+      }),
+      remove: (): Promise<void> => Promise.resolve()
+    };
+    const ctx = createTestContext({ fs: customFs });
+    expect(await ctx.fs.readFile('/foo')).toBe('custom');
+  });
+});
+
+describe('isTestContext', () => {
+  it('returns true for a test context', () => {
+    expect(isTestContext(createTestContext())).toBe(true);
+  });
+
+  it('returns false for a production context', () => {
+    const ctx = createProductionContext({ cwd: '/tmp' });
+    expect(isTestContext(ctx)).toBe(false);
+  });
+});

--- a/packages/cli/test/index.test.ts
+++ b/packages/cli/test/index.test.ts
@@ -1,0 +1,14 @@
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  run,
+} from '../src/index';
+
+describe('@ai-primitives-hub/cli barrel', () => {
+  it('exports run (the main entry point bin/ai-primitives-hub.js calls)', () => {
+    expect(typeof run).toBe('function');
+  });
+});

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "references": [
+    { "path": "../core" },
+    { "path": "../infra" },
+    { "path": "../app" }
+  ],
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test"]
+}

--- a/packages/cli/tsconfig.test.json
+++ b/packages/cli/tsconfig.test.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "declaration": false,
+    "declarationMap": false,
+    "types": ["node"]
+  },
+  "include": ["src/**/*", "test/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -4,6 +4,6 @@
     { "path": "./core" },
     { "path": "./infra" },
     { "path": "./app" },
-    // { "path": "./cli" }
+    { "path": "./cli" }
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -273,6 +273,67 @@ importers:
         specifier: ^4.1.7
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(terser@5.49.0))
 
+  packages/cli:
+    dependencies:
+      '@ai-primitives-hub/app':
+        specifier: workspace:*
+        version: link:../app
+      '@ai-primitives-hub/core':
+        specifier: workspace:*
+        version: link:../core
+      '@ai-primitives-hub/infra':
+        specifier: workspace:*
+        version: link:../infra
+      archiver:
+        specifier: ^7.0.1
+        version: 7.0.1
+      clipanion:
+        specifier: 4.0.0-rc.4
+        version: 4.0.0-rc.4(typanion@3.14.0)
+      inquirer:
+        specifier: ^9.3.8
+        version: 9.3.8(@types/node@22.20.1)
+      js-yaml:
+        specifier: ^4.1.1
+        version: 4.3.0
+      semver:
+        specifier: ^7.5.4
+        version: 7.8.5
+      typanion:
+        specifier: ^3.14.0
+        version: 3.14.0
+    devDependencies:
+      '@types/archiver':
+        specifier: ^7.0.0
+        version: 7.0.0
+      '@types/inquirer':
+        specifier: ^9.0.9
+        version: 9.0.10
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.20.1
+      '@types/semver':
+        specifier: ^7.5.6
+        version: 7.7.1
+      '@vitest/coverage-v8':
+        specifier: ^4.1.7
+        version: 4.1.10(vitest@4.1.10)
+      esbuild:
+        specifier: ^0.28.1
+        version: 0.28.1
+      postject:
+        specifier: 1.0.0-alpha.6
+        version: 1.0.0-alpha.6
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(terser@5.49.0))
+
   packages/core:
     dependencies:
       js-yaml:
@@ -1487,6 +1548,9 @@ packages:
   '@types/glob@8.1.0':
     resolution: {integrity: sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==}
 
+  '@types/inquirer@9.0.10':
+    resolution: {integrity: sha512-vFW2WbXwO9eZpRT5GJGFJ/shgyMNnYozmnjakt9jCQSS1lvqX8pZEQMjJ9RdDPct/YxwciQ8+V8OYn9euIrZDA==}
+
   '@types/istanbul-lib-coverage@2.0.6':
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
 
@@ -1540,6 +1604,9 @@ packages:
 
   '@types/sinonjs__fake-timers@15.0.1':
     resolution: {integrity: sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==}
+
+  '@types/through@0.0.33':
+    resolution: {integrity: sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ==}
 
   '@types/vscode@1.125.0':
     resolution: {integrity: sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==}
@@ -2027,6 +2094,10 @@ packages:
       typescript: '*'
       typescript-eslint: ^8.0.0
 
+  ansi-escapes@4.3.2:
+    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
+    engines: {node: '>=8'}
+
   ansi-escapes@7.3.0:
     resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
     engines: {node: '>=18'}
@@ -2363,6 +2434,10 @@ packages:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
     engines: {node: '>=6'}
 
+  cli-cursor@3.1.0:
+    resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
+    engines: {node: '>=8'}
+
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
     engines: {node: '>=18'}
@@ -2383,6 +2458,11 @@ packages:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
     engines: {node: '>= 12'}
 
+  clipanion@4.0.0-rc.4:
+    resolution: {integrity: sha512-CXkMQxU6s9GklO/1f714dkKBMu1lopS1WFF0B8o4AxPykR1hpozxSiUZ5ZUeBjfPgCWqbcNOtZVFhB8Lkfp1+Q==}
+    peerDependencies:
+      typanion: '*'
+
   cliui@6.0.0:
     resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
 
@@ -2397,6 +2477,10 @@ packages:
   clone-deep@4.0.1:
     resolution: {integrity: sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==}
     engines: {node: '>=6'}
+
+  clone@1.0.4:
+    resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
+    engines: {node: '>=0.8'}
 
   cockatiel@3.2.1:
     resolution: {integrity: sha512-gfrHV6ZPkquExvMh9IOkKsBzNDk6sDuZ6DdBGUBkvFnTCqCxzpuq48RySgP0AnaqQkw2zynOFj9yly6T1Q2G5Q==}
@@ -2426,6 +2510,10 @@ packages:
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+
+  commander@9.5.0:
+    resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
+    engines: {node: ^12.20.0 || >=14}
 
   comment-parser@1.4.1:
     resolution: {integrity: sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==}
@@ -2576,6 +2664,9 @@ packages:
   default-require-extensions@3.0.1:
     resolution: {integrity: sha512-eXTJmRbm2TIt9MgWTsOH1wEuhew6XGZcMeGKCtLedIg/NCsg1iBePXkceTdK4Fii7pzmN9tGsZhKzZ4h7O/fxw==}
     engines: {node: '>=8'}
+
+  defaults@1.0.4:
+    resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
 
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
@@ -3369,6 +3460,10 @@ packages:
     resolution: {integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
+  inquirer@9.3.8:
+    resolution: {integrity: sha512-pFGGdaHrmRKMh4WoDDSowddgjT1Vkl90atobmTeSmcPGdYiwikch/m/Ef5wRaiamHejtw0cUUMMerzDUXCci2w==}
+    engines: {node: '>=18'}
+
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
@@ -3461,6 +3556,10 @@ packages:
     resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
     engines: {node: '>=14.16'}
     hasBin: true
+
+  is-interactive@1.0.0:
+    resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
+    engines: {node: '>=8'}
 
   is-interactive@2.0.0:
     resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
@@ -3972,6 +4071,10 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
+
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
@@ -4086,6 +4189,10 @@ packages:
 
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
+
+  mute-stream@1.0.0:
+    resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   mute-stream@2.0.0:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
@@ -4241,6 +4348,10 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
+
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
@@ -4252,6 +4363,10 @@ packages:
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
+
+  ora@5.4.1:
+    resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
+    engines: {node: '>=10'}
 
   ora@8.2.0:
     resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
@@ -4449,6 +4564,11 @@ packages:
     resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postject@1.0.0-alpha.6:
+    resolution: {integrity: sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
@@ -4617,6 +4737,10 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  restore-cursor@3.1.0:
+    resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
+    engines: {node: '>=8'}
+
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
@@ -4645,6 +4769,10 @@ packages:
   run-applescript@7.1.0:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
     engines: {node: '>=18'}
+
+  run-async@3.0.0:
+    resolution: {integrity: sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==}
+    engines: {node: '>=0.12.0'}
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -5099,6 +5227,9 @@ packages:
     resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
     engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
 
+  typanion@3.14.0:
+    resolution: {integrity: sha512-ZW/lVMRabETuYCd9O9ZvMhAh8GslSqaUjxmK/JLPCh6l73CvLBiuXswj/+7LdnWOgYsQ130FqLzFz5aGT4I3Ug==}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -5110,6 +5241,10 @@ packages:
   type-detect@4.1.0:
     resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
     engines: {node: '>=4'}
+
+  type-fest@0.21.3:
+    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
+    engines: {node: '>=10'}
 
   type-fest@0.8.1:
     resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
@@ -5326,6 +5461,9 @@ packages:
   watchpack@2.5.2:
     resolution: {integrity: sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==}
     engines: {node: '>=10.13.0'}
+
+  wcwidth@1.0.1:
+    resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
   webpack-cli@5.1.4:
     resolution: {integrity: sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==}
@@ -5834,7 +5972,7 @@ snapshots:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
@@ -5874,7 +6012,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-module-imports': 7.29.7
@@ -6780,6 +6918,11 @@ snapshots:
       '@types/minimatch': 5.1.2
       '@types/node': 22.20.1
 
+  '@types/inquirer@9.0.10':
+    dependencies:
+      '@types/through': 0.0.33
+      rxjs: 7.8.2
+
   '@types/istanbul-lib-coverage@2.0.6': {}
 
   '@types/js-yaml@4.0.9': {}
@@ -6828,6 +6971,10 @@ snapshots:
       '@types/sinonjs__fake-timers': 15.0.1
 
   '@types/sinonjs__fake-timers@15.0.1': {}
+
+  '@types/through@0.0.33':
+    dependencies:
+      '@types/node': 22.20.1
 
   '@types/vscode@1.125.0': {}
 
@@ -7402,6 +7549,10 @@ snapshots:
       - chokidar
       - supports-color
 
+  ansi-escapes@4.3.2:
+    dependencies:
+      type-fest: 0.21.3
+
   ansi-escapes@7.3.0:
     dependencies:
       environment: 1.1.0
@@ -7589,7 +7740,6 @@ snapshots:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
-    optional: true
 
   body-parser@2.3.0:
     dependencies:
@@ -7648,7 +7798,6 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
-    optional: true
 
   buffer@6.0.3:
     dependencies:
@@ -7777,6 +7926,10 @@ snapshots:
 
   clean-stack@2.2.0: {}
 
+  cli-cursor@3.1.0:
+    dependencies:
+      restore-cursor: 3.1.0
+
   cli-cursor@5.0.0:
     dependencies:
       restore-cursor: 5.1.0
@@ -7791,6 +7944,10 @@ snapshots:
       string-width: 8.2.2
 
   cli-width@4.1.0: {}
+
+  clipanion@4.0.0-rc.4(typanion@3.14.0):
+    dependencies:
+      typanion: 3.14.0
 
   cliui@6.0.0:
     dependencies:
@@ -7816,6 +7973,8 @@ snapshots:
       kind-of: 6.0.3
       shallow-clone: 3.0.1
 
+  clone@1.0.4: {}
+
   cockatiel@3.2.1: {}
 
   color-convert@2.0.1:
@@ -7835,6 +7994,8 @@ snapshots:
   commander@12.1.0: {}
 
   commander@2.20.3: {}
+
+  commander@9.5.0: {}
 
   comment-parser@1.4.1: {}
 
@@ -7974,6 +8135,10 @@ snapshots:
   default-require-extensions@3.0.1:
     dependencies:
       strip-bom: 4.0.0
+
+  defaults@1.0.4:
+    dependencies:
+      clone: 1.0.4
 
   define-data-property@1.1.4:
     dependencies:
@@ -8222,7 +8387,6 @@ snapshots:
       '@esbuild/win32-arm64': 0.28.1
       '@esbuild/win32-ia32': 0.28.1
       '@esbuild/win32-x64': 0.28.1
-    optional: true
 
   escalade@3.2.0: {}
 
@@ -8922,6 +9086,23 @@ snapshots:
 
   ini@6.0.0: {}
 
+  inquirer@9.3.8(@types/node@22.20.1):
+    dependencies:
+      '@inquirer/external-editor': 1.0.3(@types/node@22.20.1)
+      '@inquirer/figures': 1.0.15
+      ansi-escapes: 4.3.2
+      cli-width: 4.1.0
+      mute-stream: 1.0.0
+      ora: 5.4.1
+      run-async: 3.0.0
+      rxjs: 7.8.2
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
+    transitivePeerDependencies:
+      - '@types/node'
+
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -9015,6 +9196,8 @@ snapshots:
   is-inside-container@1.0.0:
     dependencies:
       is-docker: 3.0.0
+
+  is-interactive@1.0.0: {}
 
   is-interactive@2.0.0: {}
 
@@ -9496,6 +9679,8 @@ snapshots:
 
   mime@1.6.0: {}
 
+  mimic-fn@2.1.0: {}
+
   mimic-function@5.0.1: {}
 
   mimic-response@3.1.0:
@@ -9591,6 +9776,8 @@ snapshots:
   ms@2.1.3: {}
 
   mute-stream@0.0.8: {}
+
+  mute-stream@1.0.0: {}
 
   mute-stream@2.0.0: {}
 
@@ -9796,6 +9983,10 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
+
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
@@ -9815,6 +10006,18 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
+
+  ora@5.4.1:
+    dependencies:
+      bl: 4.1.0
+      chalk: 4.1.2
+      cli-cursor: 3.1.0
+      cli-spinners: 2.9.2
+      is-interactive: 1.0.0
+      is-unicode-supported: 0.1.0
+      log-symbols: 4.1.0
+      strip-ansi: 6.0.1
+      wcwidth: 1.0.1
 
   ora@8.2.0:
     dependencies:
@@ -10025,6 +10228,10 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  postject@1.0.0-alpha.6:
+    dependencies:
+      commander: 9.5.0
+
   prebuild-install@7.1.3:
     dependencies:
       detect-libc: 2.1.2
@@ -10136,7 +10343,6 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
-    optional: true
 
   readable-stream@4.7.0:
     dependencies:
@@ -10220,6 +10426,11 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  restore-cursor@3.1.0:
+    dependencies:
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+
   restore-cursor@5.1.0:
     dependencies:
       onetime: 7.0.0
@@ -10266,6 +10477,8 @@ snapshots:
       - supports-color
 
   run-applescript@7.1.0: {}
+
+  run-async@3.0.0: {}
 
   run-parallel@1.2.0:
     dependencies:
@@ -10819,6 +11032,8 @@ snapshots:
 
   tunnel@0.0.6: {}
 
+  typanion@3.14.0: {}
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -10826,6 +11041,8 @@ snapshots:
   type-detect@4.0.8: {}
 
   type-detect@4.1.0: {}
+
+  type-fest@0.21.3: {}
 
   type-fest@0.8.1: {}
 
@@ -11027,6 +11244,10 @@ snapshots:
   watchpack@2.5.2:
     dependencies:
       graceful-fs: 4.2.11
+
+  wcwidth@1.0.1:
+    dependencies:
+      defaults: 1.0.4
 
   webpack-cli@5.1.4(webpack@5.108.4):
     dependencies:


### PR DESCRIPTION
## Description

Introduces the new `packages/cli` layer as part of the migration to the library-centric architecture, adding a thin CLI delivery adapter over the new `core` / `infra` / `app` packages.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test coverage improvement
- [x] 🔧 Configuration/build changes

## Related Issues

Closes #
Fixes #
Relates to #

## Changes Made

- Added `packages/cli` with command entrypoints, framework helpers, packaging config, and executable bin wrapper.
- Added CLI test coverage for commands and framework behavior.
- Updated shared package wiring (`packages/tsconfig.json`, `pnpm-lock.yaml`) to integrate the new CLI package.

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing completed
- [ ] All existing tests pass

### Manual Testing Steps

1. Build `@ai-primitives-hub/cli`.
2. Run selected CLI commands from the generated entrypoint.
3. Verify command wiring and output formatting.

### Tested On

- [ ] macOS
- [ ] Windows
- [x] Linux

- [ ] VS Code Stable
- [ ] VS Code Insiders

## Screenshots

N/A (CLI-only change).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Documentation

- [ ] README.md updated
- [ ] JSDoc comments added/updated
- [x] No documentation changes needed

## Additional Notes

This is the CLI delivery layer milestone for the library-centric migration and keeps business logic in the shared packages rather than the command layer.

## Reviewer Guidelines

Please pay special attention to:

- Whether command handlers stay thin and delegate business logic to `app` / `core` / `infra`.
- CLI package wiring, entrypoints, and packaging/build integration.

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**
