### PR TITLE
feat(vscode-extension): batch hub source registration with a single storage write

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,17 +9,17 @@
       "name": "Run Extension",
       "type": "extensionHost",
       "request": "launch",
-      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
-      "outFiles": ["${workspaceFolder}/dist/**/*.js"],
-      "preLaunchTask": "npm: compile"
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}/apps/vscode-extension"],
+      "outFiles": ["${workspaceFolder}/apps/vscode-extension/dist/**/*.js"],
+      "preLaunchTask": "pnpm: compile"
     },
     {
       "name": "Run Extension (Local ES Proxy)",
       "type": "extensionHost",
       "request": "launch",
-      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
-      "outFiles": ["${workspaceFolder}/dist/**/*.js"],
-      "preLaunchTask": "npm: compile",
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}/apps/vscode-extension"],
+      "outFiles": ["${workspaceFolder}/apps/vscode-extension/dist/**/*.js"],
+      "preLaunchTask": "pnpm: compile",
       "env": {
         "ES_LOCAL_URL": "http://localhost:8080"
       }
@@ -29,14 +29,14 @@
       "type": "extensionHost",
       "request": "launch",
       "args": [
-        "--extensionDevelopmentPath=${workspaceFolder}",
-        "--extensionTestsPath=${workspaceFolder}/test-out/test/suite/index"
+        "--extensionDevelopmentPath=${workspaceFolder}/apps/vscode-extension",
+        "--extensionTestsPath=${workspaceFolder}/apps/vscode-extension/test-dist/test/suite/index"
       ],
       "outFiles": [
-        "${workspaceFolder}/out/**/*.js",
-        "${workspaceFolder}/test-out/**/*.js"
+        "${workspaceFolder}/apps/vscode-extension/dist/**/*.js",
+        "${workspaceFolder}/apps/vscode-extension/test-dist/**/*.js"
       ],
-      "preLaunchTask": "npm: compile"
+      "preLaunchTask": "pnpm: compile"
     }
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,5 +29,8 @@
     "typescript",
     "json",
     "yaml"
-  ]
+  ],
+  "chat.tools.terminal.autoApprove": {
+    "pnpm": true
+  }
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -13,6 +13,26 @@
       "id": "testFile",
       "type": "promptString",
       "description": "Test file path relative to apps/vscode-extension (e.g. test/services/telemetry-service.test.ts)"
