### PR TITLE
feat(vscode-extension): implement progressive loading after source sync

### DIFF
--- a/apps/vscode-extension/src/commands/hub-commands.ts
+++ b/apps/vscode-extension/src/commands/hub-commands.ts
@@ -385,8 +385,8 @@ export class HubCommands {
             // HubManager.listProfilesFromHub() and displayed in "Shared Profiles" view.
             // Local profiles are only created when the user explicitly creates them.
 
-            // Auto-activate the imported hub
-            await this.hubManager.setActiveHub(importedHubId);
+            // Auto-activate the imported hub (sources already registered by importHub)
+            await this.hubManager.setActiveHub(importedHubId, { loadSources: false });
             this.logger.info(`Auto-activated imported hub: ${importedHubId}`);
 
             vscode.window.showInformationMessage(

--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -1220,7 +1220,7 @@ export class PromptRegistryExtension {
    * Handle fresh install flow
    * Initializes default sources, hub, and shows welcome notification
    */
-  private async handleFreshInstall(): Promise<void> {
+  private async handleFreshInstall(): Promise<boolean> {
     // Check if this is first run
     const state = await this.setupStateManager!.getState();
 
@@ -1239,16 +1239,19 @@ export class PromptRegistryExtension {
       }
 
       this.logger.info('First run completed successfully');
+      return true;
     }
+
+    return false;
   }
 
   /**
    * Check if this is the first run and show welcome message
    */
-  private async checkFirstRun(): Promise<void> {
+  private async checkFirstRun(): Promise<boolean> {
     if (!this.setupStateManager) {
       this.logger.warn('SetupStateManager not initialized, skipping first-run check');
-      return;
+      return false;
     }
 
     try {
@@ -1257,19 +1260,20 @@ export class PromptRegistryExtension {
         this.logger.info('Test environment detected, skipping first-run dialogs');
         // Mark setup as complete to prevent future dialogs
         await this.setupStateManager.markComplete();
-        return;
+        return false;
       }
 
       // Check for incomplete setup from previous session
       if (await this.handleIncompleteSetup()) {
-        return;
+        return false;
       }
 
       // Handle fresh install
-      await this.handleFreshInstall();
+      return await this.handleFreshInstall();
     } catch (error) {
       this.logger.error('Failed during first run', error as Error);
       await this.setupStateManager.markIncomplete();
+      return false;
     }
   }
 
@@ -1482,18 +1486,25 @@ export class PromptRegistryExtension {
       // Import and activate the selected hub
       this.logger.info(`Importing first-run hub: ${selected.hubConfig.name}`);
       try {
-        const hubId = await hubManager.importHub(selected.hubConfig.reference);
-        await hubManager.setActiveHub(hubId);
-        this.logger.info(`First-run hub ${hubId} imported and activated, syncing sources...`);
+        // Save config + kick off progressive source loading/syncing in one call.
+        // VS Code holds webview/view resolution until activate() settles, so
+        // registering (and syncing) an entire hub's worth of sources before
+        // returning was blocking the marketplace/tree views from rendering at
+        // all during first-run import (see feat/progressive-loading-after-source-sync).
+        const { hubId, onFirstSettled, onComplete } =
+          await hubManager.importHubProgressively(selected.hubConfig.reference);
 
-        // Sync all sources from the newly imported hub in the background (non-blocking)
-        // This allows the UI to be responsive while sync happens progressively
-        this.sourceCommands!.syncAllSources({ silent: true }).then(() => {
-          this.logger.info('Sources synchronized successfully');
-          vscode.commands.executeCommand('promptRegistry.refresh');
-        }).catch((syncError) => {
-          this.logger.warn('Failed to sync sources after hub import', syncError as Error);
-        });
+        // Proceed as soon as the first source has finished syncing, or the
+        // whole batch settles with zero enabled sources — whichever comes first.
+        await onFirstSettled();
+
+        await hubManager.setActiveHub(hubId, { loadSources: false });
+        this.logger.info(`First-run hub ${hubId} imported and activated; remaining sources are loading/synchronizing in the background.`);
+
+        void onComplete()
+          .catch((error) => {
+            this.logger.error(`Failed to complete source sync for first-run hub ${hubId}`, error as Error);
+          });
 
         // Note: We intentionally do NOT auto-activate any profile here.
         // Users should explicitly choose which profile to activate.
@@ -1599,10 +1610,13 @@ export class PromptRegistryExtension {
       await this.checkForAutomaticUpdates();
 
       // Check if this is first run and show welcome message
-      await this.checkFirstRun();
+      const initializedFirstRun = await this.checkFirstRun();
 
-      // Always sync active hub on activation to keep it up-to-date
-      await this.syncActiveHub();
+      // A hub selected during this activation is already current and its sources
+      // are being synchronized by the progressive first-run queue.
+      if (!initializedFirstRun) {
+        await this.syncActiveHub();
+      }
 
       // Ensure only one profile is active (cleanup any multi-active state)
       await this.ensureSingleActiveProfile();

--- a/apps/vscode-extension/src/services/hub-manager.ts
+++ b/apps/vscode-extension/src/services/hub-manager.ts
@@ -19,11 +19,14 @@ import {
   loadHubSources as appLoadHubSources,
   resolveProfileBundles as appResolveProfileBundles,
   syncProfile as appSyncProfile,
+  loadHubSourcesProgressively,
 } from '@ai-primitives-hub/app';
 import type {
   HubConfigStore,
+  LoadHubSourcesOptions,
   LogEvent,
   ProfileLifecycleDeps,
+  ProgressiveLoadResult,
 } from '@ai-primitives-hub/app';
 import type {
   HubConfig as CoreHubConfig,
@@ -61,6 +64,9 @@ import {
   ProfileDeactivationResult,
   validateHubConfig,
 } from '../types/hub';
+import {
+  CONCURRENCY_CONSTANTS,
+} from '../utils/constants';
 import {
   Logger,
 } from '../utils/logger';
@@ -108,6 +114,10 @@ export interface HubListItem {
   name: string;
   description: string;
   reference: HubReference;
+}
+
+export interface SetActiveHubOptions {
+  loadSources?: boolean;
 }
 
 /**
@@ -290,12 +300,16 @@ export class HubManager {
   }
 
   /**
-   * Import hub from remote or local source
+   * Resolve, validate, and persist a hub's configuration — without loading
+   * its sources. Returns as soon as the hub config itself is saved, so
+   * callers that don't want to block on registering every declared source
+   * (e.g. first-run activation) can await this and then call
+   * `loadHubSources()` separately without awaiting it to completion.
    * @param reference Hub reference (GitHub, URL, or local path)
    * @param hubId Optional hub identifier (auto-generated if not provided)
    * @returns Hub identifier
    */
-  public async importHub(reference: HubReference, hubId?: string): Promise<string> {
+  public async importHubConfig(reference: HubReference, hubId?: string): Promise<string> {
     const resolvedHubId = await this.appHubManager.importHub(reference, hubId);
 
     // appHubManager writes through the raw HubStore, bypassing HubStorage's
@@ -304,13 +318,70 @@ export class HubManager {
     // any other caller reading via `this.storage`) see the imported config.
     await this.storage.loadHub(resolvedHubId, true);
 
-    // Load hub sources into RegistryManager
-    if (this.registryManager) {
-      await this.loadHubSources(resolvedHubId);
-    }
-
     this._onHubImported.fire(resolvedHubId);
 
+    return resolvedHubId;
+  }
+
+  /**
+   * Import a hub and immediately start progressive source loading/syncing.
+   * Returns handles so callers can unblock early (`onFirstSettled`) or wait
+   * for the full batch (`onComplete`).
+   * @param reference Hub reference (GitHub, URL, or local path)
+   * @param hubId Optional hub identifier (auto-generated if not provided)
+   * @returns Hub identifier and progressive-load handles
+   */
+  public async importHubProgressively(
+    reference: HubReference,
+    hubId?: string
+  ): Promise<{ hubId: string } & ProgressiveLoadResult> {
+    const resolvedHubId = await this.importHubConfig(reference, hubId);
+
+    if (!this.registryManager) {
+      return {
+        hubId: resolvedHubId,
+        onFirstSettled: () => Promise.resolve(),
+        onComplete: () => Promise.resolve()
+      };
+    }
+
+    const hubData = await this.storage.loadHub(resolvedHubId);
+    const result = loadHubSourcesProgressively(
+      resolvedHubId,
+      hubData.config.sources ?? [],
+      {
+        listSources: () => this.registryManager.listSources(),
+        addSource: (s) => this.registryManager.addSource(s),
+        updateSource: (id, u) => this.registryManager.updateSource(id, u)
+      },
+      this.translateLogEvent,
+      {
+        concurrency: CONCURRENCY_CONSTANTS.SOURCE_SYNC_CONCURRENCY,
+        syncConcurrency: CONCURRENCY_CONSTANTS.SOURCE_SYNC_CONCURRENCY,
+        syncSource: (id) => this.registryManager.syncSource(id).catch((e: unknown) => {
+          this.logger.warn(`Failed to sync hub source ${id}`, e);
+        })
+      }
+    );
+
+    return { hubId: resolvedHubId, ...result };
+  }
+
+  /**
+   * Import hub from remote or local source.
+   * Delegates to `importHubProgressively` and fires background sync.
+   * @param reference Hub reference (GitHub, URL, or local path)
+   * @param hubId Optional hub identifier (auto-generated if not provided)
+   * @param _sourceLoadingOptions Kept for API compatibility; no longer used.
+   * @returns Hub identifier
+   */
+  public async importHub(
+    reference: HubReference,
+    hubId?: string,
+    _sourceLoadingOptions?: LoadHubSourcesOptions
+  ): Promise<string> {
+    const { hubId: resolvedHubId, onComplete } = await this.importHubProgressively(reference, hubId);
+    void onComplete();
     return resolvedHubId;
   }
 
@@ -497,8 +568,9 @@ export class HubManager {
   /**
    * Set the currently active hub
    * @param hubId Hub identifier to set as active
+   * @param options Activation settings.
    */
-  public async setActiveHub(hubId: string | null): Promise<void> {
+  public async setActiveHub(hubId: string | null, options?: SetActiveHubOptions): Promise<void> {
     // Get current active hub to check if we're switching
     const currentActiveHubId = await this.appHubManager.getActiveHubId();
 
@@ -514,9 +586,29 @@ export class HubManager {
         throw new Error(`Hub not found: ${hubId}`);
       }
 
-      // Load hub sources into RegistryManager when activating
-      if (this.registryManager) {
-        await this.loadHubSources(hubId);
+      // Load hub sources into RegistryManager when activating, syncing each in
+      // the background so the marketplace/tree fill in progressively.
+      if (this.registryManager && options?.loadSources !== false) {
+        const hubData = await this.storage.loadHub(hubId);
+        const sources = hubData.config.sources ?? [];
+        const { onComplete } = loadHubSourcesProgressively(
+          hubId,
+          sources,
+          {
+            listSources: () => this.registryManager.listSources(),
+            addSource: (s) => this.registryManager.addSource(s),
+            updateSource: (id, u) => this.registryManager.updateSource(id, u)
+          },
+          this.translateLogEvent,
+          {
+            concurrency: CONCURRENCY_CONSTANTS.SOURCE_SYNC_CONCURRENCY,
+            syncConcurrency: CONCURRENCY_CONSTANTS.SOURCE_SYNC_CONCURRENCY,
+            syncSource: (id) => this.registryManager.syncSource(id).catch((e: unknown) => {
+              this.logger.warn(`Failed to sync hub source ${id}`, e);
+            })
+          }
+        );
+        void onComplete();
       }
     }
 
@@ -544,8 +636,9 @@ export class HubManager {
    * (`hub-{hubId}-{sourceId}`) continue to work. Duplicate detection uses URL
    * matching, not ID matching, to handle both formats.
    * @param hubId Hub identifier
+   * @param options Optional source loading orchestration settings.
    */
-  public async loadHubSources(hubId: string): Promise<void> {
+  public async loadHubSources(hubId: string, options?: LoadHubSourcesOptions): Promise<void> {
     if (!this.registryManager) {
       this.logger.warn('RegistryManager not available, skipping source loading');
       return;
@@ -565,7 +658,8 @@ export class HubManager {
           addSource: (source) => this.registryManager.addSource(source),
           updateSource: (sourceId, updates) => this.registryManager.updateSource(sourceId, updates)
         },
-        this.translateLogEvent
+        this.translateLogEvent,
+        options
       );
     } catch (error) {
       this.logger.error(`Failed to load sources from hub ${hubId}`, error as Error);

--- a/apps/vscode-extension/src/services/hub-manager.ts
+++ b/apps/vscode-extension/src/services/hub-manager.ts
@@ -372,14 +372,21 @@ export class HubManager {
    * Delegates to `importHubProgressively` and fires background sync.
    * @param reference Hub reference (GitHub, URL, or local path)
    * @param hubId Optional hub identifier (auto-generated if not provided)
-   * @param _sourceLoadingOptions Kept for API compatibility; no longer used.
+   * @param sourceLoadingOptions Optional registration settings for callers that
+   * need to await source registration or receive per-source notifications.
    * @returns Hub identifier
    */
   public async importHub(
     reference: HubReference,
     hubId?: string,
-    _sourceLoadingOptions?: LoadHubSourcesOptions
+    sourceLoadingOptions?: LoadHubSourcesOptions
   ): Promise<string> {
+    if (sourceLoadingOptions) {
+      const importedHubId = await this.importHubConfig(reference, hubId);
+      await this.loadHubSources(importedHubId, sourceLoadingOptions);
+      return importedHubId;
+    }
+
     const { hubId: resolvedHubId, onComplete } = await this.importHubProgressively(reference, hubId);
     void onComplete();
     return resolvedHubId;

--- a/apps/vscode-extension/src/services/registry-manager.ts
+++ b/apps/vscode-extension/src/services/registry-manager.ts
@@ -641,15 +641,14 @@ export class RegistryManager {
    * Bundles whose `readmeRevision` differs (or is not provided by the adapter) are left without a
    * readme so {@link downloadReadmesConcurrently} re-downloads them. This keeps readmes fresh while
    * avoiding redundant downloads on every sync.
-   * @param sourceId - Source ID whose cache should be consulted
+   * @param previouslyCached - Snapshot of cached bundles taken before the current sync started
    * @param bundles - Freshly fetched bundles to enrich in place
    */
-  private async reuseCachedReadmes(sourceId: string, bundles: Bundle[]): Promise<void> {
-    const cached = await this.storage.getCachedSourceBundles(sourceId);
-    if (!cached || cached.length === 0) {
+  private async reuseCachedReadmes(previouslyCached: Bundle[], bundles: Bundle[]): Promise<void> {
+    if (!previouslyCached || previouslyCached.length === 0) {
       return;
     }
-    const cachedById = new Map(cached.map((b) => [b.id, b]));
+    const cachedById = new Map(previouslyCached.map((b) => [b.id, b]));
     for (const bundle of bundles) {
       const previous = cachedById.get(bundle.id);
       if (
@@ -894,6 +893,11 @@ export class RegistryManager {
     }
 
     const adapter = this.getAdapter(source);
+
+    // Snapshot the cache before fetchBundles starts overwriting it with partial results,
+    // so readme reuse can compare against the last fully-synced state.
+    const preSyncCache = await this.storage.getCachedSourceBundles(sourceId);
+
     const bundles = await adapter.fetchBundles(async (partial) => {
       // Progressive update: cache what we have so far and notify the UI.
       await this.storage.cacheSourceBundles(sourceId, partial);
@@ -901,7 +905,7 @@ export class RegistryManager {
     });
 
     // Reuse still-valid cached readmes so we only re-download when the source revision changed
-    await this.reuseCachedReadmes(sourceId, bundles);
+    await this.reuseCachedReadmes(preSyncCache, bundles);
 
     // Cache bundles
     await this.storage.cacheSourceBundles(sourceId, bundles);

--- a/apps/vscode-extension/src/storage/registry-storage.ts
+++ b/apps/vscode-extension/src/storage/registry-storage.ts
@@ -52,12 +52,14 @@ const DEFAULT_SETTINGS: RegistrySettings = {
 /**
  * Default registry configuration
  */
-const DEFAULT_CONFIG: RegistryConfig = {
-  version: '1.0.0',
-  sources: [],
-  profiles: [],
-  settings: DEFAULT_SETTINGS
-};
+function createDefaultConfig(): RegistryConfig {
+  return {
+    version: '1.0.0',
+    sources: [],
+    profiles: [],
+    settings: { ...DEFAULT_SETTINGS }
+  };
+}
 
 /**
  * Registry storage manager
@@ -70,6 +72,7 @@ export class RegistryStorage {
   private readonly paths: StoragePaths;
   private readonly appStorage: AppStorage;
   private configCache?: RegistryConfig;
+  private configMutationQueue: Promise<void> = Promise.resolve();
 
   // ===== Update Preferences Management =====
 
@@ -138,6 +141,26 @@ export class RegistryStorage {
     return sanitized;
   }
 
+  private async writeConfig(config: RegistryConfig): Promise<void> {
+    const data = JSON.stringify(config, null, 2);
+    await writeFile(this.paths.config, data, 'utf8');
+    this.configCache = config;
+  }
+
+  private async enqueueConfigMutation(mutation: () => Promise<void>): Promise<void> {
+    const queuedMutation = this.configMutationQueue.then(mutation);
+    this.configMutationQueue = queuedMutation.catch(() => undefined);
+    await queuedMutation;
+  }
+
+  private async mutateConfig(mutation: (config: RegistryConfig) => void): Promise<void> {
+    await this.enqueueConfigMutation(async () => {
+      const config = await this.loadConfig();
+      mutation(config);
+      await this.writeConfig(config);
+    });
+  }
+
   /**
    * Get the list of supported scopes for querying installed bundles.
    * Repository scope bundles are tracked via LockfileManager, not RegistryStorage.
@@ -182,7 +205,7 @@ export class RegistryStorage {
 
     // Create default config if doesn't exist
     if (!fs.existsSync(this.paths.config)) {
-      await this.saveConfig(DEFAULT_CONFIG);
+      await this.saveConfig(createDefaultConfig());
     }
   }
 
@@ -205,7 +228,7 @@ export class RegistryStorage {
       return config;
     } catch {
       // Return default config if file doesn't exist or is invalid
-      return DEFAULT_CONFIG;
+      return createDefaultConfig();
     }
   }
 
@@ -214,9 +237,9 @@ export class RegistryStorage {
    * @param config
    */
   public async saveConfig(config: RegistryConfig): Promise<void> {
-    const data = JSON.stringify(config, null, 2);
-    await writeFile(this.paths.config, data, 'utf8');
-    this.configCache = config;
+    await this.enqueueConfigMutation(async () => {
+      await this.writeConfig(config);
+    });
   }
 
   /**
@@ -233,15 +256,13 @@ export class RegistryStorage {
    * @param source
    */
   public async addSource(source: RegistrySource): Promise<void> {
-    const config = await this.loadConfig();
+    await this.mutateConfig((config) => {
+      if (config.sources.some((s) => s.id === source.id)) {
+        throw new Error(`Source with ID '${source.id}' already exists`);
+      }
 
-    // Check for duplicate IDs
-    if (config.sources.some((s) => s.id === source.id)) {
-      throw new Error(`Source with ID '${source.id}' already exists`);
-    }
-
-    config.sources.push(source);
-    await this.saveConfig(config);
+      config.sources.push(source);
+    });
   }
 
   /**
@@ -250,15 +271,15 @@ export class RegistryStorage {
    * @param updates
    */
   public async updateSource(sourceId: string, updates: Partial<RegistrySource>): Promise<void> {
-    const config = await this.loadConfig();
-    const index = config.sources.findIndex((s) => s.id === sourceId);
+    await this.mutateConfig((config) => {
+      const index = config.sources.findIndex((s) => s.id === sourceId);
 
-    if (index === -1) {
-      throw new Error(`Source '${sourceId}' not found`);
-    }
+      if (index === -1) {
+        throw new Error(`Source '${sourceId}' not found`);
+      }
 
-    config.sources[index] = { ...config.sources[index], ...updates };
-    await this.saveConfig(config);
+      config.sources[index] = { ...config.sources[index], ...updates };
+    });
   }
 
   /**
@@ -266,9 +287,9 @@ export class RegistryStorage {
    * @param sourceId
    */
   public async removeSource(sourceId: string): Promise<void> {
-    const config = await this.loadConfig();
-    config.sources = config.sources.filter((s) => s.id !== sourceId);
-    await this.saveConfig(config);
+    await this.mutateConfig((config) => {
+      config.sources = config.sources.filter((s) => s.id !== sourceId);
+    });
 
     // Clean up source cache
     await this.clearSourceCache(sourceId);
@@ -289,14 +310,13 @@ export class RegistryStorage {
    * @param profile
    */
   public async addProfile(profile: Profile): Promise<void> {
-    const config = await this.loadConfig();
+    await this.mutateConfig((config) => {
+      if (config.profiles.some((p) => p.id === profile.id)) {
+        throw new Error(`Profile with ID '${profile.id}' already exists`);
+      }
 
-    if (config.profiles.some((p) => p.id === profile.id)) {
-      throw new Error(`Profile with ID '${profile.id}' already exists`);
-    }
-
-    config.profiles.push(profile);
-    await this.saveConfig(config);
+      config.profiles.push(profile);
+    });
   }
 
   /**
@@ -305,15 +325,15 @@ export class RegistryStorage {
    * @param updates
    */
   public async updateProfile(profileId: string, updates: Partial<Profile>): Promise<void> {
-    const config = await this.loadConfig();
-    const index = config.profiles.findIndex((p) => p.id === profileId);
+    await this.mutateConfig((config) => {
+      const index = config.profiles.findIndex((p) => p.id === profileId);
 
-    if (index === -1) {
-      throw new Error(`Profile '${profileId}' not found`);
-    }
+      if (index === -1) {
+        throw new Error(`Profile '${profileId}' not found`);
+      }
 
-    config.profiles[index] = { ...config.profiles[index], ...updates };
-    await this.saveConfig(config);
+      config.profiles[index] = { ...config.profiles[index], ...updates };
+    });
   }
 
   /**
@@ -321,9 +341,9 @@ export class RegistryStorage {
    * @param profileId
    */
   public async removeProfile(profileId: string): Promise<void> {
-    const config = await this.loadConfig();
-    config.profiles = config.profiles.filter((p) => p.id !== profileId);
-    await this.saveConfig(config);
+    await this.mutateConfig((config) => {
+      config.profiles = config.profiles.filter((p) => p.id !== profileId);
+    });
   }
 
   /**
@@ -519,14 +539,7 @@ export class RegistryStorage {
    * Clear all data (sources, profiles, caches) - used for replace import strategy
    */
   public async clearAll(): Promise<void> {
-    // Reset config to defaults
-    const config: RegistryConfig = {
-      version: '1.0.0',
-      sources: [],
-      profiles: [],
-      settings: DEFAULT_SETTINGS
-    };
-    await this.saveConfig(config);
+    await this.saveConfig(createDefaultConfig());
 
     // Clear all caches
     await this.clearAllCaches();

--- a/apps/vscode-extension/src/ui/marketplace-view-provider.ts
+++ b/apps/vscode-extension/src/ui/marketplace-view-provider.ts
@@ -47,7 +47,7 @@ import {
  * Message types sent from webview to extension
  */
 interface WebviewMessage {
-  type: 'refresh' | 'install' | 'update' | 'uninstall' | 'openDetails' | 'openPromptFile' | 'installVersion'
+  type: 'ready' | 'refresh' | 'install' | 'update' | 'uninstall' | 'openDetails' | 'openPromptFile' | 'installVersion'
     | 'getVersions' | 'toggleAutoUpdate' | 'openSourceRepository' | 'completeSetup' | 'openExternalLink';
   bundleId?: string;
   installPath?: string;
@@ -70,10 +70,23 @@ interface ContentBreakdown {
   mcpServers: number;
 }
 
+interface BundlesLoadedMessage {
+  type: 'bundlesLoaded';
+  bundles: unknown[];
+  filterOptions: {
+    tags: string[];
+    sources: unknown[];
+  };
+  setupState: string;
+  sourcesCount: number;
+}
+
 export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
   public static readonly viewType = 'promptregistry.marketplace';
 
   private _view?: vscode.WebviewView;
+  private webviewReady = false;
+  private latestBundlesMessage?: BundlesLoadedMessage;
   private readonly logger: Logger;
 
   private readonly sourceSyncThrottle = new LeadingTrailingThrottle(
@@ -200,6 +213,17 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
   private handleSourceSynced(event: { sourceId: string; bundleCount: number }): void {
     this.logger.debug(`Source synced: ${event.sourceId} (${event.bundleCount} bundles)`);
     this.sourceSyncThrottle.trigger();
+  }
+
+  private async deliverBundles(): Promise<void> {
+    if (!this._view || !this.webviewReady || !this.latestBundlesMessage) {
+      return;
+    }
+
+    const delivered = await this._view.webview.postMessage(this.latestBundlesMessage);
+    if (!delivered) {
+      this.logger.warn('Marketplace webview was not ready to receive bundle data');
+    }
   }
 
   /**
@@ -372,19 +396,17 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
       // Get setup state for empty state UI
       const setupState = await this.setupStateManager.getState();
 
-      // Send to webview (only if view is available)
-      if (this._view) {
-        this._view.webview.postMessage({
-          type: 'bundlesLoaded',
-          bundles: enhancedBundles,
-          filterOptions: {
-            tags: availableTags,
-            sources: availableSources
-          },
-          setupState: setupState,
-          sourcesCount: sources.length
-        });
-      }
+      this.latestBundlesMessage = {
+        type: 'bundlesLoaded',
+        bundles: enhancedBundles,
+        filterOptions: {
+          tags: availableTags,
+          sources: availableSources
+        },
+        setupState,
+        sourcesCount: sources.length
+      };
+      await this.deliverBundles();
 
       this.logger.debug(`Loaded ${enhancedBundles.length} bundles for marketplace`);
     } catch (error) {
@@ -522,6 +544,12 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
    */
   private async handleMessage(message: WebviewMessage): Promise<void> {
     switch (message.type) {
+      case 'ready': {
+        this.webviewReady = true;
+        this.logger.debug('Marketplace webview signaled readiness');
+        await this.loadBundles();
+        break;
+      }
       case 'refresh': {
         await this.loadBundles();
         break;
@@ -1260,24 +1288,27 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
     _token: vscode.CancellationToken
   ) {
     this._view = webviewView;
+    this.webviewReady = false;
+    this.logger.debug('Marketplace webview resolving; awaiting ready signal');
 
     webviewView.webview.options = {
       enableScripts: true,
       localResourceRoots: [this.context.extensionUri]
     };
 
-    webviewView.webview.html = this.getHtmlContent(webviewView.webview);
-
     // Handle messages from webview
     webviewView.webview.onDidReceiveMessage(async (message) => {
       await this.handleMessage(message);
     });
 
-    // Load bundles with a small delay to ensure webview JavaScript is ready
-    // The webview also sends a refresh request when ready as a backup
-    setTimeout(() => {
-      void this.loadBundles();
-    }, UI_CONSTANTS.WEBVIEW_READY_DELAY_MS);
+    webviewView.onDidChangeVisibility(() => {
+      if (webviewView.visible) {
+        this.logger.debug('Marketplace webview became visible; retrying latest bundle delivery');
+        void this.deliverBundles();
+      }
+    });
+
+    webviewView.webview.html = this.getHtmlContent(webviewView.webview);
   }
 
   /**

--- a/apps/vscode-extension/src/ui/webview/marketplace/marketplace.js
+++ b/apps/vscode-extension/src/ui/webview/marketplace/marketplace.js
@@ -25,9 +25,9 @@
     }
   });
 
-  // Request initial data when webview is ready
-  // This ensures we get data even if the extension sent it before we were listening
-  vscode.postMessage({ type: 'refresh' });
+  // Signal readiness only after the message listener is installed. The extension
+  // retains the latest marketplace payload until this handshake completes.
+  vscode.postMessage({ type: 'ready' });
 
   // Update filter dropdowns with dynamic data
   const updateFilterUI = () => {

--- a/apps/vscode-extension/src/utils/constants.ts
+++ b/apps/vscode-extension/src/utils/constants.ts
@@ -131,12 +131,5 @@ export const UI_CONSTANTS = {
    * Debounce delay for reacting to source sync events (in milliseconds)
    * - Used by tree and marketplace views to avoid excessive refreshes
    */
-  SOURCE_SYNC_DEBOUNCE_MS: 500,
-
-  /**
-   * Delay before loading bundles after webview resolves (in milliseconds)
-   * - Ensures webview JavaScript is ready to receive messages
-   * - The webview also sends a refresh request as a backup
-   */
-  WEBVIEW_READY_DELAY_MS: 100
+  SOURCE_SYNC_DEBOUNCE_MS: 500
 } as const;

--- a/apps/vscode-extension/test/services/hub-manager.test.ts
+++ b/apps/vscode-extension/test/services/hub-manager.test.ts
@@ -435,12 +435,19 @@ suite('HubManager', () => {
 
     test('importHubProgressively resolves onFirstSettled before all syncs complete', async () => {
       const releases: (() => void)[] = [];
+      let allSyncsStarted!: () => void;
+      const allSyncsStartedPromise = new Promise<void>((resolve) => {
+        allSyncsStarted = resolve;
+      });
 
       class BlockingRegistryManager extends RecordingRegistryManager {
         public override syncSource(sourceId: string): Promise<void> {
           this.synced.push(sourceId);
           return new Promise<void>((r) => {
             releases.push(r);
+            if (releases.length === 2) {
+              allSyncsStarted();
+            }
           });
         }
       }
@@ -458,12 +465,14 @@ suite('HubManager', () => {
         localRef, 'test-first-settled'
       );
 
+      await allSyncsStartedPromise;
+
       // Release first sync — onFirstSettled should resolve without waiting for the second
-      releases[0]?.();
+      releases[0]();
       await onFirstSettled();
 
       // Complete the second sync
-      releases[1]?.();
+      releases[1]();
       await onComplete();
     });
   });

--- a/apps/vscode-extension/test/services/hub-manager.test.ts
+++ b/apps/vscode-extension/test/services/hub-manager.test.ts
@@ -352,6 +352,122 @@ suite('HubManager', () => {
     });
   });
 
+  suite('Progressive source loading', () => {
+    // Minimal RegistryManager stub recording the source workflow that
+    // importHub drives: sources are registered via addSource and then
+    // synced in the background via syncSource (the progressive-loading path).
+    class RecordingRegistryManager {
+      public readonly added: RegistrySource[] = [];
+      public readonly synced: string[] = [];
+
+      public listSources(): Promise<RegistrySource[]> {
+        return Promise.resolve([...this.added]);
+      }
+
+      public addSource(source: RegistrySource): Promise<void> {
+        this.added.push(source);
+        return Promise.resolve();
+      }
+
+      public updateSource(): Promise<void> {
+        return Promise.resolve();
+      }
+
+      public syncSource(sourceId: string): Promise<void> {
+        this.synced.push(sourceId);
+        return Promise.resolve();
+      }
+
+      public listProfiles(): Promise<unknown[]> {
+        return Promise.resolve([]);
+      }
+    }
+
+    test('syncs each registered source in the background after import', async () => {
+      const registryManager = new RecordingRegistryManager();
+      const managerWithRegistry = new HubManager(
+        storage,
+        mockValidator as any,
+        process.cwd(),
+        undefined,
+        registryManager as any
+      );
+
+      await managerWithRegistry.importHub(localRef, 'test-progressive');
+
+      // The fixture declares two enabled sources; both must be registered
+      // AND scheduled for a background sync so bundles populate progressively
+      // (this is what makes the marketplace/tree fill in for a custom hub).
+      assert.strictEqual(registryManager.added.length, 2, 'both hub sources should be registered');
+      assert.deepStrictEqual(
+        registryManager.synced.toSorted(),
+        registryManager.added.map((s) => s.id).toSorted(),
+        'every registered source should be synced in the background'
+      );
+    });
+
+    test('importHubProgressively returns onFirstSettled and onComplete handles', async () => {
+      const registryManager = new RecordingRegistryManager();
+      const managerWithRegistry = new HubManager(
+        storage,
+        mockValidator as any,
+        process.cwd(),
+        undefined,
+        registryManager as any
+      );
+
+      const result = await managerWithRegistry.importHubProgressively(localRef, 'test-progressive-handles');
+
+      assert.ok(result.hubId, 'should return a hubId');
+      assert.strictEqual(typeof result.onFirstSettled, 'function', 'should return onFirstSettled function');
+      assert.strictEqual(typeof result.onComplete, 'function', 'should return onComplete function');
+
+      // Awaiting onComplete must resolve and not hang
+      await result.onComplete();
+
+      assert.strictEqual(registryManager.added.length, 2, 'both sources should be registered');
+      assert.deepStrictEqual(
+        registryManager.synced.toSorted(),
+        registryManager.added.map((s) => s.id).toSorted(),
+        'every registered source should be synced'
+      );
+    });
+
+    test('importHubProgressively resolves onFirstSettled before all syncs complete', async () => {
+      const releases: (() => void)[] = [];
+
+      class BlockingRegistryManager extends RecordingRegistryManager {
+        public override syncSource(sourceId: string): Promise<void> {
+          this.synced.push(sourceId);
+          return new Promise<void>((r) => {
+            releases.push(r);
+          });
+        }
+      }
+
+      const blockingRegistry = new BlockingRegistryManager();
+      const managerWithRegistry = new HubManager(
+        storage,
+        mockValidator as any,
+        process.cwd(),
+        undefined,
+        blockingRegistry as any
+      );
+
+      const { onFirstSettled, onComplete } = await managerWithRegistry.importHubProgressively(
+        localRef, 'test-first-settled'
+      );
+
+      // Release first sync — onFirstSettled should resolve without waiting for the second
+      releases[0]?.();
+      await onFirstSettled();
+
+      // Complete the second sync
+      releases[1]?.();
+      await onComplete();
+    });
+  });
+
   suite('Reference Validation', () => {
     test('should fail with missing type', async () => {
       const badRef: any = {
@@ -636,6 +752,7 @@ suite('Hub Source Loading - SourceId Format', () => {
     private sources: RegistrySource[] = [];
     public addSourceCalls: RegistrySource[] = [];
     public updateSourceCalls: { id: string; updates: Partial<RegistrySource> }[] = [];
+    public syncSourceCalls: string[] = [];
 
     public listSources(): Promise<RegistrySource[]> {
       return Promise.resolve([...this.sources]);
@@ -656,10 +773,16 @@ suite('Hub Source Loading - SourceId Format', () => {
       return Promise.resolve();
     }
 
+    public syncSource(sourceId: string): Promise<void> {
+      this.syncSourceCalls.push(sourceId);
+      return Promise.resolve();
+    }
+
     public reset(): void {
       this.sources = [];
       this.addSourceCalls = [];
       this.updateSourceCalls = [];
+      this.syncSourceCalls = [];
     }
 
     public getSourceCount(): number {
@@ -709,6 +832,32 @@ suite('Hub Source Loading - SourceId Format', () => {
   });
 
   suite('New SourceId Format Generation', () => {
+    test('should activate an imported hub without reloading its sources when requested', async () => {
+      await hubManager.importHub(localRef, 'test-activate-without-reload');
+      mockRegistry.addSourceCalls = [];
+      mockRegistry.updateSourceCalls = [];
+
+      await hubManager.setActiveHub('test-activate-without-reload', { loadSources: false });
+
+      assert.strictEqual(mockRegistry.addSourceCalls.length, 0);
+      assert.strictEqual(mockRegistry.updateSourceCalls.length, 0);
+    });
+
+    test('should forward source-added notifications during an import', async () => {
+      const addedSourceIds: string[] = [];
+
+      await hubManager.importHub(localRef, 'test-progressive-import', {
+        concurrency: 2,
+        onSourceAdded: (source) => addedSourceIds.push(source.id)
+      });
+
+      assert.strictEqual(addedSourceIds.length, 2);
+      assert.deepStrictEqual(
+        addedSourceIds.toSorted(),
+        mockRegistry.addSourceCalls.map((source) => source.id).toSorted()
+      );
+    });
+
     test('loadHubSources() should generate sourceId via generateHubSourceId', async () => {
       // Import hub with sources
       await hubManager.importHub(localRef, 'test-new-format');

--- a/apps/vscode-extension/test/storage/registry-storage.test.ts
+++ b/apps/vscode-extension/test/storage/registry-storage.test.ts
@@ -3,6 +3,8 @@
  */
 
 import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import * as sinon from 'sinon';
 import {
@@ -316,6 +318,44 @@ suite('RegistryStorage', () => {
   });
 
   suite('Concurrent Access', () => {
+    test('should persist every concurrently added source', async () => {
+      const storageRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'registry-storage-'));
+      const context = {
+        globalState: {
+          get: sandbox.stub().returns({}),
+          update: sandbox.stub().resolves()
+        },
+        globalStorageUri: { fsPath: storageRoot }
+      } as any;
+      const storage = new RegistryStorage(context);
+
+      try {
+        await storage.initialize();
+        await Promise.all(
+          Array.from({ length: 10 }, (_, index) => storage.addSource({
+            id: `source-${index}`,
+            name: `Source ${index}`,
+            type: 'github',
+            url: `https://github.com/example/source-${index}`,
+            enabled: true,
+            priority: index
+          }))
+        );
+
+        const persisted = JSON.parse(
+          fs.readFileSync(path.join(storageRoot, 'config.json'), 'utf8')
+        ) as { sources: { id: string }[] };
+
+        assert.strictEqual(persisted.sources.length, 10);
+        assert.deepStrictEqual(
+          persisted.sources.map((source) => source.id).toSorted(),
+          Array.from({ length: 10 }, (_, index) => `source-${index}`)
+        );
+      } finally {
+        fs.rmSync(storageRoot, { recursive: true, force: true });
+      }
+    });
+
     test('should handle concurrent read operations', async () => {
       const data = { sources: [], profiles: [] };
 

--- a/apps/vscode-extension/test/ui/marketplace-view-provider.emptyState.property.test.ts
+++ b/apps/vscode-extension/test/ui/marketplace-view-provider.emptyState.property.test.ts
@@ -114,6 +114,8 @@ suite('MarketplaceViewProvider Empty State - Property Tests', () => {
     (marketplaceProvider as any)._view = {
       webview: mockWebview
     };
+    // The webview only receives bundlesLoaded messages after signaling readiness.
+    (marketplaceProvider as any).webviewReady = true;
   });
 
   teardown(() => {

--- a/apps/vscode-extension/test/ui/marketplace-view-provider.emptyState.test.ts
+++ b/apps/vscode-extension/test/ui/marketplace-view-provider.emptyState.test.ts
@@ -100,6 +100,8 @@ suite('MarketplaceViewProvider - Empty State UI', () => {
     (marketplaceProvider as any)._view = {
       webview: mockWebview
     };
+    // The webview only receives bundlesLoaded messages after signaling readiness.
+    (marketplaceProvider as any).webviewReady = true;
   });
 
   teardown(() => {

--- a/apps/vscode-extension/test/ui/marketplace-view-provider.eventHandling.test.ts
+++ b/apps/vscode-extension/test/ui/marketplace-view-provider.eventHandling.test.ts
@@ -413,6 +413,7 @@ suite('MarketplaceViewProvider - Throttle on source sync burst', () => {
 
     const provider = new MarketplaceViewProvider(mockContext, mockRegistryManager, mockSetupStateManager);
     (provider as any)._view = { webview: mockWebview };
+    (provider as any).webviewReady = true;
   });
 
   teardown(() => {

--- a/packages/app/src/registry/index.ts
+++ b/packages/app/src/registry/index.ts
@@ -11,6 +11,7 @@ export * from './install-registry-bundle';
 export * from './list-all-profiles';
 export * from './list-installed-bundles';
 export * from './load-hub-sources';
+export * from './source-sync-queue';
 export * from './local-profile-crud';
 export * from './profile-lifecycle';
 export * from './registry-settings';

--- a/packages/app/src/registry/load-hub-sources.ts
+++ b/packages/app/src/registry/load-hub-sources.ts
@@ -271,9 +271,12 @@ export function loadHubSourcesProgressively(
   return {
     onFirstSettled: () => Promise.race([
       queue.onFirstSettled(),
-      // If registration finishes before any sync settles (zero syncs enqueued),
-      // resolve so callers don't hang.
-      registrationPromise.then(() => undefined).catch(() => undefined)
+      // If registration finishes without any enabled, new sources, resolve so
+      // callers do not hang. Otherwise keep waiting for an actual sync to
+      // settle; registration can complete while background syncs are running.
+      registrationPromise.then(() => (
+        queue.hasEnqueued() ? queue.onFirstSettled() : undefined
+      )).catch(() => undefined)
     ]),
     onComplete: () => registrationPromise
       .catch(() => undefined)

--- a/packages/app/src/registry/load-hub-sources.ts
+++ b/packages/app/src/registry/load-hub-sources.ts
@@ -33,11 +33,19 @@ import type {
   LogEvent,
   OnLogEvent,
 } from '../update/log-event';
+import {
+  createSourceSyncQueue,
+} from './source-sync-queue';
 
 export interface LoadHubSourcesResult {
   added: number;
   updated: number;
   skipped: number;
+}
+
+export interface LoadHubSourcesOptions {
+  concurrency?: number;
+  onSourceAdded?: (source: RegistrySource) => void;
 }
 
 /**
@@ -89,13 +97,15 @@ export function findDuplicateSource(
  * @param hubSources Sources declared in the hub's config.
  * @param ports Registry read/write access.
  * @param onLog Optional sink for diagnostic log events.
+ * @param options Optional orchestration settings.
  * @returns Counts of added/updated/skipped sources.
  */
 export async function loadHubSources(
   hubId: string,
   hubSources: HubSource[],
   ports: HubSourceSync,
-  onLog?: OnLogEvent
+  onLog?: OnLogEvent,
+  options?: LoadHubSourcesOptions
 ): Promise<LoadHubSourcesResult> {
   const log = (level: LogEvent['level'], message: string, error?: Error): void => {
     onLog?.({ level, message, error });
@@ -109,11 +119,11 @@ export async function loadHubSources(
   let updated = 0;
   let skipped = 0;
 
-  for (const hubSource of hubSources) {
+  const processSource = async (hubSource: HubSource): Promise<void> => {
     if (!hubSource.enabled) {
       log('debug', `Skipping disabled source: ${hubSource.id}`);
       skipped++;
-      continue;
+      return;
     }
 
     const sourceId = generateSourceId(hubSource.type, hubSource.url, {
@@ -138,7 +148,7 @@ export async function loadHubSources(
         hubId
       });
       updated++;
-      continue;
+      return;
     }
 
     const duplicateSource = findDuplicateSource(hubSource, existingSources);
@@ -156,7 +166,7 @@ export async function loadHubSources(
         + `CollectionsPath: ${hubSource.config?.collectionsPath ?? 'collections'}`
       );
       skipped++;
-      continue;
+      return;
     }
 
     log('info', `Adding new hub source: ${sourceId} (${hubSource.name})`);
@@ -178,14 +188,95 @@ export async function loadHubSources(
     try {
       await ports.addSource(registrySource);
       added++;
+      try {
+        options?.onSourceAdded?.(registrySource);
+      } catch (hookError) {
+        const err = hookError instanceof Error ? hookError : new Error(String(hookError));
+        log('warn', `Source-added notification failed for ${sourceId} (${hubSource.name}): ${err.message}`, err);
+      }
     } catch (sourceError) {
       const err = sourceError instanceof Error ? sourceError : new Error(String(sourceError));
       log('warn', `Failed to add hub source ${sourceId} (${hubSource.name}): ${err.message}`, err);
       skipped++;
     }
-  }
+  };
+
+  const raw = options?.concurrency ?? 1;
+  const concurrency = Number.isFinite(raw) ? Math.max(1, Math.floor(raw)) : 1;
+  let nextIndex = 0;
+
+  const worker = async (): Promise<void> => {
+    while (nextIndex < hubSources.length) {
+      const index = nextIndex++;
+      await processSource(hubSources[index]);
+    }
+  };
+
+  await Promise.all(Array.from({ length: concurrency }, worker));
 
   log('info', `Hub source loading complete for ${hubId}: ${added} added, ${updated} updated, ${skipped} skipped`);
 
   return { added, updated, skipped };
+}
+
+export interface ProgressiveLoadResult {
+  /** Resolves when the first source sync settles, OR all registrations complete with zero syncs. */
+  onFirstSettled: () => Promise<void>;
+  /** Resolves when all source registrations AND all background syncs finish. */
+  onComplete: () => Promise<void>;
+}
+
+export interface ProgressiveLoadOptions extends LoadHubSourcesOptions {
+  /** Concurrency cap for background syncs (defaults to `concurrency`). */
+  syncConcurrency?: number;
+  /** Called for each source after it is registered, to trigger a background sync. */
+  syncSource: (sourceId: string) => Promise<void>;
+}
+
+/**
+ * Like `loadHubSources`, but also schedules a background sync for each newly
+ * registered source via `options.syncSource`, and returns handles to wait for
+ * the first sync or for the full batch to complete.
+ *
+ * - `onFirstSettled()` — resolves when the first sync settles, OR when
+ *   registration finishes with zero syncs enqueued (so callers never hang on
+ *   hubs whose sources are all disabled or duplicates).
+ * - `onComplete()` — resolves after both registration and all sync tasks finish.
+ * @param hubId Hub identifier the sources belong to.
+ * @param hubSources Sources declared in the hub's config.
+ * @param ports Registry read/write access.
+ * @param onLog Optional sink for diagnostic log events.
+ * @param options Progressive-load orchestration settings.
+ */
+export function loadHubSourcesProgressively(
+  hubId: string,
+  hubSources: HubSource[],
+  ports: HubSourceSync,
+  onLog: OnLogEvent | undefined,
+  options: ProgressiveLoadOptions
+): ProgressiveLoadResult {
+  const queue = createSourceSyncQueue(
+    options.syncSource,
+    options.syncConcurrency ?? options.concurrency ?? 1
+  );
+
+  const registrationPromise = loadHubSources(hubId, hubSources, ports, onLog, {
+    ...options,
+    onSourceAdded: (source) => {
+      queue.enqueue(source.id);
+      options.onSourceAdded?.(source);
+    }
+  });
+
+  return {
+    onFirstSettled: () => Promise.race([
+      queue.onFirstSettled(),
+      // If registration finishes before any sync settles (zero syncs enqueued),
+      // resolve so callers don't hang.
+      registrationPromise.then(() => undefined).catch(() => undefined)
+    ]),
+    onComplete: () => registrationPromise
+      .catch(() => undefined)
+      .then(() => queue.onIdle())
+  };
 }

--- a/packages/app/src/registry/source-sync-queue.ts
+++ b/packages/app/src/registry/source-sync-queue.ts
@@ -1,0 +1,83 @@
+export interface SourceSyncQueue {
+  enqueue: (sourceId: string) => void;
+  onIdle: () => Promise<void>;
+  onFirstSettled: () => Promise<void>;
+}
+
+/**
+ * Creates a bounded-concurrency queue that syncs sources via the provided
+ * `syncSource` callback.
+ *
+ * - `enqueue(sourceId)` — registers a source; dispatches up to `concurrency`
+ *   syncs immediately.
+ * - `onFirstSettled()` — resolves once the first sync has settled (success or
+ *   failure). Resolves immediately if a sync has already settled at call time,
+ *   preventing a race where the sync finishes before the caller awaits.
+ * - `onIdle()` — resolves once all enqueued sources are done and the queue is
+ *   empty. Also resolves immediately when the queue is already idle.
+ * @param syncSource
+ * @param concurrency
+ */
+export function createSourceSyncQueue(
+  syncSource: (sourceId: string) => Promise<void>,
+  concurrency: number
+): SourceSyncQueue {
+  const pending: string[] = [];
+  const idleResolvers: (() => void)[] = [];
+  const firstSettledResolvers: (() => void)[] = [];
+  let activeSyncs = 0;
+  let hasSettledOne = false;
+
+  const flush = (resolvers: (() => void)[]): void => resolvers.splice(0).forEach((r) => r());
+
+  const resolveIdle = (): void => {
+    if (activeSyncs === 0 && pending.length === 0) {
+      flush(idleResolvers);
+    }
+  };
+
+  const resolveFirstSettled = (): void => {
+    if (!hasSettledOne) {
+      hasSettledOne = true;
+      flush(firstSettledResolvers);
+    }
+  };
+
+  const startSync = (sourceId: string): void => {
+    activeSyncs++;
+    // .catch() prevents unhandled rejections — callers are expected to handle
+    // errors inside their syncSource callback, but any leak is silenced here.
+    void syncSource(sourceId).catch(() => undefined).finally(() => {
+      activeSyncs--;
+      startAvailableSyncs();
+      resolveFirstSettled();
+      resolveIdle();
+    });
+  };
+
+  const startAvailableSyncs = (): void => {
+    while (activeSyncs < concurrency && pending.length > 0) {
+      startSync(pending.shift()!);
+    }
+  };
+
+  return {
+    enqueue: (sourceId) => {
+      pending.push(sourceId);
+      startAvailableSyncs();
+    },
+    onIdle: () => new Promise<void>((resolve) => {
+      idleResolvers.push(resolve);
+      resolveIdle();
+    }),
+    onFirstSettled: () => new Promise<void>((resolve) => {
+      // Eager resolution: if a sync already settled before this is called, resolve
+      // in the same microtask tick rather than waiting indefinitely.
+      if (hasSettledOne) {
+        resolve();
+        return;
+      }
+      firstSettledResolvers.push(resolve);
+    })
+  };
+}

--- a/packages/app/src/registry/source-sync-queue.ts
+++ b/packages/app/src/registry/source-sync-queue.ts
@@ -1,5 +1,6 @@
 export interface SourceSyncQueue {
   enqueue: (sourceId: string) => void;
+  hasEnqueued: () => boolean;
   onIdle: () => Promise<void>;
   onFirstSettled: () => Promise<void>;
 }
@@ -26,6 +27,7 @@ export function createSourceSyncQueue(
   const idleResolvers: (() => void)[] = [];
   const firstSettledResolvers: (() => void)[] = [];
   let activeSyncs = 0;
+  let enqueuedCount = 0;
   let hasSettledOne = false;
 
   const flush = (resolvers: (() => void)[]): void => resolvers.splice(0).forEach((r) => r());
@@ -63,9 +65,11 @@ export function createSourceSyncQueue(
 
   return {
     enqueue: (sourceId) => {
+      enqueuedCount++;
       pending.push(sourceId);
       startAvailableSyncs();
     },
+    hasEnqueued: () => enqueuedCount > 0,
     onIdle: () => new Promise<void>((resolve) => {
       idleResolvers.push(resolve);
       resolveIdle();

--- a/packages/app/test/registry/load-hub-sources.test.ts
+++ b/packages/app/test/registry/load-hub-sources.test.ts
@@ -18,6 +18,7 @@ import {
 import {
   findDuplicateSource,
   loadHubSources,
+  loadHubSourcesProgressively,
 } from '../../src/registry/load-hub-sources';
 
 function makeHubSource(overrides: Partial<HubSource> = {}): HubSource {
@@ -183,6 +184,78 @@ describe('loadHubSources', () => {
     expect(result).toEqual({ added: 2, updated: 0, skipped: 1 });
   });
 
+  it('adds sources concurrently without exceeding the configured limit', async () => {
+    let activeAdds = 0;
+    let maxActiveAdds = 0;
+    let startedAdds = 0;
+    let releaseAdds: (() => void) | undefined;
+    const addsReleased = new Promise<void>((resolve) => {
+      releaseAdds = resolve;
+    });
+    let firstBatchStarted: (() => void) | undefined;
+    const firstBatchReady = new Promise<void>((resolve) => {
+      firstBatchStarted = resolve;
+    });
+
+    ports.addSource = vi.fn(async () => {
+      activeAdds++;
+      startedAdds++;
+      maxActiveAdds = Math.max(maxActiveAdds, activeAdds);
+      if (startedAdds === 2) {
+        firstBatchStarted?.();
+      }
+      await addsReleased;
+      activeAdds--;
+    });
+
+    const sources = [
+      makeHubSource({ id: 's1', url: 'https://github.com/org/one' }),
+      makeHubSource({ id: 's2', url: 'https://github.com/org/two' }),
+      makeHubSource({ id: 's3', url: 'https://github.com/org/three' })
+    ];
+
+    const loading = loadHubSources('hub-a', sources, ports, undefined, { concurrency: 2 });
+    await firstBatchReady;
+
+    expect(startedAdds).toBe(2);
+    expect(maxActiveAdds).toBe(2);
+
+    releaseAdds?.();
+    await loading;
+
+    expect(startedAdds).toBe(3);
+    expect(maxActiveAdds).toBe(2);
+  });
+
+  it('notifies only after a source is added successfully', async () => {
+    const addedSources: string[] = [];
+    ports.addSource = vi.fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('Source validation failed'));
+
+    const result = await loadHubSources(
+      'hub-a',
+      [
+        makeHubSource({ id: 's1', url: 'https://github.com/org/one' }),
+        makeHubSource({ id: 's2', url: 'https://github.com/org/two' })
+      ],
+      ports,
+      undefined,
+      {
+        concurrency: 2,
+        onSourceAdded: (source) => addedSources.push(source.id)
+      }
+    );
+
+    expect(result).toEqual({ added: 1, updated: 0, skipped: 1 });
+    expect(addedSources).toEqual([
+      generateSourceId('awesome-copilot', 'https://github.com/org/one', {
+        branch: 'main',
+        collectionsPath: 'collections'
+      })
+    ]);
+  });
+
   it('propagates a listSources failure', async () => {
     ports.listSources = vi.fn().mockRejectedValue(new Error('storage unavailable'));
 
@@ -196,5 +269,185 @@ describe('loadHubSources', () => {
     expect(events.some((m) => m.includes('Found 1 sources in hub hub-a'))).toBe(true);
     expect(events.some((m) => m.includes('Adding new hub source'))).toBe(true);
     expect(events.some((m) => m.includes('Hub source loading complete for hub-a: 1 added, 0 updated, 0 skipped'))).toBe(true);
+  });
+});
+
+describe('loadHubSourcesProgressively', () => {
+  let ports: ReturnType<typeof makePorts>;
+
+  beforeEach(() => {
+    ports = makePorts();
+  });
+
+  it('enqueues each newly added source for syncSource', async () => {
+    const synced: string[] = [];
+    const { onComplete } = loadHubSourcesProgressively(
+      'hub-a',
+      [
+        makeHubSource({ id: 's1', url: 'https://github.com/org/one' }),
+        makeHubSource({ id: 's2', url: 'https://github.com/org/two' })
+      ],
+      ports,
+      undefined,
+      {
+        concurrency: 2,
+        syncSource: async (id) => {
+          synced.push(id);
+        }
+      }
+    );
+
+    await onComplete();
+
+    expect(synced).toHaveLength(2);
+    const addedIds = ports.sources.map((s) => s.id);
+    expect(synced.toSorted()).toEqual(addedIds.toSorted());
+  });
+
+  it('onFirstSettled resolves after the first sync settles', async () => {
+    let releaseFirst!: () => void;
+    const firstBlocker = new Promise<void>((r) => {
+      releaseFirst = r;
+    });
+
+    const syncCalls: string[] = [];
+
+    const { onFirstSettled, onComplete } = loadHubSourcesProgressively(
+      'hub-a',
+      [makeHubSource({ id: 's1', url: 'https://github.com/org/one' })],
+      ports,
+      undefined,
+      {
+        syncSource: async (id) => {
+          syncCalls.push(id);
+          await firstBlocker;
+        }
+      }
+    );
+
+    let firstSettled = false;
+    const firstSettledPromise = onFirstSettled().then(() => {
+      firstSettled = true;
+    });
+
+    await Promise.resolve();
+    expect(firstSettled).toBe(false);
+
+    releaseFirst();
+    await firstSettledPromise;
+    expect(firstSettled).toBe(true);
+
+    await onComplete();
+  });
+
+  it('onComplete resolves only after all registrations and syncs finish', async () => {
+    const releases: (() => void)[] = [];
+    let allSyncsStarted!: () => void;
+    const allSyncsStartedPromise = new Promise<void>((r) => {
+      allSyncsStarted = r;
+    });
+
+    const { onComplete } = loadHubSourcesProgressively(
+      'hub-a',
+      [
+        makeHubSource({ id: 's1', url: 'https://github.com/org/one' }),
+        makeHubSource({ id: 's2', url: 'https://github.com/org/two' })
+      ],
+      ports,
+      undefined,
+      {
+        concurrency: 2,
+        syncSource: () => new Promise<void>((r) => {
+          releases.push(r);
+          if (releases.length === 2) {
+            allSyncsStarted();
+          }
+        })
+      }
+    );
+
+    // Wait until both background syncs have started (i.e. registration is done)
+    await allSyncsStartedPromise;
+
+    let completed = false;
+    const completedPromise = onComplete().then(() => {
+      completed = true;
+    });
+
+    await Promise.resolve();
+    expect(completed).toBe(false);
+
+    releases[0]();
+    await Promise.resolve();
+    expect(completed).toBe(false);
+
+    releases[1]();
+    await completedPromise;
+    expect(completed).toBe(true);
+  });
+
+  it('onFirstSettled resolves when registration finishes with no enabled sources', async () => {
+    // Zero sources means no syncs are ever enqueued; onFirstSettled must not hang.
+    const { onFirstSettled, onComplete } = loadHubSourcesProgressively(
+      'hub-a',
+      [makeHubSource({ enabled: false })],
+      ports,
+      undefined,
+      {
+        syncSource: async () => {
+          // never called
+        }
+      }
+    );
+
+    // Should resolve without hanging (registration finishes, zero syncs)
+    await onFirstSettled();
+    await onComplete();
+  });
+
+  it('passes through a caller-supplied onSourceAdded hook alongside the sync enqueue', async () => {
+    const notified: string[] = [];
+    const synced: string[] = [];
+
+    const { onComplete } = loadHubSourcesProgressively(
+      'hub-a',
+      [makeHubSource()],
+      ports,
+      undefined,
+      {
+        onSourceAdded: (source) => {
+          notified.push(source.id);
+        },
+        syncSource: async (id) => {
+          synced.push(id);
+        }
+      }
+    );
+
+    await onComplete();
+
+    expect(notified).toHaveLength(1);
+    expect(synced).toHaveLength(1);
+    expect(notified[0]).toBe(synced[0]);
+  });
+
+  it('does not enqueue disabled sources for sync', async () => {
+    const synced: string[] = [];
+
+    const { onComplete } = loadHubSourcesProgressively(
+      'hub-a',
+      [makeHubSource({ enabled: false })],
+      ports,
+      undefined,
+      {
+        syncSource: async (id) => {
+          synced.push(id);
+        }
+      }
+    );
+
+    await onComplete();
+
+    expect(synced).toHaveLength(0);
   });
 });

--- a/packages/app/test/registry/load-hub-sources.test.ts
+++ b/packages/app/test/registry/load-hub-sources.test.ts
@@ -340,6 +340,37 @@ describe('loadHubSourcesProgressively', () => {
     await onComplete();
   });
 
+  it('does not resolve onFirstSettled while a registered source is still syncing', async () => {
+    let release!: () => void;
+    const blocker = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const { onFirstSettled, onComplete } = loadHubSourcesProgressively(
+      'hub-a',
+      [makeHubSource()],
+      ports,
+      undefined,
+      {
+        syncSource: async () => blocker
+      }
+    );
+
+    let firstSettled = false;
+    const firstSettledPromise = onFirstSettled().then(() => {
+      firstSettled = true;
+    });
+
+    for (let i = 0; i < 5; i++) {
+      await Promise.resolve();
+    }
+    expect(firstSettled).toBe(false);
+
+    release();
+    await firstSettledPromise;
+    await onComplete();
+  });
+
   it('onComplete resolves only after all registrations and syncs finish', async () => {
     const releases: (() => void)[] = [];
     let allSyncsStarted!: () => void;

--- a/packages/app/test/registry/source-sync-queue.test.ts
+++ b/packages/app/test/registry/source-sync-queue.test.ts
@@ -1,0 +1,173 @@
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  createSourceSyncQueue,
+} from '../../src/registry/source-sync-queue';
+
+describe('createSourceSyncQueue', () => {
+  it('onIdle resolves immediately when no sources are enqueued', async () => {
+    const queue = createSourceSyncQueue(() => Promise.resolve(), 2);
+    await queue.onIdle();
+  });
+
+  it('onIdle resolves after a single enqueued source finishes', async () => {
+    let release!: () => void;
+    const blocker = new Promise<void>((r) => {
+      release = r;
+    });
+
+    const queue = createSourceSyncQueue(() => blocker, 2);
+    queue.enqueue('s1');
+
+    let resolved = false;
+    const idlePromise = queue.onIdle().then(() => {
+      resolved = true;
+    });
+
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    release();
+    await idlePromise;
+    expect(resolved).toBe(true);
+  });
+
+  it('onIdle resolves only after all enqueued sources finish', async () => {
+    const releases: (() => void)[] = [];
+    const sync = () => new Promise<void>((r) => {
+      releases.push(r);
+    });
+
+    const queue = createSourceSyncQueue(sync, 3);
+    queue.enqueue('s1');
+    queue.enqueue('s2');
+    queue.enqueue('s3');
+
+    let resolved = false;
+    const idlePromise = queue.onIdle().then(() => {
+      resolved = true;
+    });
+
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    releases[0]();
+    releases[1]();
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    releases[2]();
+    await idlePromise;
+    expect(resolved).toBe(true);
+  });
+
+  it('onFirstSettled resolves after the first source settles (success)', async () => {
+    let release!: () => void;
+    const blocker = new Promise<void>((r) => {
+      release = r;
+    });
+
+    const queue = createSourceSyncQueue(() => blocker, 1);
+    queue.enqueue('s1');
+
+    let settled = false;
+    const firstSettledPromise = queue.onFirstSettled().then(() => {
+      settled = true;
+    });
+
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    release();
+    await firstSettledPromise;
+    expect(settled).toBe(true);
+  });
+
+  it('onFirstSettled resolves after the first source settles (failure)', async () => {
+    // syncSource is expected to handle its own errors — the queue only calls
+    // .catch(() => undefined) as a safety net, so the callback swallows here.
+    const sync = () => Promise.reject(new Error('sync failed')).catch(() => undefined) as Promise<void>;
+    const queue = createSourceSyncQueue(sync, 1);
+    queue.enqueue('s1');
+
+    await queue.onFirstSettled(); // must resolve, not hang
+  });
+
+  it('onFirstSettled resolves immediately when already settled before promise is registered', async () => {
+    let release!: () => void;
+    const blocker = new Promise<void>((r) => {
+      release = r;
+    });
+
+    const queue = createSourceSyncQueue(() => blocker, 1);
+    queue.enqueue('s1');
+
+    release();
+    // Drain the microtask chain: blocker → catch → finally → hasSettledOne=true
+    for (let i = 0; i < 5; i++) {
+      await Promise.resolve();
+    }
+
+    let settled = false;
+    await queue.onFirstSettled().then(() => {
+      settled = true;
+    });
+    expect(settled).toBe(true);
+  });
+
+  it('does not exceed the concurrency limit', async () => {
+    let active = 0;
+    let maxActive = 0;
+    const releases: (() => void)[] = [];
+
+    const sync = () => new Promise<void>((r) => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      releases.push(() => {
+        active--;
+        r();
+      });
+    });
+
+    const queue = createSourceSyncQueue(sync, 2);
+    queue.enqueue('s1');
+    queue.enqueue('s2');
+    queue.enqueue('s3');
+
+    await Promise.resolve();
+    expect(active).toBe(2);
+
+    releases[0]();
+    // Drain: resolve → catch → finally → startAvailableSyncs → sync(s3) starts
+    for (let i = 0; i < 5; i++) {
+      await Promise.resolve();
+    }
+    expect(active).toBe(2);
+
+    releases[1]();
+    releases[2]();
+    await queue.onIdle();
+    expect(maxActive).toBe(2);
+  });
+
+  it('proceeds past a failing sync to remaining sources', async () => {
+    const synced: string[] = [];
+    const sync = async (id: string) => {
+      if (id === 's2') {
+        throw new Error('forced failure');
+      }
+      synced.push(id);
+    };
+
+    const queue = createSourceSyncQueue(sync, 3);
+    queue.enqueue('s1');
+    queue.enqueue('s2');
+    queue.enqueue('s3');
+
+    await queue.onIdle();
+    expect(synced.toSorted()).toEqual(['s1', 's3']);
+  });
+});


### PR DESCRIPTION
## Description

Implements progressive hub source loading for the VS Code extension. Hub configuration is persisted and surfaced immediately; enabled sources are registered and synchronized in bounded background queues so the marketplace and registry tree populate incrementally.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] ⚡ Performance improvement
- [x] 🧪 Test coverage improvement

## Changes Made

- Adds shared app-layer progressive loading and bounded source-sync queue primitives.
- Starts source registration and synchronization after hub configuration is stored, without blocking first-run activation on the full batch. First run waits only until the first source sync settles before activating the hub; the remaining work continues in the background.
- Keeps the existing explicit source-loading API behavior for callers that pass loading options, including awaited registration and source-added notifications.
- Prevents concurrent registry config mutations from losing sources; cache reads use the previous completed snapshot for README reuse, and progressive bundle-cache writes are atomic.
- Avoids duplicate source loading when an already-imported hub is activated.
- Replaces the marketplace timing delay with a webview-ready handshake and retains the latest payload until it can be delivered.

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing completed
- [x] All existing tests pass

###Manual testing

https://github.com/user-attachments/assets/be472402-1801-47b1-a30b-1445e8ec6679


## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Documentation

- [x] No documentation changes needed

## Additional Notes

### Architecture

```mermaid
flowchart LR
  User[User selects or imports a hub] --> HM[HubManager]
  HM --> App[App HubManager: resolve, validate, persist config]
  App --> HS[HubStorage cache refresh]
  HS --> Event[Hub imported event: refresh views]
  HM --> Loader[app loadHubSourcesProgressively]
  Loader --> Registry[RegistryManager: add/update sources]
  Registry --> Queue[SourceSyncQueue: bounded concurrency]
  Queue --> Sync[RegistryManager syncSource]
  Sync --> Cache[Atomic bundle-cache updates]
  Cache --> Views[Marketplace and registry tree]
  Views --> Webview[Ready-handshake bundle delivery]
```

App package build, lint, and tests pass. Extension compile, test compilation, lint, and unit tests pass. Repository-wide lint reports 648 pre-existing warnings and no errors.

## Reviewer Guidelines

Please pay special attention to:

- Source registration and source-sync lifecycle boundaries, including first-settled behavior.
- The preservation of explicit source-loading options and duplicate-loading avoidance.

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**