### PR TITLE
fix(agent): recognize plain .md files inside agents/ as Copilot agent

### DIFF
--- a/apps/vscode-extension/src/commands/validate-apm-command.ts
+++ b/apps/vscode-extension/src/commands/validate-apm-command.ts
@@ -74,6 +74,9 @@ export class ValidateApmCommand {
         } else {
           if (PROMPT_EXTENSIONS.some((ext) => name.endsWith(ext))) {
             fileList.push(entryUri.fsPath);
+          } else if (name.endsWith('.md') && /(?:^|[/])agents[/]/i.test(entryUri.fsPath.replace(/\\/g, '/'))) {
+            // VS Code no longer requires .agent.md suffix — any .md in agents/ is an agent
+            fileList.push(entryUri.fsPath);
           }
         }
       }

--- a/apps/vscode-extension/src/services/bundle-installer.ts
+++ b/apps/vscode-extension/src/services/bundle-installer.ts
@@ -54,6 +54,7 @@ import {
   RepositoryCommitMode,
 } from '../types/registry';
 import {
+  CopilotFileType,
   determineFileType,
   getRepositoryTargetDirectory,
   getSkillName,
@@ -240,7 +241,7 @@ export class BundleInstaller {
       // Collect files from .github/ directories based on manifest
       for (const promptDef of manifest.prompts) {
         const promptId = normalizePromptId(promptDef.id);
-        const fileType = determineFileType(promptDef.file, promptDef.tags);
+        const fileType = (promptDef.type as CopilotFileType) || determineFileType(promptDef.file, promptDef.tags);
         const targetDir = getRepositoryTargetDirectory(fileType);
 
         if (fileType === 'skill') {

--- a/packages/cli/src/commands/index-search.ts
+++ b/packages/cli/src/commands/index-search.ts
@@ -9,6 +9,10 @@
  * with `--index <FILE>`.
  * @module commands/index-search
  */
+import * as path from 'node:path';
+import {
+  resolveUserConfigPaths,
+} from '@ai-primitives-hub/app';
 import {
   generateSourceId,
 } from '@ai-primitives-hub/core';
@@ -19,8 +23,10 @@ import type {
   TokenProvider,
 } from '@ai-primitives-hub/core';
 import {
+  ActiveHubStore,
   defaultIndexFile,
   defaultTokenProvider,
+  HubStore,
   loadIndex,
   NodeHttpClient,
   readTargets,
@@ -47,6 +53,30 @@ import {
 } from './install';
 
 type SearchCandidate = { bundleId: string; version: string; source: RegistrySource };
+
+async function resolveActiveHubSources(
+  ctx: Context,
+  mgr: ReturnType<typeof createHubManager>
+): Promise<RegistrySource[] | null> {
+  const active = await mgr.getActiveHub();
+  if (active !== null) {
+    return active.config.sources;
+  }
+
+  const userPaths = resolveUserConfigPaths(ctx.env);
+  const legacyRoot = path.join(path.dirname(userPaths.root), 'prompt-registry');
+  const legacyActiveStore = new ActiveHubStore(path.join(legacyRoot, 'active-hub.json'), ctx.fs);
+  const legacyHubId = await legacyActiveStore.get();
+  if (legacyHubId === null) {
+    return null;
+  }
+  const legacyStore = new HubStore(path.join(legacyRoot, 'hubs'), ctx.fs);
+  if (!(await legacyStore.has(legacyHubId))) {
+    return null;
+  }
+  const legacyHub = await legacyStore.load(legacyHubId);
+  return legacyHub.config.sources;
+}
 
 function buildSearchCandidates(sources: RegistrySource[], hits: SearchResult['hits']): SearchCandidate[] {
   const sourceById = new Map<string, RegistrySource>();
@@ -132,13 +162,13 @@ async function searchAndInstall(
   const http = opts.http ?? new NodeHttpClient();
   const tokens = opts.tokens ?? defaultTokenProvider(ctx.env);
   const mgr = createHubManager({ ctx, http, tokens });
-  const active = await mgr.getActiveHub();
-  if (active === null) {
+  const activeSources = await resolveActiveHubSources(ctx, mgr);
+  if (activeSources === null) {
     ctx.stderr.write('No active hub found. Run `ai-primitives-hub hub use <id>` first.\n');
     return 1;
   }
 
-  const candidates = buildSearchCandidates(active.config.sources, result.hits);
+  const candidates = buildSearchCandidates(activeSources, result.hits);
 
   if (candidates.length === 0) {
     ctx.stdout.write('No bundles from the active hub matched the search results.\n');

--- a/packages/cli/test/commands/index.test.ts
+++ b/packages/cli/test/commands/index.test.ts
@@ -18,6 +18,11 @@ import {
 import * as os from 'node:os';
 import * as path from 'node:path';
 import {
+  resolveUserConfigPaths,
+} from '@ai-primitives-hub/app';
+import {
+  ActiveHubStore,
+  HubStore,
   NodeFileSystem,
 } from '@ai-primitives-hub/infra';
 import {
@@ -164,6 +169,59 @@ describe('index commands', () => {
       expect(result.exitCode).toBe(0);
       const envelope = parseJson<{ hits: unknown[] }>(result.stdout);
       expect(envelope.data.hits).toEqual([]);
+    });
+
+    it('uses legacy prompt-registry active hub when installing from search results', async () => {
+      const userPaths = resolveUserConfigPaths({
+        HOME: workspace,
+        USERPROFILE: workspace,
+        XDG_CONFIG_HOME: path.join(workspace, 'xdg-config'),
+        XDG_CACHE_HOME: path.join(workspace, 'xdg-cache')
+      });
+      const legacyRoot = path.join(path.dirname(userPaths.root), 'prompt-registry');
+      const legacyHubsDir = path.join(legacyRoot, 'hubs');
+      const legacyActiveHubPath = path.join(legacyRoot, 'active-hub.json');
+      const fs = new NodeFileSystem();
+      const hubId = 'legacy-hub';
+
+      const hubStore = new HubStore(legacyHubsDir, fs);
+      await hubStore.save(hubId, {
+        version: '1.0.0',
+        metadata: {
+          name: 'Legacy Hub',
+          description: 'Legacy hub for regression test',
+          maintainer: 'tests',
+          updatedAt: new Date().toISOString()
+        },
+        sources: [
+          {
+            id: 'local-foo-src',
+            name: 'Local Foo Source',
+            description: 'Source matching indexed bundle source id',
+            type: 'local',
+            url: 'file:///tmp/local-foo',
+            repository: 'local/foo',
+            branch: 'main',
+            path: '/',
+            hubId
+          }
+        ],
+        profiles: []
+      }, {
+        type: 'local',
+        location: legacyRoot
+      });
+
+      const activeHubStore = new ActiveHubStore(legacyActiveHubPath, fs);
+      await activeHubStore.set(hubId);
+
+      const result = await run([
+        'index', 'search', '--query', 'hello', '--index', indexFile, '--install'
+      ]);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('No target found. Run `ai-primitives-hub target add` first.');
+      expect(result.stderr).not.toContain('No active hub found');
     });
   });
 

--- a/packages/core/src/domain/install/copilot-file-type.ts
+++ b/packages/core/src/domain/install/copilot-file-type.ts
@@ -103,10 +103,11 @@ export function getSkillName(skillPath: string): string | null {
  *
  * Detection priority:
  * 1. File extension patterns (e.g., .prompt.md, .agent.md)
- * 2. Special file names (e.g., SKILL.md)
- * 3. Tags from manifest
- * 4. Filename patterns (e.g., contains "instructions")
- * 5. Default to 'prompt'
+ * 2. Directory-based detection (e.g., any .md file in an agents/ directory)
+ * 3. Special file names (e.g., SKILL.md)
+ * 4. Tags from manifest
+ * 5. Filename patterns (e.g., contains "instructions")
+ * 6. Default to 'prompt'
  * @param fileName - The file name or path to analyze
  * @param tags - Optional tags from the manifest
  * @returns The detected CopilotFileType
@@ -130,12 +131,19 @@ export function determineFileType(fileName: string, tags?: string[]): CopilotFil
     return 'agent';
   }
 
-  // 2. Check for special file names
+  // 2. Check if file is in an agents/ directory
+  // VS Code no longer requires .agent.md suffix — any .md in agents/ is an agent
+  const normalizedPath = fileName.replace(/\\/g, '/');
+  if (lowerBaseName.endsWith('.md') && /(?:^|[/])agents[/]/i.test(normalizedPath)) {
+    return 'agent';
+  }
+
+  // 3. Check for special file names
   if (lowerBaseName === 'skill.md') {
     return 'skill';
   }
 
-  // 3. Check tags if provided
+  // 4. Check tags if provided
   if (tags && tags.length > 0) {
     const lowerTags = tags.map((t) => t.toLowerCase());
 
@@ -153,12 +161,12 @@ export function determineFileType(fileName: string, tags?: string[]): CopilotFil
     }
   }
 
-  // 4. Check filename patterns
+  // 5. Check filename patterns
   if (lowerBaseName.includes('instructions')) {
     return 'instructions';
   }
 
-  // 5. Default to prompt
+  // 6. Default to prompt
   return 'prompt';
 }
 

--- a/packages/core/test/domain/install/copilot-file-type.test.ts
+++ b/packages/core/test/domain/install/copilot-file-type.test.ts
@@ -35,6 +35,16 @@ describe('determineFileType', () => {
     expect(determineFileType('foo.agent.md')).toBe('agent');
   });
 
+  it('detects any .md file in an agents/ directory as an agent', () => {
+    expect(determineFileType('agents/reviewer.md')).toBe('agent');
+    expect(determineFileType('path/to/agents/my-agent.md')).toBe('agent');
+  });
+
+  it('does not treat .md files outside agents/ as agents', () => {
+    expect(determineFileType('prompts/my-agent.md')).toBe('prompt');
+    expect(determineFileType('instructions/my-agent.md')).toBe('prompt');
+  });
+
   it('is case-insensitive on extension', () => {
     expect(determineFileType('FOO.PROMPT.MD')).toBe('prompt');
   });

--- a/packages/infra/src/adapters/apm-adapter.ts
+++ b/packages/infra/src/adapters/apm-adapter.ts
@@ -165,7 +165,8 @@ function titleCase(value: string): string {
     .join(' ');
 }
 
-function detectFileType(filename: string): 'prompt' | 'instructions' | 'chatmode' | 'agent' {
+function detectFileType(filePath: string): 'prompt' | 'instructions' | 'chatmode' | 'agent' {
+  const filename = path.basename(filePath);
   if (filename.endsWith('.instructions.md')) {
     return 'instructions';
   }
@@ -173,6 +174,11 @@ function detectFileType(filename: string): 'prompt' | 'instructions' | 'chatmode
     return 'chatmode';
   }
   if (filename.endsWith('.agent.md')) {
+    return 'agent';
+  }
+  // VS Code no longer requires .agent.md suffix — any .md in agents/ is an agent
+  const normalized = filePath.replace(/\\/g, '/');
+  if (/(?:^|[/])agents[/]/i.test(normalized) && filename.endsWith('.md')) {
     return 'agent';
   }
   return 'prompt';
@@ -466,6 +472,9 @@ export class ApmAdapter extends BaseSourceAdapter {
           }
         } else if (PROMPT_EXTENSIONS.some((ext) => entry.name.endsWith(ext))) {
           files.push(fullPath);
+        } else if (entry.name.endsWith('.md') && /(?:^|[/])agents[/]/i.test(fullPath.replace(/\\/g, '/'))) {
+          // VS Code no longer requires .agent.md suffix — any .md in agents/ is an agent
+          files.push(fullPath);
         }
       }
     };
@@ -483,13 +492,13 @@ export class ApmAdapter extends BaseSourceAdapter {
     const promptFiles = await this.findPromptFiles(installDir);
     const prompts = promptFiles.map((file) => {
       const filename = path.basename(file);
-      const id = filename.replace(/\.(prompt|instructions|agent|chatmode)\.md$/, '');
+      const id = filename.replace(/\.(prompt|instructions|agent|chatmode)\.md$/, '').replace(/\.md$/, '');
       return {
         id,
         name: titleCase(id.replace(/-/g, ' ')),
         description: `From ${bundle.name}`,
         file: `prompts/${filename}`,
-        type: detectFileType(filename),
+        type: detectFileType(file),
         tags: apmManifest.tags ?? []
       };
     });

--- a/packages/infra/src/adapters/awesome-copilot-adapter.ts
+++ b/packages/infra/src/adapters/awesome-copilot-adapter.ts
@@ -300,7 +300,7 @@ export class AwesomeCopilotAdapter extends BaseSourceAdapter {
       }
 
       const filename = item.path.split('/').pop() ?? 'unknown';
-      const id = filename.replace(/\.(prompt|instructions|chatmode|agent)\.md$/, '');
+      const id = filename.replace(/\.(prompt|instructions|chatmode|agent)\.md$/, '').replace(/\.md$/, '');
       return {
         id,
         name: titleCase(id.replace(/-/g, ' ')),

--- a/packages/infra/src/adapters/local-apm-adapter.ts
+++ b/packages/infra/src/adapters/local-apm-adapter.ts
@@ -127,7 +127,8 @@ function titleCase(value: string): string {
     .join(' ');
 }
 
-function detectFileType(filename: string): 'prompt' | 'instructions' | 'chatmode' | 'agent' {
+function detectFileType(filePath: string): 'prompt' | 'instructions' | 'chatmode' | 'agent' {
+  const filename = path.basename(filePath);
   if (filename.endsWith('.instructions.md')) {
     return 'instructions';
   }
@@ -135,6 +136,11 @@ function detectFileType(filename: string): 'prompt' | 'instructions' | 'chatmode
     return 'chatmode';
   }
   if (filename.endsWith('.agent.md')) {
+    return 'agent';
+  }
+  // VS Code no longer requires .agent.md suffix — any .md in agents/ is an agent
+  const normalized = filePath.replace(/\\/g, '/');
+  if (/(?:^|[/])agents[/]/i.test(normalized) && filename.endsWith('.md')) {
     return 'agent';
   }
   return 'prompt';
@@ -264,6 +270,9 @@ export class LocalApmAdapter extends BaseSourceAdapter {
           }
         } else if (PROMPT_EXTENSIONS.some((ext) => entry.name.endsWith(ext))) {
           files.push(fullPath);
+        } else if (entry.name.endsWith('.md') && /(?:^|[/])agents[/]/i.test(fullPath.replace(/\\/g, '/'))) {
+          // VS Code no longer requires .agent.md suffix — any .md in agents/ is an agent
+          files.push(fullPath);
         }
       }
     };
@@ -290,13 +299,13 @@ export class LocalApmAdapter extends BaseSourceAdapter {
     const promptFiles = await this.findPromptFiles(packageDir, true);
     const prompts = promptFiles.map((file) => {
       const filename = path.basename(file);
-      const id = filename.replace(/\.(prompt|instructions|agent|chatmode)\.md$/, '');
+      const id = filename.replace(/\.(prompt|instructions|agent|chatmode)\.md$/, '').replace(/\.md$/, '');
       return {
         id,
         name: titleCase(id.replace(/-/g, ' ')),
         description: `From ${bundle.name}`,
         file: `prompts/${filename}`,
-        type: detectFileType(filename),
+        type: detectFileType(file),
         tags: apmManifest.tags ?? []
       };
     });

--- a/packages/infra/src/adapters/local-awesome-copilot-adapter.ts
+++ b/packages/infra/src/adapters/local-awesome-copilot-adapter.ts
@@ -257,7 +257,7 @@ export class LocalAwesomeCopilotAdapter extends BaseSourceAdapter {
       }
 
       const filename = item.path.split('/').pop() ?? 'unknown';
-      const id = filename.replace(/\.(prompt|instructions|chatmode|agent)\.md$/, '');
+      const id = filename.replace(/\.(prompt|instructions|chatmode|agent)\.md$/, '').replace(/\.md$/, '');
       return {
         id,
         name: titleCase(id.replace(/-/g, ' ')),


### PR DESCRIPTION
## Description

Two related fixes:

1. **Agent file detection** — align with the current Copilot convention that any `.md` file placed in an `agents/` directory is an agent, regardless of the `.agent.md` suffix.
2. **CLI legacy active-hub fallback** — `index search --install` can now fall back to a pre-migration `prompt-registry` active hub when no new-style hub is active.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test coverage improvement
- [ ] 🔧 Configuration/build changes

## Related Issues

Fixes #307

## Changes Made

- `packages/core/src/domain/install/copilot-file-type.ts`
  - `determineFileType` now detects any `.md` file inside an `agents/` directory as an `agent`.
- `packages/infra/src/adapters/{apm,local-apm,awesome-copilot,local-awesome-copilot}-adapter.ts`
  - APM `detectFileType` and `findPromptFiles` include plain `.md` files in `agents/`.
  - ID extraction now also strips a bare `.md` extension so agent ids are clean.
- `apps/vscode-extension/src/services/bundle-installer.ts`
  - Prefer `promptDef.type` from the manifest, falling back to `determineFileType`.
- `apps/vscode-extension/src/commands/validate-apm-command.ts`
  - APM validation now recognizes plain `.md` files inside `agents/` directories.
- `packages/cli/src/commands/index-search.ts`
  - `resolveActiveHubSources` checks the new active hub first, then falls back to a legacy `prompt-registry` active hub and sources.
- Tests added/updated for agent detection in `core` and for the legacy active-hub fallback in `cli`.

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing completed
- [x] All existing tests pass

### Manual Testing Steps

N/A — changes are covered by automated unit tests and package build/lint runs.

### Tested On

- [ ] macOS
- [ ] Windows
- [x] Linux

- [ ] VS Code Stable
- [ ] VS Code Insiders

## Screenshots

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Documentation

- [ ] README.md updated
- [ ] JSDoc comments added/updated
- [x] No documentation changes needed

## Additional Notes

- The branch `issue-307` contains two commits:
  - `a2647f5` — CLI legacy active-hub fallback
  - `322f0bb` — agent `.md` detection fix
- `pnpm -C packages -r build` and `pnpm -C packages -r lint` pass with only pre-existing warnings.
- `apps/vscode-extension` `compile-tests` and `test:unit` were run; the suite reports 2113 passing, 27 pending, and 2 pre-existing `ApmRuntimeManager` timeout failures that are unrelated to these changes.

## Reviewer Guidelines

Please pay special attention to:

- `determineFileType` directory-based agent detection in `core`.
- ID extraction for plain `.md` agent files in the APM and awesome-copilot adapters.
- The legacy active-hub fallback path in `packages/cli/src/commands/index-search.ts`.

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**