+    },
+    {
+      "id": "lintFiles",
+      "type": "promptString",
+      "description": "Whitespace-separated workspace-relative files to lint (e.g. packages/app/src/foo.ts apps/vscode-extension/src/bar.ts)"
+    },
+    {
+      "id": "extensionTestFiles",
+      "type": "promptString",
+      "description": "Whitespace-separated test paths relative to apps/vscode-extension (e.g. test/services/foo.test.ts test/storage/bar.test.ts)"
+    },
+    {
+      "id": "packageDirectory",
+      "type": "promptString",
+      "description": "Package directory relative to the workspace (e.g. packages/app)"
+    },
+    {
+      "id": "packageTestFiles",
+      "type": "promptString",
+      "description": "Whitespace-separated Vitest file paths relative to the selected package (e.g. test/registry/foo.test.ts)"
     }
   ],
   "tasks": [
@@ -95,6 +115,17 @@
     },
     {
       "type": "shell",
+      "label": "pnpm: lint files",
+      "command": "pnpm exec eslint ${input:lintFiles}",
+      "problemMatcher": ["$eslint-stylish"],
+      "group": "test",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared"
+      }
+    },
+    {
+      "type": "shell",
       "label": "pnpm: test:unit",
       "command": "pnpm",
       "args": ["run", "test:unit"],
@@ -137,6 +168,28 @@
       "label": "pnpm: test:one",
       "command": "pnpm",
       "args": ["-C", "apps/vscode-extension", "run", "test:one", "--", "${input:testFile}"],
+      "problemMatcher": [],
+      "group": "test",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared"
+      }
+    },
+    {
+      "type": "shell",
+      "label": "pnpm: test extension files",
+      "command": "pnpm -C apps/vscode-extension run test:one -- ${input:extensionTestFiles}",
+      "problemMatcher": [],
+      "group": "test",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared"
+      }
+    },
+    {
+      "type": "shell",
+      "label": "pnpm: test package files",
+      "command": "pnpm -C ${input:packageDirectory} exec vitest run ${input:packageTestFiles}",
       "problemMatcher": [],
       "group": "test",
       "presentation": {

--- a/apps/vscode-extension/schemas/apm.schema.json
+++ b/apps/vscode-extension/schemas/apm.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "APM Package Manifest",
+  "type": "object",
+  "required": ["name", "version", "description", "author"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z0-9._-]+$"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+(-[a-zA-Z0-9.-]+)?$"
+    },
+    "description": {
+      "type": "string",
+      "maxLength": 500
+    },
+    "author": {
+      "type": "string"
+    },
+    "license": {
+      "type": "string"
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "maxLength": 30
+      },
+      "maxItems": 20
+    },
+    "dependencies": {
+      "type": "object",
+      "properties": {
+        "apm": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "mcp": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "scripts": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/apps/vscode-extension/schemas/collection.schema.json
+++ b/apps/vscode-extension/schemas/collection.schema.json
@@ -1,0 +1,345 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/AmadeusITGroup/prompt-registry/schemas/collection.schema.json",
+  "title": "Awesome Copilot Collection",
+  "description": "Schema for Copilot prompt collection files",
+  "type": "object",
+  "required": [
+    "id",
+    "name",
+    "description",
+    "items"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Unique identifier for the collection (lowercase letters, numbers, and hyphens only)",
+      "pattern": "^[a-z0-9-]+$",
+      "minLength": 1,
+      "examples": [
+        "my-prompts",
+        "python-helpers",
+        "git-workflows"
+      ]
+    },
+    "name": {
+      "type": "string",
+      "description": "Human-readable name of the collection",
+      "minLength": 1,
+      "maxLength": 100,
+      "examples": [
+        "My Awesome Prompts",
+        "Python Development Helpers"
+      ]
+    },
+    "description": {
+      "type": "string",
+      "description": "Detailed description of the collection's purpose and contents",
+      "minLength": 1,
+      "maxLength": 500
+    },
+    "items": {
+      "type": "array",
+      "description": "List of resources in this collection",
+      "minItems": 0,
+      "maxItems": 50,
+      "items": {
+        "type": "object",
+        "required": [
+          "path",
+          "kind"
+        ],
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "Relative path to the resource file",
+            "minLength": 1,
+            "examples": [
+              "prompts/my-prompt.prompt.md",
+              "instructions/code-style.instructions.md",
+              "skills/my-skill/SKILL.md"
+            ]
+          },
+          "kind": {
+            "type": "string",
+            "description": "Type of resource",
+            "enum": [
+              "prompt",
+              "instruction",
+              "chat-mode",
+              "agent",
+              "skill",
+              "plugin",
+              "hook"
+            ]
+          },
+          "title": {
+            "type": "string",
+            "description": "Optional display title for the resource"
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional description of the resource"
+          },
+          "tags": {
+            "type": "array",
+            "description": "Optional tags for categorization",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "mcp": {
+      "type": "object",
+      "description": "Model Context Protocol (MCP) server configurations to be installed with this collection",
+      "properties": {
+        "items": {
+          "type": "object",
+          "description": "MCP servers to install (follows mcp.json spec)",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "type": "object",
+              "description": "MCP server configuration",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "description": "Transport type for the MCP server",
+                  "enum": ["stdio", "http", "sse"],
+                  "default": "stdio",
+                  "examples": ["stdio", "http", "sse"]
+                },
+                "command": {
+                  "type": "string",
+                  "description": "Command to start the MCP server (required for stdio type)",
+                  "examples": [
+                    "node",
+                    "python",
+                    "npx"
+                  ]
+                },
+                "args": {
+                  "type": "array",
+                  "description": "Arguments for the server command (stdio only)",
+                  "items": {
+                    "type": "string"
+                  },
+                  "examples": [
+                    [
+                      "${bundlePath}/server.js"
+                    ],
+                    [
+                      "${bundlePath}/mcp_server.py"
+                    ],
+                    [
+                      "${env:HOME}/.local/bin/my-mcp-server"
+                    ]
+                  ]
+                },
+                "env": {
+                  "type": "object",
+                  "description": "Environment variables for the server (stdio only)",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "envFile": {
+                  "type": "string",
+                  "description": "Path to an environment file to load variables from (stdio only)",
+                  "examples": [
+                    "${workspaceFolder}/.env",
+                    "${bundlePath}/.env"
+                  ]
+                },
+                "url": {
+                  "type": "string",
+                  "description": "URL for the remote MCP server (required for http/sse types). Supports HTTP/HTTPS URLs, Unix sockets (unix:///path), and Windows named pipes (pipe:///pipe/name)",
+                  "examples": [
+                    "http://localhost:3000/mcp",
+                    "https://api.example.com/mcp",
+                    "unix:///tmp/mcp.sock",
+                    "pipe:///pipe/mcp-server"
+                  ]
+                },
+                "headers": {
+                  "type": "object",
+                  "description": "HTTP headers for authentication or configuration (http/sse only)",
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "examples": [
+                    {
+                      "Authorization": "Bearer ${input:api-token}"
+                    }
+                  ]
+                },
+                "disabled": {
+                  "type": "boolean",
+                  "description": "Whether the server is disabled",
+                  "default": false
+                }
+              },
+              "allOf": [
+                {
+                  "if": {
+                    "properties": {
+                      "type": {
+                        "const": "stdio"
+                      }
+                    }
+                  },
+                  "then": {
+                    "required": ["command"]
+                  }
+                },
+                {
+                  "if": {
+                    "not": {
+                      "properties": {
+                        "type": {
+                          "const": "stdio"
+                        }
+                      }
+                    },
+                    "required": ["type"]
+                  },
+                  "then": {
+                    "required": ["url"]
+                  }
+                },
+                {
+                  "if": {
+                    "properties": {
+                      "type": {
+                        "enum": ["http", "sse"]
+                      }
+                    },
+                    "required": ["type"]
+                  },
+                  "then": {
+                    "required": ["url"]
+                  }
+                },
+                {
+                  "if": {
+                    "not": {
+                      "required": ["type"]
+                    }
+                  },
+                  "then": {
+                    "required": ["command"]
+                  }
+                }
+              ],
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "inputs": {
+          "type": "array",
+          "description": "Input definitions for MCP server secrets or configurable values (follows VS Code mcp.json inputs spec)",
+          "items": {
+            "type": "object",
+            "required": ["id", "type"],
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "Unique identifier for this input, referenced in args/env as ${input:id}",
+                "pattern": "^[a-zA-Z0-9_-]+$",
+                "examples": ["apiToken", "bbUser", "ocToken"]
+              },
+              "type": {
+                "type": "string",
+                "description": "Input type",
+                "enum": ["promptString", "pickString", "command"]
+              },
+              "description": {
+                "type": "string",
+                "description": "Human-readable description shown to the user"
+              },
+              "password": {
+                "type": "boolean",
+                "description": "If true, the input is masked (for secrets). Only applies to promptString.",
+                "default": false
+              },
+              "default": {
+                "type": "string",
+                "description": "Default value pre-filled in the prompt"
+              },
+              "options": {
+                "type": "array",
+                "description": "List of options for pickString type",
+                "items": { "type": "string" }
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "readme": {
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Optional path to a README file for the collection",
+          "examples": [
+            "README.md",
+            "docs/collection-overview.md"
+          ]
+        }
+      }
+    },
+    "version": {
+      "type": "string",
+      "description": "Version of the collection",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$",
+      "examples": [
+        "1.0.0",
+        "2.1.3"
+      ]
+    },
+    "author": {
+      "type": "string",
+      "description": "Author of the collection"
+    },
+    "tags": {
+      "type": "array",
+      "description": "Tags for the entire collection",
+      "items": {
+        "type": "string"
+      }
+    },
+    "display": {
+      "type": "object",
+      "description": "Display preferences for the collection",
+      "properties": {
+        "color": {
+          "type": "string",
+          "description": "Color theme for the collection"
+        },
+        "icon": {
+          "type": "string",
+          "description": "Icon identifier for the collection"
+        },
+        "ordering": {
+          "type": "string",
+          "description": "How to order items in the collection",
+          "enum": [
+            "manual",
+            "alphabetical"
+          ]
+        },
+        "show_badge": {
+          "type": "boolean",
+          "description": "Whether to show a badge for the collection"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/apps/vscode-extension/schemas/default-hubs-config.schema.json
+++ b/apps/vscode-extension/schemas/default-hubs-config.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Default Hubs Configuration",
+  "description": "Configuration for default hubs offered during extension installation",
+  "type": "object",
+  "properties": {
+    "defaultHubs": {
+      "type": "array",
+      "description": "List of default hub configurations",
+      "items": {
+        "type": "object",
+        "required": ["name", "description", "icon", "reference"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Display name for the hub"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description shown in the selector"
+          },
+          "icon": {
+            "type": "string",
+            "description": "VS Code codicon name (without $() wrapper)",
+            "examples": ["cloud", "organization", "repo", "globe"]
+          },
+          "reference": {
+            "type": "object",
+            "description": "Hub reference configuration",
+            "required": ["type", "location"],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["github", "local", "url"],
+                "description": "Type of hub source"
+              },
+              "location": {
+                "type": "string",
+                "description": "Location of the hub (repo path, local path, or URL)"
+              },
+              "ref": {
+                "type": "string",
+                "description": "Git ref for GitHub sources (branch, tag, or commit)",
+                "default": "main"
+              },
+              "autoSync": {
+                "type": "boolean",
+                "description": "Whether to automatically sync this hub",
+                "default": false
+              }
+            }
+          },
+          "recommended": {
+            "type": "boolean",
+            "description": "Whether this is the recommended default hub",
+            "default": false
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether to show this hub in first-run selector",
+            "default": true
+          }
+        }
+      }
+    }
+  },
+  "required": ["defaultHubs"]
+}

--- a/apps/vscode-extension/schemas/hub-config.schema.json
+++ b/apps/vscode-extension/schemas/hub-config.schema.json
@@ -1,0 +1,389 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/AmadeusITGroup/prompt-registry/blob/main/schemas/hub-config.schema.json",
+  "title": "Hub Configuration Schema",
+  "description": "JSON Schema for Prompt Registry hub configuration files",
+  "type": "object",
+  "required": [
+    "version",
+    "metadata",
+    "sources"
+  ],
+  "properties": {
+    "version": {
+      "type": "string",
+      "description": "Semantic version of the hub configuration format",
+      "pattern": "^\\d+\\.\\d+\\.\\d+(-[a-zA-Z0-9.-]+)?$"
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Hub metadata and descriptive information",
+      "required": [
+        "name",
+        "description",
+        "maintainer",
+        "updatedAt"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Human-readable name of the hub",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "description": {
+          "type": "string",
+          "description": "Detailed description of the hub's purpose and content",
+          "minLength": 1,
+          "maxLength": 500
+        },
+        "maintainer": {
+          "type": "string",
+          "description": "Name or identifier of the hub maintainer",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "updatedAt": {
+          "type": "string",
+          "description": "ISO 8601 timestamp of last update",
+          "format": "date-time"
+        },
+        "checksum": {
+          "type": "string",
+          "description": "Optional integrity checksum for the hub configuration",
+          "pattern": "^(sha256|sha512):[a-f0-9]+$"
+        }
+      }
+    },
+    "sources": {
+      "type": "array",
+      "description": "List of bundle sources available in this hub",
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "type",
+          "enabled",
+          "priority"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the source",
+            "pattern": "^[a-zA-Z0-9-_]+$",
+            "minLength": 1,
+            "maxLength": 50
+          },
+          "type": {
+            "type": "string",
+            "description": "Type of the source repository (github, local, awesome-copilot, local-awesome-copilot, apm, local-apm, skills)",
+            "enum": [
+              "github",
+              "local",
+              "awesome-copilot",
+              "local-awesome-copilot",
+              "apm",
+              "local-apm",
+              "skills"
+            ]
+          },
+          "url": {
+            "type": "string",
+            "description": "URL or path to the source (optional if repository is specified)"
+          },
+          "repository": {
+            "type": "string",
+            "description": "GitHub repository in owner/repo format"
+          },
+          "branch": {
+            "type": "string",
+            "description": "Git branch name"
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable name of the source"
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether this source is currently active"
+          },
+          "priority": {
+            "type": "number",
+            "description": "Priority order for source resolution (higher = higher priority)",
+            "minimum": 0,
+            "maximum": 100
+          },
+          "config": {
+            "type": "object",
+            "description": "Source-specific configuration settings (e.g., branch, collectionsPath for awesome-copilot sources)",
+            "properties": {
+              "branch": {
+                "type": "string",
+                "description": "Git branch name (for git-based sources)"
+              },
+              "collectionsPath": {
+                "type": "string",
+                "description": "Path to collections directory (for awesome-copilot sources)"
+              },
+              "indexFile": {
+                "type": "string",
+                "description": "Index file name (for awesome-copilot sources)"
+              }
+            }
+          },
+          "metadata": {
+            "type": "object",
+            "description": "Additional source metadata",
+            "properties": {
+              "description": {
+                "type": "string",
+                "description": "Source description"
+              },
+              "homepage": {
+                "type": "string",
+                "description": "Source homepage URL"
+              },
+              "contact": {
+                "type": "string",
+                "description": "Contact information"
+              }
+            }
+          }
+        }
+      }
+    },
+    "profiles": {
+      "type": "array",
+      "description": "Predefined bundle profiles/collections",
+      "default": [],
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "description",
+          "bundles"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the profile",
+            "pattern": "^[a-zA-Z0-9-_]+$",
+            "minLength": 1,
+            "maxLength": 50
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable name of the profile",
+            "minLength": 1,
+            "maxLength": 100
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the profile's purpose",
+            "minLength": 1,
+            "maxLength": 500
+          },
+          "icon": {
+            "type": "string",
+            "description": "Optional icon/emoji for the profile"
+          },
+          "active": {
+            "type": "boolean",
+            "description": "Whether this profile is currently active"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "ISO 8601 timestamp of creation",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "ISO 8601 timestamp of last update",
+            "format": "date-time"
+          },
+          "bundles": {
+            "type": "array",
+            "description": "List of bundles included in this profile",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": [
+                "id",
+                "version",
+                "source",
+                "required"
+              ],
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "Bundle identifier",
+                  "pattern": "^[\\w\\.\\-]+$",
+                  "minLength": 1,
+                  "maxLength": 200
+                },
+                "version": {
+                  "type": "string",
+                  "description": "Bundle version (semver or 'latest')",
+                  "pattern": "^(\\d+\\.\\d+\\.\\d+(-[a-zA-Z0-9.-]+)?|latest)$"
+                },
+                "source": {
+                  "type": "string",
+                  "description": "Source ID where this bundle is available",
+                  "pattern": "^[a-zA-Z0-9-_]+$",
+                  "minLength": 1,
+                  "maxLength": 50
+                },
+                "required": {
+                  "type": "boolean",
+                  "description": "Whether this bundle is mandatory for the profile"
+                }
+              }
+            }
+          },
+          "path": {
+            "type": "array",
+            "description": "Optional path hierarchy for organizing this profile in the UI",
+            "items": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 50,
+              "pattern": "^[a-zA-Z0-9-_. ]+$"
+            }
+          }
+        }
+      }
+    },
+    "configuration": {
+      "type": "object",
+      "description": "Optional hub-level configuration settings",
+      "properties": {
+        "autoSync": {
+          "type": "boolean",
+          "description": "Enable automatic synchronization with hub sources"
+        },
+        "syncInterval": {
+          "type": "number",
+          "description": "Sync interval in seconds",
+          "minimum": 60,
+          "maximum": 86400
+        },
+        "strictMode": {
+          "type": "boolean",
+          "description": "Enable strict validation and security checks"
+        }
+      }
+    },
+    "telemetry": {
+      "type": "object",
+      "description": "Telemetry configuration for this hub",
+      "properties": {
+        "elasticSearch": {
+          "type": "object",
+          "description": "ES telemetry proxy configuration",
+          "required": ["node"],
+          "properties": {
+            "node": {
+              "type": "string",
+              "description": "ES telemetry proxy URL (e.g. https://es-proxy.internal:8080)",
+              "format": "uri"
+            },
+            "indexPrefix": {
+              "type": "string",
+              "description": "Custom index prefix (default: prompt-registry-telemetry)",
+              "pattern": "^[a-z0-9-]+$",
+              "minLength": 1,
+              "maxLength": 100
+            }
+          }
+        }
+      }
+    },
+    "engagement": {
+      "type": "object",
+      "description": "Engagement features configuration (telemetry, ratings, feedback)",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable engagement features for this hub"
+        },
+        "backend": {
+          "type": "object",
+          "description": "Backend configuration for engagement data storage",
+          "required": ["type"],
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "Backend type for engagement data",
+              "enum": ["file", "github-issues", "github-discussions", "api"]
+            },
+            "repository": {
+              "type": "string",
+              "description": "GitHub repository in owner/repo format (for github-issues or github-discussions backends)",
+              "pattern": "^[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$"
+            },
+            "apiUrl": {
+              "type": "string",
+              "description": "API endpoint URL (for api backend)",
+              "format": "uri"
+            }
+          }
+        },
+        "telemetry": {
+          "type": "object",
+          "description": "Telemetry configuration",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable telemetry collection"
+            },
+            "anonymize": {
+              "type": "boolean",
+              "description": "Anonymize telemetry data"
+            }
+          }
+        },
+        "ratings": {
+          "type": "object",
+          "description": "Rating configuration",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable rating features"
+            },
+            "ratingsUrl": {
+              "type": "string",
+              "description": "URL to pre-computed ratings.json file (static hosting)",
+              "format": "uri"
+            }
+          }
+        },
+        "feedback": {
+          "type": "object",
+          "description": "Feedback configuration",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable feedback features"
+            },
+            "requireRating": {
+              "type": "boolean",
+              "description": "Require rating when submitting feedback"
+            },
+            "maxLength": {
+              "type": "number",
+              "description": "Maximum feedback comment length",
+              "minimum": 100,
+              "maximum": 10000
+            },
+            "feedbackUrl": {
+              "type": "string",
+              "description": "URL to pre-computed feedbacks.json file (static hosting)",
+              "format": "uri"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/vscode-extension/schemas/lockfile.schema.json
+++ b/apps/vscode-extension/schemas/lockfile.schema.json
@@ -1,0 +1,243 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/AmadeusITGroup/prompt-registry/schemas/lockfile.schema.json",
+  "title": "Prompt Registry Lockfile",
+  "description": "Schema for prompt-registry.lock.json files that track repository-level bundle installations",
+  "type": "object",
+  "required": [
+    "$schema",
+    "version",
+    "generatedAt",
+    "generatedBy",
+    "bundles",
+    "sources"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "JSON schema reference for validation",
+      "examples": [
+        "https://github.com/AmadeusITGroup/prompt-registry/schemas/lockfile.schema.json"
+      ]
+    },
+    "version": {
+      "type": "string",
+      "description": "Lockfile schema version",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$",
+      "examples": [
+        "2.0.0"
+      ]
+    },
+    "generatedAt": {
+      "type": "string",
+      "description": "ISO 8601 timestamp when the lockfile was generated",
+      "format": "date-time",
+      "examples": [
+        "2026-01-13T10:30:00.000Z"
+      ]
+    },
+    "generatedBy": {
+      "type": "string",
+      "description": "Extension name and version that generated the lockfile",
+      "examples": [
+        "prompt-registry@1.0.0"
+      ]
+    },
+    "bundles": {
+      "type": "object",
+      "description": "Map of bundle IDs to their metadata",
+      "additionalProperties": {
+        "$ref": "#/definitions/bundleEntry"
+      }
+    },
+    "sources": {
+      "type": "object",
+      "description": "Map of source IDs to their configuration",
+      "additionalProperties": {
+        "$ref": "#/definitions/sourceEntry"
+      }
+    },
+    "hubs": {
+      "type": "object",
+      "description": "Optional map of hub IDs to their configuration",
+      "additionalProperties": {
+        "$ref": "#/definitions/hubEntry"
+      }
+    },
+    "profiles": {
+      "type": "object",
+      "description": "Optional map of profile IDs to their configuration",
+      "additionalProperties": {
+        "$ref": "#/definitions/profileEntry"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "bundleEntry": {
+      "type": "object",
+      "description": "Bundle entry in the lockfile",
+      "required": [
+        "version",
+        "sourceId",
+        "sourceType",
+        "installedAt",
+        "files"
+      ],
+      "properties": {
+        "version": {
+          "type": "string",
+          "description": "Semantic version of the installed bundle",
+          "examples": [
+            "1.0.0",
+            "2.1.3"
+          ]
+        },
+        "sourceId": {
+          "type": "string",
+          "description": "ID of the source this bundle was installed from",
+          "minLength": 1
+        },
+        "sourceType": {
+          "type": "string",
+          "description": "Type of the source",
+          "enum": [
+            "github",
+            "local",
+            "awesome-copilot",
+            "local-awesome-copilot",
+            "apm",
+            "local-apm"
+          ]
+        },
+        "installedAt": {
+          "type": "string",
+          "description": "ISO 8601 timestamp when bundle was installed",
+          "format": "date-time"
+        },
+        "commitMode": {
+          "type": "string",
+          "description": "DEPRECATED: Commit mode is now implicit based on which lockfile contains the entry. Bundles in prompt-registry.lock.json are implicitly 'commit' mode, bundles in prompt-registry.local.lock.json are implicitly 'local-only' mode. This field is retained for backward compatibility but should not be included in new entries.",
+          "enum": [
+            "commit",
+            "local-only"
+          ]
+        },
+        "checksum": {
+          "type": "string",
+          "description": "Optional checksum of the bundle archive"
+        },
+        "files": {
+          "type": "array",
+          "description": "List of installed files with their checksums",
+          "items": {
+            "$ref": "#/definitions/fileEntry"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "fileEntry": {
+      "type": "object",
+      "description": "File entry within a bundle",
+      "required": [
+        "path",
+        "checksum"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Relative path from repository root",
+          "minLength": 1,
+          "examples": [
+            ".github/prompts/my-prompt.prompt.md",
+            ".github/agents/my-agent.agent.md"
+          ]
+        },
+        "checksum": {
+          "type": "string",
+          "description": "SHA256 checksum of the file contents",
+          "pattern": "^[a-f0-9]{64}$"
+        }
+      },
+      "additionalProperties": false
+    },
+    "sourceEntry": {
+      "type": "object",
+      "description": "Source configuration entry",
+      "required": [
+        "type",
+        "url"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Source type",
+          "enum": [
+            "github",
+            "local",
+            "awesome-copilot",
+            "local-awesome-copilot",
+            "apm",
+            "local-apm"
+          ]
+        },
+        "url": {
+          "type": "string",
+          "description": "URL of the source",
+          "minLength": 1
+        },
+        "branch": {
+          "type": "string",
+          "description": "Optional Git branch for git-based sources"
+        }
+      },
+      "additionalProperties": false
+    },
+    "hubEntry": {
+      "type": "object",
+      "description": "Hub configuration entry",
+      "required": [
+        "name",
+        "url"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Display name of the hub",
+          "minLength": 1
+        },
+        "url": {
+          "type": "string",
+          "description": "URL of the hub configuration",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "profileEntry": {
+      "type": "object",
+      "description": "Profile entry in the lockfile",
+      "required": [
+        "name",
+        "bundleIds"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Display name of the profile",
+          "minLength": 1
+        },
+        "bundleIds": {
+          "type": "array",
+          "description": "List of bundle IDs included in this profile",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/apps/vscode-extension/src/services/hub-manager.ts
+++ b/apps/vscode-extension/src/services/hub-manager.ts
@@ -29,6 +29,7 @@ import type {
   HubConfig as CoreHubConfig,
   ValidationResult as CoreValidationResult,
   ProfileLifecycleSync,
+  RegistrySource,
 } from '@ai-primitives-hub/core';
 import {
   CompositeHubResolver,
@@ -562,7 +563,8 @@ export class HubManager {
         hubSources,
         {
           listSources: () => this.registryManager.listSources(),
-          addSource: (source) => this.registryManager.addSource(source),
+          addSource: (source) => this.registryManager.addSource(source, { validate: false }),
+          addSources: (sources: RegistrySource[]) => this.registryManager.addSources(sources, { validate: false }),
           updateSource: (sourceId, updates) => this.registryManager.updateSource(sourceId, updates)
         },
         this.translateLogEvent

--- a/apps/vscode-extension/src/services/registry-manager.ts
+++ b/apps/vscode-extension/src/services/registry-manager.ts
@@ -801,27 +801,57 @@ export class RegistryManager {
   /**
    * Add a new registry source
    * @param source
+   * @param options Registration options. Hub sources can skip remote validation
+   * because their configuration has already passed hub schema validation.
+   * @param options.validate Whether to validate the source remotely before registration.
    */
-  public async addSource(source: RegistrySource): Promise<void> {
+  public async addSource(
+    source: RegistrySource,
+    options: { validate?: boolean } = {}
+  ): Promise<void> {
     this.logger.info(`Adding source: ${source.name}`);
+    await this.addSources([source], options);
+    this.logger.info(`Source '${source.name}' added successfully`);
+  }
 
-    // Validate source (with global token if applicable)
-    const enrichedSource = this.enrichSourceWithGlobalToken(source);
-    const adapter = createRegistryAdapter(enrichedSource);
-    const validation = await adapter.validate();
+  /**
+   * Add registry sources with one storage write.
+   * @param sources
+   * @param options Registration options.
+   * @param options.validate Whether to validate sources remotely before registration.
+   */
+  public async addSources(
+    sources: RegistrySource[],
+    options: { validate?: boolean } = {}
+  ): Promise<void> {
+    const sourceAdapters = sources.map((source) => ({
+      source,
+      adapter: createRegistryAdapter(this.enrichSourceWithGlobalToken(source))
+    }));
 
-    if (!validation.valid) {
-      throw new Error(`Source validation failed: ${validation.errors.join(', ')}`);
+    if (options.validate !== false) {
+      const validations = await Promise.all(sourceAdapters.map(async ({ source, adapter }) => ({
+        source,
+        validation: await adapter.validate()
+      })));
+
+      const invalid = validations.find(({ validation }) => !validation.valid);
+      if (invalid) {
+        const errors = invalid.validation.errors.join(', ');
+        throw new Error(`Source validation failed for '${invalid.source.name}': ${errors}`);
+      }
     }
 
-    await this.storage.addSource(source);
-    this.adapters.set(source.id, adapter);
+    await this.storage.addSources(sources);
+    for (const { source, adapter } of sourceAdapters) {
+      this.adapters.set(source.id, adapter);
+    }
 
-    // Update cache
     this.sourcesCache = await this.storage.getSources();
 
-    this._onSourceAdded.fire(source);
-    this.logger.info(`Source '${source.name}' added successfully`);
+    for (const source of sources) {
+      this._onSourceAdded.fire(source);
+    }
   }
 
   /**

--- a/apps/vscode-extension/src/storage/registry-storage.ts
+++ b/apps/vscode-extension/src/storage/registry-storage.ts
@@ -233,14 +233,29 @@ export class RegistryStorage {
    * @param source
    */
   public async addSource(source: RegistrySource): Promise<void> {
-    const config = await this.loadConfig();
+    await this.addSources([source]);
+  }
 
-    // Check for duplicate IDs
-    if (config.sources.some((s) => s.id === source.id)) {
-      throw new Error(`Source with ID '${source.id}' already exists`);
+  /**
+   * Add multiple sources with a single configuration write.
+   * @param sources
+   */
+  public async addSources(sources: RegistrySource[]): Promise<void> {
+    if (sources.length === 0) {
+      return;
     }
 
-    config.sources.push(source);
+    const config = await this.loadConfig();
+    const sourceIds = new Set(config.sources.map((source) => source.id));
+
+    for (const source of sources) {
+      if (sourceIds.has(source.id)) {
+        throw new Error(`Source with ID '${source.id}' already exists`);
+      }
+      sourceIds.add(source.id);
+    }
+
+    config.sources.push(...sources);
     await this.saveConfig(config);
   }
 

--- a/apps/vscode-extension/test/services/hub-manager.test.ts
+++ b/apps/vscode-extension/test/services/hub-manager.test.ts
@@ -635,15 +635,26 @@ suite('Hub Source Loading - SourceId Format', () => {
   class MockRegistryManager {
     private sources: RegistrySource[] = [];
     public addSourceCalls: RegistrySource[] = [];
+    public addSourceOptions: ({ validate?: boolean } | undefined)[] = [];
+    public addSourcesCalls = 0;
     public updateSourceCalls: { id: string; updates: Partial<RegistrySource> }[] = [];
 
     public listSources(): Promise<RegistrySource[]> {
       return Promise.resolve([...this.sources]);
     }
 
-    public addSource(source: RegistrySource): Promise<void> {
+    public addSource(source: RegistrySource, options?: { validate?: boolean }): Promise<void> {
       this.sources.push(source);
       this.addSourceCalls.push(source);
+      this.addSourceOptions.push(options);
+      return Promise.resolve();
+    }
+
+    public addSources(sources: RegistrySource[], options?: { validate?: boolean }): Promise<void> {
+      this.sources.push(...sources);
+      this.addSourceCalls.push(...sources);
+      this.addSourceOptions.push(...sources.map(() => options));
+      this.addSourcesCalls++;
       return Promise.resolve();
     }
 
@@ -659,6 +670,8 @@ suite('Hub Source Loading - SourceId Format', () => {
     public reset(): void {
       this.sources = [];
       this.addSourceCalls = [];
+      this.addSourceOptions = [];
+      this.addSourcesCalls = 0;
       this.updateSourceCalls = [];
     }
 
@@ -754,6 +767,17 @@ suite('Hub Source Loading - SourceId Format', () => {
           `Source ID "${source.id}" should NOT start with 'hub-' (legacy format)`
         );
       }
+    });
+
+    test('loadHubSources() should register schema-validated hub sources without remote validation', async () => {
+      await hubManager.importHub(localRef, 'trusted-hub');
+
+      assert.ok(mockRegistry.addSourceOptions.length > 0, 'Hub sources should be registered');
+      assert.ok(
+        mockRegistry.addSourceOptions.every((options) => options?.validate === false),
+        'Hub source registration should skip remote validation'
+      );
+      assert.strictEqual(mockRegistry.addSourcesCalls, 1, 'Hub sources should be registered in one batch');
     });
   });
 

--- a/apps/vscode-extension/test/services/registry-manager.test.ts
+++ b/apps/vscode-extension/test/services/registry-manager.test.ts
@@ -663,6 +663,68 @@ suite('RegistryManager - Source Management', () => {
     assert.ok(factoryStub.called, 'Adapter factory should be called');
     assert.ok(mockAdapter.validate.called, 'Adapter validation should be called');
   });
+
+  test('should register a trusted source without remote validation', async () => {
+    const trustedSource: RegistrySource = {
+      id: 'trusted-source',
+      name: 'Trusted Hub Source',
+      type: 'github',
+      url: 'https://github.com/example/trusted',
+      enabled: true,
+      priority: 0
+    };
+
+    mockStorage.addSource.resolves();
+    mockStorage.getSources.resolves([trustedSource]);
+
+    const mockAdapter = {
+      validate: sandbox.stub().rejects(new Error('Remote validation should not run')),
+      fetchBundles: sandbox.stub().resolves([])
+    };
+    sandbox.stub(InfraAdapterFactory, 'createRegistryAdapter').returns(mockAdapter as any);
+
+    await manager.addSource(trustedSource, { validate: false });
+
+    const sources = await manager.listSources();
+    assert.ok(sources.some((source) => source.id === trustedSource.id), 'Trusted source should be registered');
+    assert.strictEqual(mockAdapter.validate.callCount, 0, 'Trusted source should not be remotely validated');
+  });
+
+  test('should register trusted sources in one storage operation', async () => {
+    const trustedSources: RegistrySource[] = [
+      {
+        id: 'trusted-source-1',
+        name: 'Trusted Hub Source 1',
+        type: 'github',
+        url: 'https://github.com/example/one',
+        enabled: true,
+        priority: 0
+      },
+      {
+        id: 'trusted-source-2',
+        name: 'Trusted Hub Source 2',
+        type: 'github',
+        url: 'https://github.com/example/two',
+        enabled: true,
+        priority: 1
+      }
+    ];
+
+    mockStorage.addSources.resolves();
+    mockStorage.getSources.resolves(trustedSources);
+
+    const validate = sandbox.stub().rejects(new Error('Remote validation should not run'));
+    sandbox.stub(InfraAdapterFactory, 'createRegistryAdapter').returns({
+      validate,
+      fetchBundles: sandbox.stub().resolves([])
+    } as any);
+
+    await manager.addSources(trustedSources, { validate: false });
+
+    assert.ok(mockStorage.addSources.calledOnceWith(trustedSources), 'Sources should be persisted together');
+    assert.strictEqual(validate.callCount, 0, 'Trusted sources should not be remotely validated');
+    assert.strictEqual((await manager.listSources()).length, 2, 'All trusted sources should be registered');
+  });
 });
 
 suite('RegistryManager - Version Change Installation', () => {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "watch": "pnpm -r watch",
     "lint": "pnpm -r lint",
     "test": "pnpm -r test",
-    "compile": "pnpm -C apps/vscode-extension run compile",
+    "compile": "pnpm -r --filter @ai-primitives-hub/app... run build && pnpm -C apps/vscode-extension run compile",
     "compile-tests": "pnpm -C apps/vscode-extension run compile-tests",
     "test:unit": "pnpm -C apps/vscode-extension run test:unit",
     "package:vsix": "pnpm -C apps/vscode-extension run package:vsix"

--- a/packages/app/src/registry/load-hub-sources.ts
+++ b/packages/app/src/registry/load-hub-sources.ts
@@ -80,10 +80,9 @@ export function findDuplicateSource(
 /**
  * Sync a hub's declared sources into the registry.
  *
- * Per-source `addSource` failures (e.g. a private repo returning 404)
- * are caught, logged, and skipped rather than failing the whole
- * operation — a hub with one bad source should still get its other
- * sources loaded. `listSources`/`updateSource` failures are not
+ * New sources are registered in one operation when the port supports
+ * batching; otherwise per-source `addSource` failures are caught,
+ * logged, and skipped. `listSources`/`updateSource` failures are not
  * caught here; they propagate to the caller.
  * @param hubId Hub identifier the sources belong to.
  * @param hubSources Sources declared in the hub's config.
@@ -108,6 +107,7 @@ export async function loadHubSources(
   let added = 0;
   let updated = 0;
   let skipped = 0;
+  const sourcesToAdd: RegistrySource[] = [];
 
   for (const hubSource of hubSources) {
     if (!hubSource.enabled) {
@@ -175,13 +175,29 @@ export async function loadHubSources(
       hubId
     };
 
+    sourcesToAdd.push(registrySource);
+    existingSources.push(registrySource);
+  }
+
+  if (ports.addSources && sourcesToAdd.length > 0) {
     try {
-      await ports.addSource(registrySource);
-      added++;
+      await ports.addSources(sourcesToAdd);
+      added += sourcesToAdd.length;
     } catch (sourceError) {
       const err = sourceError instanceof Error ? sourceError : new Error(String(sourceError));
-      log('warn', `Failed to add hub source ${sourceId} (${hubSource.name}): ${err.message}`, err);
-      skipped++;
+      log('warn', `Failed to add ${sourcesToAdd.length} hub sources: ${err.message}`, err);
+      skipped += sourcesToAdd.length;
+    }
+  } else {
+    for (const source of sourcesToAdd) {
+      try {
+        await ports.addSource(source);
+        added++;
+      } catch (sourceError) {
+        const err = sourceError instanceof Error ? sourceError : new Error(String(sourceError));
+        log('warn', `Failed to add hub source ${source.id} (${source.name}): ${err.message}`, err);
+        skipped++;
+      }
     }
   }
 

--- a/packages/app/test/registry/load-hub-sources.test.ts
+++ b/packages/app/test/registry/load-hub-sources.test.ts
@@ -49,6 +49,7 @@ function makeRegistrySource(overrides: Partial<RegistrySource> = {}): RegistrySo
 function makePorts(initial: RegistrySource[] = []): {
   listSources: ReturnType<typeof vi.fn>;
   addSource: ReturnType<typeof vi.fn>;
+  addSources?: ReturnType<typeof vi.fn>;
   updateSource: ReturnType<typeof vi.fn>;
   sources: RegistrySource[];
 } {
@@ -58,6 +59,9 @@ function makePorts(initial: RegistrySource[] = []): {
     listSources: vi.fn(async () => [...sources]),
     addSource: vi.fn(async (source: RegistrySource) => {
       sources.push(source);
+    }),
+    addSources: vi.fn(async (newSources: RegistrySource[]) => {
+      sources.push(...newSources);
     }),
     updateSource: vi.fn(async (id: string, updates: Partial<RegistrySource>) => {
       const index = sources.findIndex((s) => s.id === id);
@@ -118,11 +122,28 @@ describe('loadHubSources', () => {
     const result = await loadHubSources('hub-a', [source], ports);
 
     expect(result).toEqual({ added: 1, updated: 0, skipped: 0 });
-    expect(ports.addSource).toHaveBeenCalledWith(expect.objectContaining({
-      id: generateSourceId('awesome-copilot', source.url, { branch: 'main', collectionsPath: 'collections' }),
-      name: 'Source 1',
-      hubId: 'hub-a'
-    }));
+    expect(ports.addSources).toHaveBeenCalledWith([
+      expect.objectContaining({
+        id: generateSourceId('awesome-copilot', source.url, { branch: 'main', collectionsPath: 'collections' }),
+        name: 'Source 1',
+        hubId: 'hub-a'
+      })
+    ]);
+  });
+
+  it('registers all new hub sources in one bulk operation', async () => {
+    const result = await loadHubSources('hub-a', [
+      makeHubSource({ id: 's1', url: 'https://github.com/org/one' }),
+      makeHubSource({ id: 's2', url: 'https://github.com/org/two' }),
+      makeHubSource({ id: 's3', url: 'https://github.com/org/three' })
+    ], ports);
+
+    expect(result).toEqual({ added: 3, updated: 0, skipped: 0 });
+    expect(ports.addSources).toHaveBeenCalledTimes(1);
+    expect(ports.addSources).toHaveBeenCalledWith(expect.arrayContaining([
+      expect.objectContaining({ name: 'Source 1' })
+    ]));
+    expect(ports.addSource).not.toHaveBeenCalled();
   });
 
   it('skips disabled sources', async () => {
@@ -167,6 +188,7 @@ describe('loadHubSources', () => {
   });
 
   it('continues loading remaining sources when one addSource call fails', async () => {
+    ports.addSources = undefined;
     ports.addSource = vi.fn()
       .mockResolvedValueOnce(undefined)
       .mockRejectedValueOnce(new Error('Source validation failed: HTTP 404'))

--- a/packages/core/src/ports/registry-operations.ts
+++ b/packages/core/src/ports/registry-operations.ts
@@ -65,6 +65,7 @@ export interface SourceOperations {
 export interface HubSourceSync {
   listSources(): Promise<RegistrySource[]>;
   addSource(source: RegistrySource): Promise<void>;
+  addSources?(sources: RegistrySource[]): Promise<void>;
   updateSource(sourceId: string, updates: Partial<RegistrySource>): Promise<void>;
 }
 


### PR DESCRIPTION
## Description

Registering hub sources one-by-one meant N sequential storage writes per hub import. This PR adds a bulk `addSources()` path that commits all new sources in a single write, making hub addition noticeably faster for hubs with many sources.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] ⚡ Performance improvement

## Related Issues

Relates to #

## Changes Made

- `packages/core/src/ports/registry-operations.ts` — added optional `addSources?()` to the `HubSourceSync` port so app-layer code can use it when available
- `packages/app/src/registry/load-hub-sources.ts` — `loadHubSources` collects all new sources first, then dispatches a single `addSources()` call when the port supports it; falls back to the per-source loop otherwise (backward compat)
- `apps/vscode-extension/src/storage/registry-storage.ts` — new `addSources()` persists all sources in one `saveConfig` call; `addSource` delegates to it
- `apps/vscode-extension/src/services/registry-manager.ts` — new `addSources()` validates (optional), writes to storage, registers adapters, refreshes cache, and fires events; `addSource` delegates to it
- `apps/vscode-extension/src/services/hub-manager.ts` — wires `addSources` directly into the `HubSourceSync` port with `validate: false` (hub schema validation already happened upstream)
- `apps/vscode-extension/schemas/` — JSON schema files for hub config, APM, collections, lockfile, and default-hubs-config added for VS Code IntelliSense
- `.vscode/launch.json` + `package.json` — updated paths and task names to match the monorepo move to `apps/vscode-extension`

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

### Manual Testing Steps

1. Import a hub that declares multiple sources
2. Verify all sources appear in the registry after a single activation
3. Confirm no duplicate or missing sources

### Tested On

- [x] macOS
- [ ] Windows
- [ ] Linux

- [x] VS Code Stable
- [ ] VS Code Insiders

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Documentation

- [x] No documentation changes needed

## Additional Notes

Hub sources skip remote validation in `addSources` because hub schema validation has already passed by the time sources reach the registry — this is intentional and tested.

## Reviewer Guidelines

Please pay special attention to:

- The `addSources?` optional method on `HubSourceSync` — the port stays backward-compatible; implementations without it fall back to the per-source loop in `loadHubSources`
- The `validate: false` path in `RegistryManager.addSources` — this is only used from `HubManager`, where hub-level validation has already occurred

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**