### PR TITLE
fix(cli): resolve default bundle collection file

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai-primitives-hub/app",
-  "version": "0.0.1-alpha.1",
+  "version": "0.0.1-alpha.2",
   "description": "Use-case orchestration for AI Primitives Hub: install/uninstall pipelines, registry (hub/profile), discovery and search, multi-target content transforms. Also the public SDK surface until a standalone sdk package has a real consumer.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -10,12 +10,19 @@
     "url": "git+https://github.com/AmadeusITGroup/ai-primitives-hub.git",
     "directory": "packages/app"
   },
-  "keywords": ["ai-primitives-hub", "app", "use-cases", "orchestration"],
+  "keywords": [
+    "ai-primitives-hub",
+    "app",
+    "use-cases",
+    "orchestration"
+  ],
   "author": {
     "name": "Amadeus IT Group",
     "email": "opensource@amadeus.com"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "watch": "tsc --watch",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai-primitives-hub/cli",
-  "version": "0.0.1-alpha.1",
+  "version": "0.0.1-alpha.2",
   "description": "ai-primitives-hub CLI. Thin Clipanion delivery adapter over @ai-primitives-hub/app — argument parsing and output formatting only, never business logic.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli/src/commands/bundle-build.ts
+++ b/packages/cli/src/commands/bundle-build.ts
@@ -44,6 +44,7 @@ import {
 } from '../framework';
 import {
   generateBundleManifest,
+  resolveCollectionFile,
 } from './bundle-manifest';
 
 /**
@@ -177,11 +178,11 @@ export class BundleBuildCommand extends Command {
   public async execute(): Promise<number> {
     const { ctx } = this.commandContext;
     const fmt = (this.output ?? 'text');
-    const collectionFile = this.collectionFile ?? '';
     const version = this.version ?? '';
 
     try {
       const cwd = ctx.cwd();
+      const collectionFile = await resolveCollectionFile(ctx, cwd, this.collectionFile);
       const repoSlug = (this.repoSlug
         ?? (ctx.env.GITHUB_REPOSITORY ?? '').replaceAll('/', '-'))
       || path.basename(cwd);

--- a/packages/cli/src/commands/bundle-manifest.ts
+++ b/packages/cli/src/commands/bundle-manifest.ts
@@ -306,7 +306,7 @@ function buildManifest(
  * @param explicit Explicit collection file path.
  * @returns Resolved collection file path.
  */
-const resolveCollectionFile = async (
+export const resolveCollectionFile = async (
   ctx: Context,
   cwd: string,
   explicit: string | undefined

--- a/packages/cli/test/commands/collection-bundle.test.ts
+++ b/packages/cli/test/commands/collection-bundle.test.ts
@@ -248,6 +248,18 @@ items:
       const zipStat = await stat(envelope.data.zipAsset);
       expect(zipStat.size).toBeGreaterThan(0);
     });
+
+    it('defaults to the first collection file under collections/ when --collection-file is omitted', async () => {
+      const result = await run([
+        'bundle', 'build', '--version', '1.0.0', '-o', 'json'
+      ]);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ zipAsset: string; manifestAsset: string }>(result.stdout);
+      expect(envelope.data.manifestAsset).toContain('deployment-manifest.yml');
+      expect(envelope.data.zipAsset).toContain('foo.bundle.zip');
+      const zipStat = await stat(envelope.data.zipAsset);
+      expect(zipStat.size).toBeGreaterThan(0);
+    });
   });
 
   describe('version compute', () => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai-primitives-hub/core",
-  "version": "0.0.1-alpha.1",
+  "version": "0.0.1-alpha.2",
   "description": "Core domain types and port interfaces for AI Primitives Hub. No dependency on other @ai-primitives-hub packages.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -10,12 +10,19 @@
     "url": "git+https://github.com/AmadeusITGroup/ai-primitives-hub.git",
     "directory": "packages/core"
   },
-  "keywords": ["ai-primitives-hub", "core", "domain", "ports"],
+  "keywords": [
+    "ai-primitives-hub",
+    "core",
+    "domain",
+    "ports"
+  ],
   "author": {
     "name": "Amadeus IT Group",
     "email": "opensource@amadeus.com"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "watch": "tsc --watch",

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai-primitives-hub/infra",
-  "version": "0.0.1-alpha.1",
+  "version": "0.0.1-alpha.2",
   "description": "Adapters implementing @ai-primitives-hub/core ports: source adapters, harvest, search, per-target writers, stores, scaffolding.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -10,12 +10,18 @@
     "url": "git+https://github.com/AmadeusITGroup/ai-primitives-hub.git",
     "directory": "packages/infra"
   },
-  "keywords": ["ai-primitives-hub", "infra", "adapters"],
+  "keywords": [
+    "ai-primitives-hub",
+    "infra",
+    "adapters"
+  ],
   "author": {
     "name": "Amadeus IT Group",
     "email": "opensource@amadeus.com"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc && npm run copy-templates",
     "watch": "tsc --watch",


### PR DESCRIPTION
## Description

Fix `bundle build` so it resolves the default collection file the same
way as `bundle manifest` when `--collection-file` is omitted.

This prevents the command from treating the workspace root as the
collection path and failing with `EISDIR: illegal operation on a
directory, read`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test coverage improvement
- [ ] 🔧 Configuration/build changes

## Related Issues

Closes #
Fixes #
Relates to #

## Changes Made

- Reused the shared `resolveCollectionFile()` helper from
  `bundle-manifest` in `bundle-build`
- Resolved the collection file after `cwd` is initialized so
  `bundle build` uses the correct workspace root
- Added a regression test covering `bundle build --version 1.0.0`
  without `--collection-file`

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing completed
- [x] All existing tests pass

### Manual Testing Steps

1. Run `pnpm vitest run test/commands/collection-bundle.test.ts`
2. Verify `bundle build` succeeds with `--collection-file`
3. Verify `bundle build` also succeeds when the flag is omitted

### Tested On

- [ ] macOS
- [ ] Windows
- [x] Linux

- [ ] VS Code Stable
- [ ] VS Code Insiders

## Screenshots

Not applicable for this CLI fix.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Documentation

- [ ] README.md updated
- [ ] JSDoc comments added/updated
- [x] No documentation changes needed

## Additional Notes

The fix keeps `bundle build` aligned with `bundle manifest` by using the
same default collection-file discovery path.

## Reviewer Guidelines

Please pay special attention to:

- Whether reusing `resolveCollectionFile()` is the right long-term shared
  behavior for both commands
- The regression test coverage for the no-flag `bundle build` path

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**
