### PR TITLE
feat: improve KPI for bundles per bundleName

### DIFF
--- a/apps/vscode-extension/src/services/telemetry-service.ts
+++ b/apps/vscode-extension/src/services/telemetry-service.ts
@@ -4,11 +4,15 @@ import {
   Profile,
   RegistrySource,
   SourceSyncedEvent,
+  SourceType,
 } from '../types/registry';
 import {
   TelemetryDocument,
   TelemetryTransport,
 } from '../types/telemetry';
+import {
+  VersionManager,
+} from '../utils/version-manager';
 import {
   RegistryManager,
 } from './registry-manager';
@@ -62,11 +66,16 @@ export class TelemetryService {
   }
 
   private trackBundleEvent(eventName: string, bundle: InstalledBundle): void {
+    const sourceType = (bundle.sourceType as SourceType | undefined) ?? 'unknown';
+    const normalizedBundleId = sourceType === 'github'
+      ? VersionManager.extractBundleIdentity(bundle.bundleId, 'github')
+      : bundle.bundleId;
+
     this.telemetryLogger.logUsage(eventName, {
-      bundleId: bundle.bundleId,
+      bundleId: normalizedBundleId,
       version: bundle.version,
       scope: bundle.scope,
-      sourceType: bundle.sourceType ?? 'unknown'
+      sourceType
     });
   }
 

--- a/apps/vscode-extension/test/services/telemetry-service.test.ts
+++ b/apps/vscode-extension/test/services/telemetry-service.test.ts
@@ -182,6 +182,19 @@ suite('TelemetryService', () => {
         assert.strictEqual(doc.data?.sourceType, 'unknown');
       });
 
+      test('should strip version suffix from GitHub bundle IDs in telemetry payloads', () => {
+        const bundle = createMockInstalledBundle('acme-telemetry-v1.2.3', '1.2.3', {
+          scope: 'user',
+          sourceType: 'github'
+        });
+        emitters.bundleInstalled.fire(bundle);
+
+        const doc = mockTransport.last();
+        assert.strictEqual(doc.eventName, 'bundle.installed');
+        assert.strictEqual(doc.data?.bundleId, 'acme-telemetry');
+        assert.strictEqual(doc.data?.version, '1.2.3');
+      });
+
       test('should track bundle.uninstalled with bundleId', () => {
         emitters.bundleUninstalled.fire('my-bundle');
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -37,7 +37,7 @@ You can also set it in `settings.json`:
 }
 ```
 
-Enabling telemetry helps us understand how the extension is used so we can focus on the features that matter most.
+Enabling telemetry helps us understand how the extension is used so we can focus on the features that matter most. For GitHub-based bundle installs, the telemetry payload uses the base bundle identity in the bundleId field and keeps the version in the version field so analytics can aggregate installs correctly.
 
 ## Export/Import Settings
 


### PR DESCRIPTION
## Description

Improve KPI reporting for bundles by aggregating bundle statistics per bundleName without including version information, providing clearer insights into bundle usage patterns across all versions.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧪 Test coverage improvement

## Related Issues

Relates to #

## Changes Made

- Modified telemetry service to aggregate bundle KPI metrics per bundleName without version
- Added comprehensive test coverage for the new telemetry aggregation behavior
- Updated configuration documentation to reflect telemetry changes

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [x] All existing tests pass

### Manual Testing Steps

1. Install VS Code extension
2. Open a workspace with bundles
3. Install a bundle
4. Monitor telemetry output to verify bundle KPI is reported per bundleName only

### Tested On

- [x] macOS

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Documentation

- [x] Configuration documentation updated

## Additional Notes

Bundle KPI now provides aggregated metrics per bundleName, simplifying analysis and reducing metric cardinality by excluding version information.

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**