### PR TITLE
fix(test): ignore temp folder deletion failure in the Windows platform

### DIFF
--- a/apps/vscode-extension/test/e2e/github-scaffold-integration.test.ts
+++ b/apps/vscode-extension/test/e2e/github-scaffold-integration.test.ts
@@ -20,6 +20,9 @@ import {
   ScaffoldCommand,
   ScaffoldType,
 } from '../../src/commands/scaffold-command';
+import {
+  rmrfSync,
+} from '../helpers/e2e-test-helpers';
 
 suite('E2E: GitHub Scaffold Integration Tests', () => {
   const templateRoot = path.join(process.cwd(), 'templates/scaffolds/github');
@@ -32,9 +35,7 @@ suite('E2E: GitHub Scaffold Integration Tests', () => {
 
   teardown(() => {
     // Clean up test directory
-    if (fs.existsSync(testDir)) {
-      fs.rmSync(testDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
-    }
+    rmrfSync(testDir);
   });
 
   suite('Complete Scaffolding Flow', () => {
@@ -386,10 +387,13 @@ suite('E2E: Script Execution Tests', () => {
     }
   });
 
-  suiteTeardown(() => {
-    if (fs.existsSync(testDir)) {
-      fs.rmSync(testDir, { recursive: true, force: true });
-    }
+  suiteTeardown(function () {
+    // The script-execution suite runs `npm install`, leaving a node_modules/
+    // tree. rmrfSync removes everything except node_modules/ (which may be
+    // locked by orphaned processes on Windows CI) — the CI runner is an
+    // ephemeral VM, so a leftover node_modules/ is harmless.
+    this.timeout(60_000);
+    rmrfSync(testDir);
   });
 
   setup(function () {
@@ -398,9 +402,7 @@ suite('E2E: Script Execution Tests', () => {
     }
     // Clean artifacts from previous tests to maintain isolation
     const distDir = path.join(testDir, 'dist');
-    if (fs.existsSync(distDir)) {
-      fs.rmSync(distDir, { recursive: true, force: true });
-    }
+    rmrfSync(distDir);
   });
 
   /**

--- a/apps/vscode-extension/test/helpers/e2e-test-helpers.ts
+++ b/apps/vscode-extension/test/helpers/e2e-test-helpers.ts
@@ -339,14 +339,16 @@ export function rmrfSync(dir: string): void {
   try {
     fs.rmSync(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
   } catch (err) {
-    // Log instead of throw — on Windows, orphaned node processes from
-    // `npm run` can hold node_modules/ handles open via memory-mapped
-    // native addons. The CI runner is ephemeral, so a leftover temp dir
-    // is harmless. Observing for now to confirm this is the only failure mode.
-    // eslint-disable-next-line no-console -- intentional: log cleanup failure for observation
+    if (process.platform !== 'win32') {
+      throw new Error(`[rmrfSync] Could not remove ${dir}: ${(err as NodeJS.ErrnoException).message}`);
+    }
+    // Windows: orphaned node processes from `npm run` can hold node_modules/
+    // handles open via memory-mapped native addons. The CI runner is
+    // ephemeral, so a leftover temp dir is harmless — just log it.
+    // eslint-disable-next-line no-console -- known Windows issue: orphaned processes hold temp dir handles
     console.warn(
       `[rmrfSync] Could not remove ${dir}: ${(err as NodeJS.ErrnoException).message}.`
-      + ' On Windows this is a known issue: orphaned node processes from `npm run`'
+      + ' This is a known Windows issue: orphaned node processes from `npm run`'
       + ' can hold node_modules/ handles open. The CI runner is ephemeral,'
       + ' so a leftover temp dir is harmless.'
     );

--- a/apps/vscode-extension/test/helpers/e2e-test-helpers.ts
+++ b/apps/vscode-extension/test/helpers/e2e-test-helpers.ts
@@ -314,3 +314,41 @@ export async function setupSourceAndGetBundleGeneric(
 
   return { sourceId, bundle };
 }
+
+/**
+ * Remove a temp directory tree.
+ *
+ * On non-Windows platforms, a simple `fs.rmSync` is used and errors are
+ * thrown so real problems aren't hidden.
+ *
+ * On Windows, `npm install` + `npm run` can leave orphaned node processes
+ * that hold `node_modules/` handles open (memory-mapped native addons),
+ * making the directory undeletable (EPERM). Since the CI runner is an
+ * ephemeral VM, a leftover temp dir is not a test-correctness issue — so
+ * on Windows we just log the error instead of throwing.
+ * @param dir - Absolute path to the directory to remove.
+ * @example
+ * import { rmrfSync } from '../helpers/e2e-test-helpers';
+ * teardown(() => rmrfSync(testDir));
+ */
+export function rmrfSync(dir: string): void {
+  if (!fs.existsSync(dir)) {
+    return;
+  }
+
+  try {
+    fs.rmSync(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+  } catch (err) {
+    // Log instead of throw — on Windows, orphaned node processes from
+    // `npm run` can hold node_modules/ handles open via memory-mapped
+    // native addons. The CI runner is ephemeral, so a leftover temp dir
+    // is harmless. Observing for now to confirm this is the only failure mode.
+    // eslint-disable-next-line no-console -- intentional: log cleanup failure for observation
+    console.warn(
+      `[rmrfSync] Could not remove ${dir}: ${(err as NodeJS.ErrnoException).message}.`
+      + ' On Windows this is a known issue: orphaned node processes from `npm run`'
+      + ' can hold node_modules/ handles open. The CI runner is ephemeral,'
+      + ' so a leftover temp dir is harmless.'
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Temporarily fixes a Windows CI test failure where the `E2E: Script Execution Tests` suite's `suiteTeardown` hook crashed with `EPERM, Permission denied` when trying to remove a temp directory containing `node_modules/`.

Tried to trace the process locking the folder https://github.com/AmadeusITGroup/ai-primitives-hub/actions/runs/30158048917/job/89680422001

## Root Cause

Through detailed CI diagnostics (process listings, `icacls` permissions, directory tree analysis), we identified that:

1. **Orphaned `node.exe` processes** — The tests run `npm install` followed by several `npm run *` commands via `execSync`. On Windows with npm 11, `execSync` waits for the direct child (npm), but npm spawns the `ai-primitives-hub` CLI as a **grandchild** that can outlive the npm process. Windows has no process groups (unlike Linux), so `execSync` cannot cascade-kill these grandchildren.

2. **Memory-mapped native addons** — The orphaned node processes load native `.node` addons from `node_modules/` (e.g., `@opentelemetry/semantic-conventions/build/`), which get **memory-mapped**. These file handles persist until the process exits, making `node_modules/` — and the parent temp directory — undeletable (EPERM).

3. **Not a permission issue** — `icacls` confirmed full control permissions for SYSTEM, Administrators, and runneradmin. Even the native `rd /s /q` command failed, confirming it's a handle lock, not a file attribute issue.

4. **Pre-existing, not a regression** — The test code is byte-for-byte identical to what passed previously. The failure is environmental (GitHub Actions Windows runner image + Node 24 + npm 11), and was only exposed because the E2E tests now actually run in CI.

## What Changed

Added a shared `rmrfSync` helper to `test/helpers/e2e-test-helpers.ts`:

- Tries `fs.rmSync` with retries (works in the common case)
- On **non-Windows**: throws on failure (real problems surface)
- On **Windows**: logs a warning instead of throwing — the orphaned-process handle lock is a known Windows/npm issue, and the CI runner is an ephemeral VM destroyed after the job, so a leftover temp dir is harmless

Updated `test/e2e/github-scaffold-integration.test.ts` to use the shared `rmrfSync` helper for all `teardown`, `suiteTeardown`, and `setup` cleanup sites.

## Why This Approach

- **Cross-platform**: no platform-specific shell commands (`rd /s /q`, PowerShell, `handle.exe`)
- **Minimal**: ~20 lines, one function, one export
- **Strict where it matters**: non-Windows failures throw (preserving test correctness)
- **Lenient where it should be**: Windows cleanup failures log instead of crashing (avoiding environmental flakiness masking real test results)
- **Reusable**: any future test file can `import { rmrfSync } from '../helpers/e2e-test-helpers'`

## Type of Change

- [x] 🐛 Bug fix CI (non-breaking change which fixes an issue)

## Testing

- [x] All existing unit tests pass locally (`pnpm run test:unit` — 2125 passing)
- [x] Lint clean (`pnpm run lint` — 0 errors)
- [x] Compiles clean (`pnpm run compile-tests`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] New and existing unit tests pass locally with my changes