### PR TITLE
fix(infra): add timeout to gh CLI token provider

### DIFF
--- a/docs/contributor-guide/architecture/authentication.md
+++ b/docs/contributor-guide/architecture/authentication.md
@@ -32,6 +32,10 @@ private async performAuthentication(): Promise<string | undefined> {
 }
 ```
 
+## GitHub CLI Timeout
+
+The GitHub CLI step (step 3) includes a **3-second timeout** to prevent indefinite hangs when `gh` is unresponsive, missing, or misconfigured. If the timeout is exceeded, the authentication chain falls through to "No auth" and the request proceeds with rate-limited anonymous access. This timeout ensures the extension remains responsive during authentication edge cases.
+
 ## Token Format
 
 Uses GitHub token format:

--- a/packages/infra/src/auth/gh-cli-token-provider.ts
+++ b/packages/infra/src/auth/gh-cli-token-provider.ts
@@ -32,8 +32,12 @@ import {
 
 export type ExecFn = (command: string) => Promise<{ stdout: string }>;
 
+const GH_CLI_TIMEOUT_MS = 3000;
+
 export class GhCliTokenProvider implements TokenProvider {
-  public constructor(private readonly execFn: ExecFn = promisify(exec)) {}
+  public constructor(
+    private readonly execFn: ExecFn = (cmd) => promisify(exec)(cmd, { timeout: GH_CLI_TIMEOUT_MS })
+  ) {}
 
   public async getToken(host: string): Promise<string | undefined> {
     if (!isGitHubHost(host)) {


### PR DESCRIPTION
## Description

Fixes a test timeout failure in the CI build where the gh CLI token provider was hanging indefinitely during test execution. Adds a 3-second timeout to prevent the gh CLI token command from hanging, ensuring the authentication flow remains responsive even when gh is slow or unresponsive.

**Related build failure:** https://github.com/AmadeusITGroup/ai-primitives-hub/actions/runs/29904189574/job/88872584613?pr=337

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Added `GH_CLI_TIMEOUT_MS` constant (3 seconds)
- Updated `GhCliTokenProvider` constructor to apply timeout to the `exec` call
- This prevents indefinite hangs when the gh CLI command is unresponsive (fixes test timeout: "Timeout of 5000ms exceeded")

## Testing

- [x] Fixes the failing test timeout in CI
- [x] Existing unit tests pass with timeout
- [x] Manual testing completed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

This fix ensures the CLI and future VS Code extension remain responsive during authentication attempts, even in edge cases where the gh CLI is slow or hanging. The timeout prevents test suites from hanging indefinitely when the gh CLI command is unresponsive.