### PR TITLE
fix: prevent duplicate type extensions on bundle install (#184)

### DIFF
--- a/apps/vscode-extension/src/utils/copilot-file-type-utils.ts
+++ b/apps/vscode-extension/src/utils/copilot-file-type-utils.ts
@@ -173,7 +173,18 @@ export function getTargetFileName(id: string, type: CopilotFileType): string {
     return 'SKILL.md';
   }
 
-  return `${id}${FILE_EXTENSIONS[type]}`;
+  // Defensively strip a type suffix the id may already carry (e.g. an id of
+  // "foo.prompt" from a manifest that didn't strip the compound extension), so we
+  // don't produce "foo.prompt.prompt.md". The suffix is derived from FILE_EXTENSIONS
+  // rather than hardcoded, so new file types are handled automatically.
+  const extension = FILE_EXTENSIONS[type];
+  const bareSuffix = extension.replace(/\.md$/, ''); // e.g. ".prompt"
+  let baseId = id;
+  if (bareSuffix && baseId.toLowerCase().endsWith(bareSuffix.toLowerCase())) {
+    baseId = baseId.slice(0, -bareSuffix.length);
+  }
+
+  return `${baseId}${extension}`;
 }
 
 /**

--- a/apps/vscode-extension/test/utils/copilot-file-type-utils.test.ts
+++ b/apps/vscode-extension/test/utils/copilot-file-type-utils.test.ts
@@ -169,6 +169,23 @@ suite('copilotFileTypeUtils', () => {
     test('should handle IDs with special characters', () => {
       assert.strictEqual(getTargetFileName('my_prompt-v1', 'prompt'), 'my_prompt-v1.prompt.md');
     });
+
+    // Regression for #184: an id that already carries the type suffix (from a manifest
+    // that didn't strip the compound extension) must not produce a doubled extension.
+    test('should not double the extension when the id already ends in the type suffix', () => {
+      assert.strictEqual(getTargetFileName('summarize.prompt', 'prompt'), 'summarize.prompt.md');
+      assert.strictEqual(getTargetFileName('code-reviewer.agent', 'agent'), 'code-reviewer.agent.md');
+      assert.strictEqual(getTargetFileName('coding-standards.instructions', 'instructions'), 'coding-standards.instructions.md');
+    });
+
+    test('should strip the type suffix case-insensitively', () => {
+      assert.strictEqual(getTargetFileName('Summarize.PROMPT', 'prompt'), 'Summarize.prompt.md');
+    });
+
+    test('should only strip the exact type suffix, leaving other dotted segments intact', () => {
+      // "bundle.v1" is a legitimate id; ".v1" is not a type suffix and must survive.
+      assert.strictEqual(getTargetFileName('bundle.v1', 'prompt'), 'bundle.v1.prompt.md');
+    });
   });
 
   suite('getRepositoryTargetDirectory', () => {

--- a/lib/bin/generate-manifest.js
+++ b/lib/bin/generate-manifest.js
@@ -95,7 +95,17 @@ try {
       const pathParts = itemPath.split('/');
       itemId = pathParts.length >= 2 ? pathParts[pathParts.length - 2] : path.basename(itemPath, extension);
     } else {
-      itemId = path.basename(itemPath, extension);
+      // Strip the full compound suffix (e.g. ".prompt.md", ".agent.md") rather than only
+      // the last extension. path.basename(f, ".md") leaves ".prompt"/".agent" in the id,
+      // which install then re-appends -> "foo.prompt.prompt.md". The suffix is derived
+      // from the item's own type (files follow the ".<type>.md" convention), so new types
+      // work with no hardcoded list. Falls back to the plain ".md" strip if the filename
+      // doesn't follow the convention.
+      const baseName = path.basename(itemPath);
+      const typeSuffix = `.${type}.md`;
+      itemId = baseName.toLowerCase().endsWith(typeSuffix.toLowerCase())
+        ? baseName.slice(0, -typeSuffix.length)
+        : path.basename(itemPath, extension);
     }
 
     return {

--- a/lib/test/generate-manifest.test.ts
+++ b/lib/test/generate-manifest.test.ts
@@ -235,6 +235,48 @@ items:
     });
   });
 
+  describe('Item IDs', () => {
+    it('should strip the full compound type suffix from item ids', () => {
+      // Regression for #184: ids kept only ".md" stripped, leaving ".agent"/".prompt"
+      // which install then re-appended -> "code-reviewer.agent.agent.md".
+      const collectionYaml = `
+id: suffix-collection
+name: Suffix Collection
+description: A collection exercising compound type suffixes
+version: "1.0.0"
+items:
+  - path: agents/code-reviewer.agent.md
+    kind: agent
+  - path: prompts/summarize.prompt.md
+    kind: prompt
+`;
+
+      writeFile(tempDir, 'collections/suffix.collection.yml', collectionYaml);
+      writeFile(tempDir, 'agents/code-reviewer.agent.md', '# Code Reviewer\n\nAgent content');
+      writeFile(tempDir, 'prompts/summarize.prompt.md', '# Summarize\n\nPrompt content');
+
+      const outFile = path.join(tempDir, 'deployment-manifest.yml');
+
+      const result = spawnSync('node', [scriptPath, '1.0.0', '--collection-file', 'collections/suffix.collection.yml', '--out', outFile], {
+        cwd: tempDir,
+        encoding: 'utf8'
+      });
+
+      assert.strictEqual(result.status, 0, `Script failed: ${result.stderr}`);
+
+      const manifest = yaml.load(fs.readFileSync(outFile, 'utf8')) as any;
+
+      const agent = manifest.prompts.find((p: any) => p.type === 'agent');
+      const prompt = manifest.prompts.find((p: any) => p.type === 'prompt');
+
+      assert.ok(agent, 'Manifest should include the agent item');
+      assert.strictEqual(agent.id, 'code-reviewer', 'Agent id should not retain the .agent suffix');
+
+      assert.ok(prompt, 'Manifest should include the prompt item');
+      assert.strictEqual(prompt.id, 'summarize', 'Prompt id should not retain the .prompt suffix');
+    });
+  });
+
   describe('README asset', () => {
     it('should record the README basename when the collection declares a readme', () => {
       const collectionYaml = `


### PR DESCRIPTION
## Description

Bundle installation produced files with a doubled type extension under the user
profile — e.g. `investigate.prompt.md` installed as `investigate.prompt.prompt.md`
and `AcusInvestigator.agent.md` as `AcusInvestigator.agent.agent.md`. This exposes
the agent under the wrong name (`AcusInvestigator.agent` instead of
`AcusInvestigator`), breaking `agent:` references between prompts and agents.

Root cause is a mismatch between how the manifest `id` is produced and how it is
consumed:

- **Producer** — `lib/bin/generate-manifest.js` computed each item id with
  `path.basename(itemPath, '.md')`, stripping only the last extension. The compound
  `.prompt` / `.agent` segment survived into the manifest `id`.
- **Consumer** — `getTargetFileName(id, type)` unconditionally appended the full
  `.prompt.md` / `.agent.md` extension, so an id already ending in `.prompt` became
  `foo.prompt.prompt.md`.

Fixed on both sides. The other adapters (`src/adapters/*-adapter.ts`) already strip
the full compound suffix, so only these two spots were wrong.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #184

> Supersedes the stale draft #185: that branch edits `src/utils/copilotFileTypeUtils.ts`
> (camelCase), a path that no longer exists after the repo moved to kebab-case
> `src/utils/copilot-file-type-utils.ts`, and it only touches the consumer side. This PR
> applies the consumer-side guard to the current file and also fixes the producer
> (`generate-manifest.js`) so bad ids stop being generated at the source. #185 can be
> closed in favour of this.

## Changes Made

- `lib/bin/generate-manifest.js`: derive the suffix to strip from the item's own
  `type` (`.<type>.md`) instead of only stripping `.md`, so the manifest `id` no
  longer retains the compound suffix. Generic — no hardcoded type list; falls back to
  the plain `.md` strip when the filename doesn't follow the convention.
- `src/utils/copilot-file-type-utils.ts`: `getTargetFileName` now defensively strips a
  trailing type suffix from the `id` (derived from `FILE_EXTENSIONS`, case-insensitive)
  before appending, so already-published manifests carrying a doubled id install
  correctly too.
- Regression tests for both.

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

### Manual Testing Steps

1. In `lib/`: `npm run build && npm test` — new "Item IDs" case passes, all 163 pass.
2. At root: `npm run compile-tests` then run the `getTargetFileName` unit suite —
   new cases pass, all 55 pass.
3. Regenerate a collection manifest and confirm ids are `AcusInvestigator` /
   `investigate` (no doubled suffix); reinstall under a fresh user profile and confirm
   files land as `AcusInvestigator.agent.md` / `investigate.prompt.md`.

### Tested On

- [x] Windows

- [x] VS Code Stable

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Documentation

- [x] No documentation changes needed

## Additional Notes

The generator lives in the published `@prompt-registry/collection-scripts` package, so
collections must regenerate their `deployment-manifest.yml` with the new version for the
producer-side fix to reach install time. The consumer-side guard ships in the extension
and fixes already-published manifests as soon as the extension updates.

Note: the same `getTargetFileName` logic is duplicated in
`packages/core/src/domain/install/copilot-file-type.ts`, but that copy is only consumed by
the not-yet-shipped `packages/*` monorepo and lives in a separate build the extension can't
import today. Left untouched to keep this fix scoped to the shipped extension; happy to
propagate it if you'd prefer.

## Reviewer Guidelines

Please pay special attention to:

- The suffix-stripping in `getTargetFileName` only removes the exact type suffix
  (e.g. `bundle.v1` → `bundle.v1.prompt.md` is preserved).
- Whether you'd like the `packages/core` copy updated in the same PR.

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**
