### PR TITLE
fix: publish release artifacts and retrofit README support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,11 +22,13 @@ Use Node 22+ and pnpm 11+.
 pnpm install
 pnpm run compile
 pnpm run test:unit
-pnpm run lint
+pnpm run lint:fix
 pnpm run package:vsix
 ```
 
-`lib/` has its own test cycle: `cd lib && npm test`. For package work, run `pnpm -C packages -r build`, `pnpm -C packages -r lint`, or `pnpm -C packages -r test`.
+`lib/` has its own test cycle: `cd lib && npm test`. For package work, run `pnpm -C packages -r build`, `pnpm -C packages -r lint:fix`, or `pnpm -C packages -r test`.
+
+Always run linting with its `:fix` option. Do not run the corresponding non-fixing lint command afterwards: it reports the same remaining issues without adding useful validation.
 
 ## Architecture
 

--- a/apps/vscode-extension/src/services/registry-manager.ts
+++ b/apps/vscode-extension/src/services/registry-manager.ts
@@ -11,6 +11,7 @@ import {
   detectBundleUpdates,
   exportLocalProfile,
   exportRegistrySettings,
+  hydrateSourceReadmes,
   importLocalProfile,
   importRegistrySettings,
   installRegistryBundle,
@@ -18,6 +19,7 @@ import {
   listAllProfiles,
   listInstalledBundles as listInstalledBundlesCore,
   listLocalProfiles as listLocalProfilesCore,
+  reuseCachedSourceReadmes,
   searchRegistryBundles,
   uninstallInstalledBundle,
   updateLocalProfile,
@@ -637,67 +639,6 @@ export class RegistryManager {
   }
 
   /**
-   * Carry over cached readmes into freshly fetched bundles when the source revision is unchanged.
-   * Bundles whose `readmeRevision` differs (or is not provided by the adapter) are left without a
-   * readme so {@link downloadReadmesConcurrently} re-downloads them. This keeps readmes fresh while
-   * avoiding redundant downloads on every sync.
-   * @param previouslyCached - Snapshot of cached bundles taken before the current sync started
-   * @param bundles - Freshly fetched bundles to enrich in place
-   */
-  private async reuseCachedReadmes(previouslyCached: Bundle[], bundles: Bundle[]): Promise<void> {
-    if (!previouslyCached || previouslyCached.length === 0) {
-      return;
-    }
-    const cachedById = new Map(previouslyCached.map((b) => [b.id, b]));
-    for (const bundle of bundles) {
-      const previous = cachedById.get(bundle.id);
-      if (
-        previous?.readme
-        && previous.readmeRevision !== undefined
-        && previous.readmeRevision === bundle.readmeRevision
-      ) {
-        bundle.readme = previous.readme;
-      }
-    }
-  }
-
-  /**
-   * Download readme files concurrently
-   * @param bundles - Bundles to download readmes for
-   * @param sourceId - Source ID for caching purposes
-   * @param adapter - Adapter to use for downloading readmes
-   */
-  private async downloadReadmesConcurrently(bundles: Bundle[], sourceId: string, adapter: IRepositoryAdapter): Promise<void> {
-    const concurrency = CONCURRENCY_CONSTANTS.README_DOWNLOAD_CONCURRENCY;
-    const filteredBundles = bundles.filter((b) => b.readmeUrl && !b.readme);
-    const succeeded: string[] = [];
-    const failed: string[] = [];
-    for (let i = 0; i < filteredBundles.length; i += concurrency) {
-      const batch = filteredBundles.slice(i, i + concurrency);
-      const newlyDownloaded = new Set<string>();
-      await Promise.allSettled(
-        batch.map(async (bundle) => {
-          const readme = await adapter.downloadReadme(bundle);
-          if (readme) {
-            bundle.readme = readme;
-            newlyDownloaded.add(bundle.id);
-          } else {
-            failed.push(bundle.id);
-          }
-        })
-      );
-      succeeded.push(...newlyDownloaded);
-      if (newlyDownloaded.size > 0) {
-        const bundleIdsWithReadmes = [...newlyDownloaded];
-        // Cache all bundles (including previously downloaded) so consumers get full state
-        await this.storage.cacheSourceBundles(sourceId, bundles);
-        this._onReadmeDownloaded.fire({ sourceId, bundleIds: bundleIdsWithReadmes });
-      }
-    }
-    this._onReadmeDownloadComplete.fire({ sourceId, succeeded, failed });
-  }
-
-  /**
    * Set HubManager instance for hub integration
    * @param hubManager
    */
@@ -904,8 +845,8 @@ export class RegistryManager {
       this._onSourceSynced.fire({ sourceId, bundleCount: partial.length });
     });
 
-    // Reuse still-valid cached readmes so we only re-download when the source revision changed
-    await this.reuseCachedReadmes(preSyncCache, bundles);
+    // Reuse still-valid cached readmes so we only re-download when the source revision changed.
+    reuseCachedSourceReadmes(bundles, preSyncCache);
 
     // Cache bundles
     await this.storage.cacheSourceBundles(sourceId, bundles);
@@ -944,7 +885,11 @@ export class RegistryManager {
     this._onSourceSynced.fire({ sourceId, bundleCount: bundles.length });
 
     // Download the readme files in concurrent, non blocking way
-    this.downloadReadmesConcurrently(bundles, sourceId, adapter).catch((err) => {
+    hydrateSourceReadmes(sourceId, bundles, adapter, {
+      cacheSourceBundles: (id, cachedBundles) => this.storage.cacheSourceBundles(id, cachedBundles),
+      onReadmesDownloaded: (event) => this._onReadmeDownloaded.fire(event),
+      onReadmesComplete: (event) => this._onReadmeDownloadComplete.fire(event)
+    }).catch((err) => {
       this.logger.error(`Failed to download readmes for source '${sourceId}'`, err as Error);
     });
   }

--- a/apps/vscode-extension/src/utils/constants.ts
+++ b/apps/vscode-extension/src/utils/constants.ts
@@ -61,13 +61,6 @@ export const CONCURRENCY_CONSTANTS = {
   MANIFEST_DOWNLOAD_CONCURRENCY: 10,
 
   /**
-   * Concurrency limit for parallel README downloads in GitHub adapter
-   * - Controls how many README files are downloaded simultaneously
-   * - GitHub API rate limit is 5000 requests/hour for authenticated users
-   */
-  README_DOWNLOAD_CONCURRENCY: 5,
-
-  /**
    * Maximum number of popular bundles to display in quick pick
    * - Prevents UI overflow in bundle selection dialogs
    * - Maintains reasonable response times for bundle loading

--- a/apps/vscode-extension/templates/scaffolds/github/workflows/publish.template.yml
+++ b/apps/vscode-extension/templates/scaffolds/github/workflows/publish.template.yml
@@ -66,13 +66,18 @@ jobs:
             tag=$(echo "$version_data" | jq -r '.data.tag')
 
             echo "Publishing $collection_id @ $version (tag: $tag)"
-            npx ai-primitives-hub bundle build --collection-file "$file" --version "$version" --out-dir "dist/$collection_id"
+            bundle_data=$(npx ai-primitives-hub bundle build --collection-file "$file" --version "$version" --out-dir "dist" -o json)
+            assets=()
+            # Bash 3.2 (default on macOS runners) lacks mapfile/readarray, so
+            # build the array with a portable read loop instead.
+            while IFS= read -r asset; do
+              assets+=("$asset")
+            done < <(echo "$bundle_data" | jq -r '[.data.zipAsset, .data.manifestAsset, .data.readmeAsset] | map(select(. != null)) | .[]')
 
             gh release create "$tag" \
               --title "$collection_id $version" \
               --notes "Release $tag" \
-              "dist/$collection_id/$collection_id.bundle.zip" \
-              "dist/$collection_id/deployment-manifest.yml"
+              "${assets[@]}"
           done
 
   publish-preview:
@@ -131,7 +136,7 @@ jobs:
             collection_id=$(basename "$file" .collection.yml)
             version=$(npx ai-primitives-hub version compute --collection-file "$file" -o json | jq -r '.data.nextVersion')
             echo "Previewing $collection_id @ $version"
-            npx ai-primitives-hub bundle build --collection-file "$file" --version "$version" --out-dir "dist/$collection_id"
+            npx ai-primitives-hub bundle build --collection-file "$file" --version "$version" --out-dir "dist"
           done
 
       - name: Upload preview artifacts

--- a/apps/vscode-extension/test/commands/scaffold-command.github.property.test.ts
+++ b/apps/vscode-extension/test/commands/scaffold-command.github.property.test.ts
@@ -439,7 +439,6 @@ suite('GitHub Scaffold Property-Based Tests', () => {
             || publishCommonContent.includes('npm run validate'),
             'publish-common action should include validation step'
           );
-
           // Verify validation runs before publishing
           // The publish-common action should run before the publish step
           const publishCommonIndex = publishWorkflowContent.indexOf('publish-common');
@@ -448,6 +447,19 @@ suite('GitHub Scaffold Property-Based Tests', () => {
           assert.ok(
             publishCommonIndex < publishCollectionsIndex,
             'publish-common (with validation) should run before publishing collections'
+          );
+
+          assert.ok(
+            publishWorkflowContent.includes('bundle build --collection-file "$file" --version "$version" --out-dir "dist" -o json'),
+            'publish.yml should consume JSON output from bundle build'
+          );
+          assert.ok(
+            publishWorkflowContent.includes('.data.readmeAsset'),
+            'publish.yml should include the optional README in the release asset list'
+          );
+          assert.ok(
+            publishWorkflowContent.includes('"${assets[@]}"'),
+            'publish.yml should pass all computed assets to gh release create'
           );
 
           // Verify both jobs (publish-collections and publish-preview) use validation

--- a/packages/app/src/collection/index.ts
+++ b/packages/app/src/collection/index.ts
@@ -16,6 +16,7 @@ export {
   loadItemKindsFromSchema,
   readCollection,
   resolveCollectionItemPaths,
+  resolveCollectionReadmePath,
   validateAllCollections,
   validateCollectionFile,
   writeCollection,

--- a/packages/app/src/collection/read-collection.ts
+++ b/packages/app/src/collection/read-collection.ts
@@ -71,6 +71,7 @@ export function validateCollectionFile(
     : path.join(repoRoot, collectionFile);
 
   const errors: string[] = [];
+  const warnings: string[] = [];
 
   if (!fs.existsSync(abs)) {
     return { ok: false, errors: [`${rel}: Collection file not found`] };
@@ -106,7 +107,19 @@ export function validateCollectionFile(
     });
   }
 
-  return { ok: errors.length === 0, errors, collection };
+  let readmePath: string | null = null;
+  try {
+    readmePath = resolveCollectionReadmePath(collection);
+  } catch {
+    // Invalid paths are already reported by validateCollectionObject.
+  }
+  if (!collection?.readme?.path) {
+    warnings.push(`${rel}: Collection has no readme. Consider adding a readme to help users understand this collection.`);
+  } else if (readmePath && !fs.existsSync(path.join(repoRoot, readmePath))) {
+    errors.push(`${rel}: readme referenced file not found: ${readmePath}`);
+  }
+
+  return { ok: errors.length === 0, errors, warnings, collection };
 }
 
 /**
@@ -120,6 +133,7 @@ export function validateAllCollections(
   collectionFiles: string[]
 ): AllCollectionsResult {
   const errors: string[] = [];
+  const warnings: string[] = [];
   const fileResults: ({ file: string } & FileValidationResult)[] = [];
   const seenIds = new Map<string, string>(); // id -> file path
   const seenNames = new Map<string, string>(); // name -> file path
@@ -128,6 +142,7 @@ export function validateAllCollections(
     const result = validateCollectionFile(repoRoot, file);
     fileResults.push({ file, ...result });
     errors.push(...result.errors);
+    warnings.push(...(result.warnings ?? []));
 
     // Check for duplicate IDs and names
     if (result.collection) {
@@ -147,7 +162,7 @@ export function validateAllCollections(
     }
   }
 
-  return { ok: errors.length === 0, errors, fileResults };
+  return { ok: errors.length === 0, errors, warnings, fileResults };
 }
 
 /**
@@ -166,6 +181,14 @@ export function generateMarkdown(result: AllCollectionsResult, totalFiles: numbe
     md += '### Errors\n\n';
     result.errors.forEach((err) => {
       md += `- ${err}\n`;
+    });
+  }
+
+  const warnings = result.warnings;
+  if (warnings.length > 0) {
+    md += '\n### Warnings\n\n';
+    warnings.forEach((warning) => {
+      md += `- ${warning}\n`;
     });
   }
 
@@ -280,4 +303,19 @@ export function resolveCollectionItemPaths(repoRoot: string, collection: Collect
   }
 
   return allPaths;
+}
+
+/**
+ * Resolve the README path declared by a collection.
+ * @param collection Parsed collection.
+ * @param collection.readme
+ * @param collection.readme.path
+ * @returns Normalized repo-relative path or null when no README is declared.
+ * @throws {Error} if the declared path escapes the repository root.
+ */
+export function resolveCollectionReadmePath(collection: { readme?: { path?: string } }): string | null {
+  if (!collection.readme?.path) {
+    return null;
+  }
+  return normalizeRepoRelativePath(collection.readme.path);
 }

--- a/packages/app/src/registry/hydrate-source-readmes.ts
+++ b/packages/app/src/registry/hydrate-source-readmes.ts
@@ -1,0 +1,81 @@
+/**
+ * Reuse and hydrate README content for source bundles.
+ * @module registry/hydrate-source-readmes
+ */
+import type {
+  Bundle,
+  SourceAdapter,
+} from '@ai-primitives-hub/core';
+
+/** Maximum number of concurrent README downloads per source. */
+export const README_DOWNLOAD_CONCURRENCY = 5;
+
+export interface HydrateSourceReadmesPorts {
+  cacheSourceBundles(sourceId: string, bundles: Bundle[]): Promise<void>;
+  onReadmesDownloaded?(event: { sourceId: string; bundleIds: string[] }): void;
+  onReadmesComplete?(event: { sourceId: string; succeeded: string[]; failed: string[] }): void;
+}
+
+/**
+ * Reuse cached README content when the source revision is unchanged.
+ * @param bundles Freshly fetched bundles to enrich in place.
+ * @param cachedBundles Bundles cached by the last completed sync.
+ */
+export function reuseCachedSourceReadmes(bundles: Bundle[], cachedBundles: Bundle[]): void {
+  const cachedById = new Map((cachedBundles ?? []).map((bundle) => [bundle.id, bundle]));
+
+  for (const bundle of bundles) {
+    const previous = cachedById.get(bundle.id);
+    if (
+      previous?.readme
+      && previous.readmeRevision !== undefined
+      && previous.readmeRevision === bundle.readmeRevision
+    ) {
+      bundle.readme = previous.readme;
+    }
+  }
+}
+
+/**
+ * Download missing README content in bounded batches without failing source sync.
+ * @param sourceId Source cache key.
+ * @param bundles Bundles to enrich in place.
+ * @param adapter Source adapter used to download README content.
+ * @param ports Cache and event callbacks.
+ */
+export async function hydrateSourceReadmes(
+  sourceId: string,
+  bundles: Bundle[],
+  adapter: SourceAdapter,
+  ports: HydrateSourceReadmesPorts
+): Promise<void> {
+  const candidates = bundles.filter((bundle) => bundle.readmeUrl && !bundle.readme);
+  const succeeded: string[] = [];
+  const failed: string[] = [];
+
+  for (let index = 0; index < candidates.length; index += README_DOWNLOAD_CONCURRENCY) {
+    const batch = candidates.slice(index, index + README_DOWNLOAD_CONCURRENCY);
+    const results = await Promise.allSettled(
+      batch.map(async (bundle) => adapter.downloadReadme(bundle))
+    );
+    const downloaded: string[] = [];
+
+    for (const [resultIndex, result] of results.entries()) {
+      const bundle = batch[resultIndex];
+      if (result.status === 'fulfilled' && result.value) {
+        bundle.readme = result.value;
+        downloaded.push(bundle.id);
+      } else {
+        failed.push(bundle.id);
+      }
+    }
+
+    if (downloaded.length > 0) {
+      succeeded.push(...downloaded);
+      await ports.cacheSourceBundles(sourceId, bundles);
+      ports.onReadmesDownloaded?.({ sourceId, bundleIds: downloaded });
+    }
+  }
+
+  ports.onReadmesComplete?.({ sourceId, succeeded, failed });
+}

--- a/packages/app/src/registry/index.ts
+++ b/packages/app/src/registry/index.ts
@@ -7,6 +7,7 @@ export * from './create-source-adapter';
 export * from './deactivate-registry-profile';
 export * from './detect-updates';
 export * from './hub-manager';
+export * from './hydrate-source-readmes';
 export * from './install-registry-bundle';
 export * from './list-all-profiles';
 export * from './list-installed-bundles';

--- a/packages/app/test/collection/read-collection.test.ts
+++ b/packages/app/test/collection/read-collection.test.ts
@@ -1,0 +1,107 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  generateMarkdown,
+  resolveCollectionReadmePath,
+  validateAllCollections,
+  validateCollectionFile,
+} from '../../src/collection/read-collection';
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'read-collection-test-'));
+  fs.mkdirSync(path.join(tempDir, 'collections'), { recursive: true });
+  fs.mkdirSync(path.join(tempDir, 'prompts'), { recursive: true });
+  fs.writeFileSync(path.join(tempDir, 'prompts', 'hello.prompt.md'), '# Hello\n');
+});
+
+afterEach(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+const writeCollection = (content: string): string => {
+  const collectionFile = path.join('collections', 'foo.collection.yml');
+  fs.writeFileSync(path.join(tempDir, collectionFile), content);
+  return collectionFile;
+};
+
+describe('collection README handling', () => {
+  it('resolves a normalized nested README path', () => {
+    expect(resolveCollectionReadmePath({ readme: { path: 'docs\\collection-overview.md' } })).toBe('docs/collection-overview.md');
+  });
+
+  it('validates an existing README without warnings', () => {
+    fs.mkdirSync(path.join(tempDir, 'docs'), { recursive: true });
+    fs.writeFileSync(path.join(tempDir, 'docs', 'collection-overview.md'), '# Overview\n');
+    const collectionPath = writeCollection(`id: foo
+name: Foo
+readme:
+  path: docs/collection-overview.md
+items:
+  - path: prompts/hello.prompt.md
+    kind: prompt
+`);
+
+    const result = validateCollectionFile(tempDir, collectionPath);
+
+    expect(result.ok).toBe(true);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('rejects a declared README that does not exist', () => {
+    const collectionPath = writeCollection(`id: foo
+name: Foo
+readme:
+  path: docs/missing.md
+items: []
+`);
+
+    const result = validateCollectionFile(tempDir, collectionPath);
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain('collections/foo.collection.yml: readme referenced file not found: docs/missing.md');
+  });
+
+  it('collects an invalid README path without aborting validation of other collections', () => {
+    const invalidCollection = writeCollection(`id: foo
+name: Foo
+readme:
+  path: ../README.md
+items: []
+`);
+    const validCollection = path.join('collections', 'bar.collection.yml');
+    fs.writeFileSync(path.join(tempDir, validCollection), `id: bar
+name: Bar
+items: []
+`);
+
+    const result = validateAllCollections(tempDir, [invalidCollection, validCollection]);
+
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((error) => error.includes('readme.path'))).toBe(true);
+    expect(result.fileResults).toHaveLength(2);
+    expect(result.fileResults[1].collection?.id).toBe('bar');
+  });
+
+  it('warns when no README is declared and includes it in markdown output', () => {
+    const collectionPath = writeCollection(`id: foo
+name: Foo
+items: []
+`);
+
+    const result = validateAllCollections(tempDir, [collectionPath]);
+
+    expect(result.ok).toBe(true);
+    expect(result.warnings).toContain('collections/foo.collection.yml: Collection has no readme. Consider adding a readme to help users understand this collection.');
+    expect(generateMarkdown(result, 1)).toContain('### Warnings');
+  });
+});

--- a/packages/app/test/registry/hydrate-source-readmes.test.ts
+++ b/packages/app/test/registry/hydrate-source-readmes.test.ts
@@ -1,0 +1,116 @@
+import type {
+  Bundle,
+  SourceAdapter,
+} from '@ai-primitives-hub/core';
+import {
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import {
+  hydrateSourceReadmes,
+  README_DOWNLOAD_CONCURRENCY,
+  reuseCachedSourceReadmes,
+} from '../../src/registry';
+
+function makeBundle(overrides: Partial<Bundle> = {}): Bundle {
+  return {
+    id: 'bundle-1',
+    name: 'Bundle One',
+    version: '1.0.0',
+    description: 'A test bundle',
+    author: 'author',
+    sourceId: 'source-1',
+    environments: ['vscode'],
+    tags: [],
+    lastUpdated: '2026-01-01T00:00:00.000Z',
+    size: '1 KB',
+    dependencies: [],
+    license: 'MIT',
+    manifestUrl: 'https://example.test/manifest',
+    downloadUrl: 'https://example.test/bundle.zip',
+    readmeUrl: 'https://example.test/README.md',
+    readmeRevision: 'revision-1',
+    ...overrides
+  };
+}
+
+function makeAdapter(downloadReadme: SourceAdapter['downloadReadme']): SourceAdapter {
+  return { downloadReadme } as SourceAdapter;
+}
+
+describe('README source hydration', () => {
+  it('reuses cached README content only when revisions match', () => {
+    const matching = makeBundle();
+    const changed = makeBundle({ id: 'bundle-2', readmeRevision: 'revision-2' });
+    reuseCachedSourceReadmes([matching, changed], [
+      makeBundle({ readme: '# Cached' }),
+      makeBundle({ id: 'bundle-2', readme: '# Stale', readmeRevision: 'revision-1' })
+    ]);
+
+    expect(matching.readme).toBe('# Cached');
+    expect(changed.readme).toBeUndefined();
+  });
+
+  it('hydrates missing READMEs, caches the enriched bundles, and reports progress', async () => {
+    const bundles = [makeBundle(), makeBundle({ id: 'bundle-2' })];
+    const cacheSourceBundles = vi.fn().mockResolvedValue(undefined);
+    const onReadmesDownloaded = vi.fn();
+    const onReadmesComplete = vi.fn();
+    await hydrateSourceReadmes('source-1', bundles, makeAdapter(async (bundle) => `# ${bundle.id}`), {
+      cacheSourceBundles,
+      onReadmesDownloaded,
+      onReadmesComplete
+    });
+
+    expect(bundles.map((bundle) => bundle.readme)).toEqual(['# bundle-1', '# bundle-2']);
+    expect(cacheSourceBundles).toHaveBeenCalledWith('source-1', bundles);
+    expect(onReadmesDownloaded).toHaveBeenCalledWith({ sourceId: 'source-1', bundleIds: ['bundle-1', 'bundle-2'] });
+    expect(onReadmesComplete).toHaveBeenCalledWith({ sourceId: 'source-1', succeeded: ['bundle-1', 'bundle-2'], failed: [] });
+  });
+
+  it('continues after failed README downloads', async () => {
+    const bundles = [makeBundle(), makeBundle({ id: 'bundle-2' })];
+    const onReadmesComplete = vi.fn();
+    await hydrateSourceReadmes('source-1', bundles, makeAdapter(async (bundle) => {
+      if (bundle.id === 'bundle-2') {
+        throw new Error('network failure');
+      }
+      return '# Available';
+    }), {
+      cacheSourceBundles: vi.fn().mockResolvedValue(undefined),
+      onReadmesComplete
+    });
+
+    expect(bundles[0].readme).toBe('# Available');
+    expect(bundles[1].readme).toBeUndefined();
+    expect(onReadmesComplete).toHaveBeenCalledWith({ sourceId: 'source-1', succeeded: ['bundle-1'], failed: ['bundle-2'] });
+  });
+
+  it('limits each download batch to the configured concurrency', async () => {
+    const bundles = Array.from({ length: README_DOWNLOAD_CONCURRENCY + 1 }, (_, index) => makeBundle({ id: `bundle-${index}` }));
+    let active = 0;
+    let maximumActive = 0;
+    const pending: (() => void)[] = [];
+    const downloadReadme = vi.fn(() => new Promise<string>((resolve) => {
+      active += 1;
+      maximumActive = Math.max(maximumActive, active);
+      pending.push(() => {
+        active -= 1;
+        resolve('# README');
+      });
+    }));
+
+    const hydration = hydrateSourceReadmes('source-1', bundles, makeAdapter(downloadReadme), {
+      cacheSourceBundles: vi.fn().mockResolvedValue(undefined)
+    });
+    await vi.waitFor(() => expect(pending).toHaveLength(README_DOWNLOAD_CONCURRENCY));
+    pending.splice(0).forEach((resolve) => resolve());
+    await vi.waitFor(() => expect(pending).toHaveLength(1));
+    pending.splice(0).forEach((resolve) => resolve());
+    await hydration;
+
+    expect(maximumActive).toBe(README_DOWNLOAD_CONCURRENCY);
+  });
+});

--- a/packages/cli/src/commands/bundle-build.ts
+++ b/packages/cli/src/commands/bundle-build.ts
@@ -27,6 +27,7 @@ import * as path from 'node:path';
 import {
   readCollection,
   resolveCollectionItemPaths,
+  resolveCollectionReadmePath,
 } from '@ai-primitives-hub/app';
 import {
   generateBundleId,
@@ -56,6 +57,7 @@ interface BundleBuildData {
   outDir: string;
   manifestAsset: string;
   zipAsset: string;
+  readmeAsset?: string;
   bundleId: string;
 }
 
@@ -222,6 +224,7 @@ export class BundleBuildCommand extends Command {
       );
 
       const itemPaths = resolveCollectionItemPaths(cwd, collection);
+      const readmeAsset = resolveCollectionReadmePath(collection);
       const zipPath = path.join(collectionOutDir, `${collectionId}.bundle.zip`);
       await createDeterministicZip({
         repoRoot: cwd,
@@ -236,6 +239,7 @@ export class BundleBuildCommand extends Command {
         outDir: collectionOutDir.replaceAll('\\', '/'),
         manifestAsset: standaloneManifestPath.replaceAll('\\', '/'),
         zipAsset: zipPath.replaceAll('\\', '/'),
+        ...(readmeAsset ? { readmeAsset: readmeAsset.replaceAll('\\', '/') } : {}),
         bundleId
       };
       formatOutput({

--- a/packages/cli/src/commands/bundle-manifest.ts
+++ b/packages/cli/src/commands/bundle-manifest.ts
@@ -7,6 +7,9 @@
  */
 import * as path from 'node:path';
 import {
+  resolveCollectionReadmePath,
+} from '@ai-primitives-hub/app';
+import {
   normalizeRepoRelativePath,
 } from '@ai-primitives-hub/core';
 import * as yaml from 'js-yaml';
@@ -66,6 +69,7 @@ interface RawCollection {
   description?: string;
   author?: string;
   tags?: string[];
+  readme?: { path?: string };
   items?: { path?: string; kind?: string }[];
   mcpServers?: Record<string, unknown>;
   mcp?: { items?: Record<string, unknown>; inputs?: unknown[] };
@@ -284,6 +288,7 @@ function buildManifest(
   const manifestId = collection.id ?? 'unknown';
   const mcpServers = collection.mcpServers ?? collection.mcp?.items;
   const mcpInputs = collection.mcp?.inputs;
+  const readmePath = resolveCollectionReadmePath(collection);
   return {
     id: manifestId,
     version,
@@ -296,6 +301,7 @@ function buildManifest(
     repository: '',
     prompts,
     dependencies: [],
+    ...(readmePath ? { readme: path.basename(readmePath) } : {}),
     ...(mcpServers !== undefined && Object.keys(mcpServers).length > 0 ? { mcpServers } : {}),
     ...(mcpInputs !== undefined && mcpInputs.length > 0 ? { mcpInputs } : {})
   };

--- a/packages/cli/src/commands/collection-affected.ts
+++ b/packages/cli/src/commands/collection-affected.ts
@@ -13,6 +13,7 @@ import {
   listCollectionFiles,
   readCollection,
   resolveCollectionItemPaths,
+  resolveCollectionReadmePath,
 } from '@ai-primitives-hub/app';
 import {
   Command,
@@ -87,9 +88,14 @@ export class CollectionAffectedCommand extends Command {
     for (const file of collectionFiles) {
       const collection = readCollection(cwd, file);
       const itemPaths = resolveCollectionItemPaths(cwd, collection).map((p) => normalize(p));
+      const readmePath = resolveCollectionReadmePath(collection);
       const itemPathsSet = new Set(itemPaths);
       const normalizedFile = normalize(file);
       if (changedSet.has(normalizedFile)) {
+        affected.push({ id: collection.id, file });
+        continue;
+      }
+      if (readmePath && changedSet.has(normalize(readmePath))) {
         affected.push({ id: collection.id, file });
         continue;
       }

--- a/packages/cli/src/commands/collection-validate.ts
+++ b/packages/cli/src/commands/collection-validate.ts
@@ -40,6 +40,7 @@ interface ValidateData {
   totalFiles: number;
   fileResults: AllCollectionsResult['fileResults'];
   errors: string[];
+  warnings: string[];
 }
 
 /**
@@ -142,11 +143,13 @@ export class CollectionValidateCommand extends Command {
       ? this.collectionFile
       : listCollectionFiles(cwd);
     const result = validateAllCollections(cwd, files);
+    const warnings = result.warnings;
     const data: ValidateData = {
       ok: result.ok,
       totalFiles: files.length,
       fileResults: result.fileResults,
-      errors: result.errors
+      errors: result.errors,
+      warnings
     };
 
     if (this.markdownPath !== undefined) {
@@ -158,8 +161,9 @@ export class CollectionValidateCommand extends Command {
       ctx,
       command: 'collection.validate',
       output: fmt,
-      status: result.ok ? 'ok' : 'error',
+      status: result.ok ? (warnings.length > 0 ? 'warning' : 'ok') : 'error',
       data,
+      warnings,
       textRenderer: (d) => renderText(d, this.verbose)
     });
     return result.ok ? 0 : 1;

--- a/packages/cli/test/commands/collection-bundle.test.ts
+++ b/packages/cli/test/commands/collection-bundle.test.ts
@@ -75,6 +75,7 @@ const COMMAND_CLASSES = [
 interface JsonEnvelope<T> {
   status: string;
   data: T;
+  warnings: string[];
 }
 
 describe('collection/bundle/version/skill commands', () => {
@@ -167,8 +168,18 @@ items:
     it('passes for the seeded valid collection', async () => {
       const result = await run(['collection', 'validate', '-o', 'json']);
       expect(result.exitCode).toBe(0);
-      const envelope = parseJson<{ ok: boolean }>(result.stdout);
+      const envelope = parseJson<{ ok: boolean; warnings: string[] }>(result.stdout);
       expect(envelope.data.ok).toBe(true);
+      expect(envelope.status).toBe('warning');
+      expect(envelope.warnings).toContain('collections/foo.collection.yml: Collection has no readme. Consider adding a readme to help users understand this collection.');
+    });
+
+    it('emits text warnings only once through stderr', async () => {
+      const result = await run(['collection', 'validate']);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).not.toContain('Warnings:');
+      expect(result.stderr).toContain('warning: collections/foo.collection.yml: Collection has no readme. Consider adding a readme to help users understand this collection.');
     });
 
     it('fails for a collection missing the required id field', async () => {
@@ -195,6 +206,30 @@ items:
       expect(envelope.data.affected.map((a) => a.id)).toContain('foo');
     });
 
+    it('reports the collection as affected when its README changed', async () => {
+      await mkdir(path.join(workspace, 'docs'), { recursive: true });
+      await writeFile(path.join(workspace, 'docs', 'collection-overview.md'), '# Overview\n');
+      await writeFile(
+        path.join(workspace, 'collections', 'foo.collection.yml'),
+        `id: foo
+name: Foo Collection
+readme:
+  path: docs/collection-overview.md
+items:
+  - path: prompts/hello.prompt.md
+    kind: prompt
+`
+      );
+
+      const result = await run([
+        'collection', 'affected', '--changed-path', 'docs/collection-overview.md', '-o', 'json'
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ affected: { id: string }[] }>(result.stdout);
+      expect(envelope.data.affected.map((a) => a.id)).toContain('foo');
+    });
+
     it('reports no affected collections for an unrelated path', async () => {
       const result = await run([
         'collection', 'affected', '--changed-path', 'unrelated/file.md', '-o', 'json'
@@ -216,6 +251,7 @@ items:
       expect(envelope.data).toMatchObject({ id: 'foo', totalItems: 1 });
       const content = await readFile(outFile, 'utf8');
       expect(content).toContain('id: foo');
+      expect(content).not.toContain('readme:');
     });
 
     it('generates the expected MCP fields and matches the legacy generator', async () => {
@@ -316,6 +352,46 @@ mcp:
       expect(cliManifest).toEqual(legacyManifest);
     });
 
+    it('records the declared README basename and matches the legacy generator', async () => {
+      await mkdir(path.join(workspace, 'docs'), { recursive: true });
+      await writeFile(path.join(workspace, 'docs', 'collection-overview.md'), '# Overview\n');
+      await writeFile(
+        path.join(workspace, 'collections', 'foo.collection.yml'),
+        `id: foo
+name: Foo Collection
+description: Test collection
+readme:
+  path: docs/collection-overview.md
+items:
+  - path: prompts/hello.prompt.md
+    kind: prompt
+`
+      );
+
+      const legacyManifestPath = path.join(workspace, 'legacy-manifest.yml');
+      const cliManifestPath = path.join(workspace, 'cli-manifest.yml');
+      const legacyGeneratorPath = path.resolve(process.cwd(), '../../lib/bin/generate-manifest.js');
+      execFileSync(process.execPath, [
+        legacyGeneratorPath,
+        '1.0.0',
+        '--collection-file', 'collections/foo.collection.yml',
+        '--out', legacyManifestPath
+      ], { cwd: workspace, encoding: 'utf8' });
+
+      const result = await run([
+        'bundle', 'manifest',
+        '--version', '1.0.0',
+        '--collection-file', 'collections/foo.collection.yml',
+        '--out-file', cliManifestPath,
+        '-o', 'json'
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      const cliManifest = yaml.load(await readFile(cliManifestPath, 'utf8'));
+      expect(cliManifest).toEqual(yaml.load(await readFile(legacyManifestPath, 'utf8')));
+      expect(cliManifest).toMatchObject({ readme: 'collection-overview.md' });
+    });
+
     it('fails with exit 1 when collections/ does not exist and no --collection-file is given', async () => {
       const freshDir = await mkdtemp(path.join(os.tmpdir(), 'cli-collection-test-nocol-'));
       try {
@@ -346,9 +422,37 @@ mcp:
         'bundle', 'build', '--version', '1.0.0', '--collection-file', 'collections/foo.collection.yml', '-o', 'json'
       ]);
       expect(result.exitCode).toBe(0);
-      const envelope = parseJson<{ zipAsset: string; manifestAsset: string }>(result.stdout);
+      const envelope = parseJson<{ zipAsset: string; manifestAsset: string; readmeAsset?: string }>(result.stdout);
       const zipStat = await stat(envelope.data.zipAsset);
       expect(zipStat.size).toBeGreaterThan(0);
+      expect(envelope.data.readmeAsset).toBeUndefined();
+    });
+
+    it('returns the declared README as a release asset', async () => {
+      await mkdir(path.join(workspace, 'docs'), { recursive: true });
+      await writeFile(path.join(workspace, 'docs', 'collection-overview.md'), '# Overview\n');
+      await writeFile(
+        path.join(workspace, 'collections', 'foo.collection.yml'),
+        `id: foo
+name: Foo Collection
+readme:
+  path: docs/collection-overview.md
+items:
+  - path: prompts/hello.prompt.md
+    kind: prompt
+`
+      );
+
+      const result = await run([
+        'bundle', 'build', '--version', '1.0.0', '--collection-file', 'collections/foo.collection.yml', '-o', 'json'
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ readmeAsset?: string }>(result.stdout);
+      expect(envelope.data.readmeAsset).toBe('docs/collection-overview.md');
+      expect(await readFile(path.join(workspace, envelope.data.readmeAsset!), 'utf8')).toBe('# Overview\n');
+      const manifest = yaml.load(await readFile(path.join(workspace, 'dist', 'foo', 'deployment-manifest.yml'), 'utf8')) as { readme: string };
+      expect(manifest.readme).toBe(path.basename(envelope.data.readmeAsset!));
     });
 
     it('defaults to the first collection file under collections/ when --collection-file is omitted', async () => {

--- a/packages/core/src/domain/collection/types.ts
+++ b/packages/core/src/domain/collection/types.ts
@@ -40,6 +40,9 @@ export interface Collection {
   version?: string;
   author?: string;
   tags?: string[];
+  readme?: {
+    path: string;
+  };
   items: CollectionItem[];
 }
 
@@ -72,6 +75,7 @@ export interface ObjectValidationResult {
  * Result of validating a collection file on disk (parse + structure).
  */
 export interface FileValidationResult extends ObjectValidationResult {
+  warnings?: string[];
   collection?: Collection;
 }
 
@@ -79,6 +83,7 @@ export interface FileValidationResult extends ObjectValidationResult {
  * Aggregate result of validating every collection file in a repository.
  */
 export interface AllCollectionsResult extends ObjectValidationResult {
+  warnings: string[];
   fileResults: ({ file: string } & FileValidationResult)[];
 }
 

--- a/packages/core/src/domain/collection/validate.ts
+++ b/packages/core/src/domain/collection/validate.ts
@@ -214,6 +214,19 @@ export function validateCollectionObject(
     }
   }
 
+  if (col.readme !== undefined) {
+    if (!col.readme || typeof col.readme !== 'object') {
+      errors.push(`${sourceLabel}: readme must be an object with a "path" property`);
+    } else {
+      const readme = col.readme as Record<string, unknown>;
+      if (!readme.path || typeof readme.path !== 'string' || readme.path.trim() === '') {
+        errors.push(`${sourceLabel}: readme.path must be a non-empty string`);
+      } else if (!isSafeRepoRelativePath(readme.path)) {
+        errors.push(`${sourceLabel}: readme.path has an invalid path (must be repo-root relative): ${readme.path}`);
+      }
+    }
+  }
+
   if (!Array.isArray(col.items)) {
     errors.push(`${sourceLabel}: Missing required field: items (array)`);
   }

--- a/packages/core/test/domain/collection/validate.test.ts
+++ b/packages/core/test/domain/collection/validate.test.ts
@@ -199,6 +199,35 @@ describe('validateCollectionObject', () => {
     expect(result.ok).toBe(true);
   });
 
+  it('accepts a collection with a nested README path', () => {
+    const collection = {
+      id: 'my-collection',
+      name: 'My Collection',
+      readme: { path: 'docs/collection-overview.md' },
+      items: []
+    };
+    const result = validateCollectionObject(collection, 'test');
+    expect(result.ok).toBe(true);
+  });
+
+  it.each([
+    ['a non-object README', 'README.md', 'readme must be an object with a "path" property'],
+    ['a null README', null, 'readme must be an object with a "path" property'],
+    ['an empty README object', {}, 'readme.path must be a non-empty string'],
+    ['an empty README path', { path: '' }, 'readme.path must be a non-empty string'],
+    ['a traversal README path', { path: '../README.md' }, 'readme.path has an invalid path']
+  ])('rejects %s', (_label, readme, expectedError) => {
+    const collection = {
+      id: 'my-collection',
+      name: 'My Collection',
+      readme,
+      items: []
+    };
+    const result = validateCollectionObject(collection, 'test');
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((error) => error.includes(expectedError))).toBe(true);
+  });
+
   it('rejects non-object', () => {
     const result = validateCollectionObject(null, 'test');
     expect(result.ok).toBe(false);

--- a/packages/infra/src/adapters/local-awesome-copilot-adapter.ts
+++ b/packages/infra/src/adapters/local-awesome-copilot-adapter.ts
@@ -203,11 +203,14 @@ export class LocalAwesomeCopilotAdapter extends BaseSourceAdapter {
     return yaml.load(content) as CollectionManifest;
   }
 
-  private buildBundle(collection: CollectionManifest, collectionFile: string, mtimeMs: number): Bundle {
+  private buildBundle(
+    collection: CollectionManifest,
+    collectionFile: string,
+    mtimeMs: number
+  ): Bundle {
     const collectionPath = path.join(this.getCollectionsDir(), collectionFile);
-    const localPath = this.getLocalPath();
     const readmePath = collection.readme?.path
-      ? path.join(localPath, collection.readme.path)
+      ? path.join(this.getLocalPath(), collection.readme.path)
       : undefined;
     const bundle: Bundle = {
       id: collection.id,
@@ -225,8 +228,7 @@ export class LocalAwesomeCopilotAdapter extends BaseSourceAdapter {
       size: `${collection.items.length} items`,
       dependencies: [],
       license: 'MIT',
-      readmeUrl: readmePath ? `file://${readmePath}` : undefined,
-      readmeRevision: String(mtimeMs)
+      readmeUrl: readmePath ? `file://${readmePath}` : undefined
     };
 
     // Attach a content breakdown + raw MCP servers for the Marketplace
@@ -241,6 +243,16 @@ export class LocalAwesomeCopilotAdapter extends BaseSourceAdapter {
     return bundle;
   }
 
+  /**
+   * Absolute path of the README a local collection declares, if any.
+   * Single source of truth for both `readmeUrl` and `readmeRevision`, so the
+   * two can never describe different files. Rejects declarations that
+   * escape the configured source root (e.g. `../outside.md`) - the local
+   * adapter reads manifests directly, so core's schema validation never
+   * sees this path.
+   * @param collection Parsed local collection manifest.
+   * @returns Absolute README path, or undefined when none is declared or unsafe.
+   */
   private createDeploymentManifest(collection: CollectionManifest): Record<string, unknown> {
     const prompts = collection.items.map((item) => {
       if (item.kind === 'skill') {

--- a/packages/infra/test/adapters/local-awesome-copilot-adapter.test.ts
+++ b/packages/infra/test/adapters/local-awesome-copilot-adapter.test.ts
@@ -143,6 +143,19 @@ describe('LocalAwesomeCopilotAdapter', () => {
       expect((bundle as unknown as { breakdown: Record<string, number> }).breakdown.mcpServers).toBe(0);
     });
 
+    it('does not cache local README content by revision', async () => {
+      const fs = new InMemoryFileSystem();
+      fs.seed(
+        '/collections-root/collections/my-collection.collection.yml',
+        `${collectionYaml()}\nreadme:\n  path: docs/collection-overview.md`
+      );
+      fs.seed('/collections-root/docs/collection-overview.md', '# Overview');
+
+      const [bundle] = await new LocalAwesomeCopilotAdapter(makeSource(), fs).fetchBundles();
+
+      expect(bundle.readmeRevision).toBeUndefined();
+    });
+
     it('ignores files in the collections directory that are not .collection.yml', async () => {
       const fs = new InMemoryFileSystem();
       fs.seed('/collections-root/collections/my-collection.collection.yml', collectionYaml());


### PR DESCRIPTION
## Description

Fix generated release publication and port the README functionality introduced in PR #251 from the legacy scripts and VS Code service into the shared packages and CLI architecture.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📝 Documentation update
- [x] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test coverage improvement
- [x] 🔧 Configuration/build changes

## Related Issues

Relates to #251

## Changes Made

- Fix the generated GitHub publishing workflow to use the CLI bundle output directory correctly and upload the ZIP, deployment manifest, and optional authored README returned by `bundle build -o json`.
- Port collection README support into `core`, `app`, and the CLI: collection typing and validation, missing-README warnings, affected-collection detection, deployment-manifest metadata, and the optional `readmeAsset` bundle output.
- Move the existing README cache reuse and bounded download flow from `RegistryManager` into `@ai-primitives-hub/app`, leaving the VS Code extension responsible for storage and events.
- Keep local README sources uncached by revision so local README content is refreshed on each source sync, matching the original extension behavior.
- Update repository lint guidance to use the fixing lint commands.

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing completed
- [ ] All existing tests pass

### Validation Performed

- `pnpm -C packages/core test` (208 tests)
- `pnpm -C packages/app test` (545 tests)
- `pnpm -C packages/infra test` (666 tests)
- `pnpm -C packages/cli test` (286 tests)
- VS Code extension production compilation
- Focused GitHub scaffold property tests
- Package and extension lint fixes, with no lint errors
- CI validation passed on macOS, Ubuntu, and Windows; Stable and Insiders integration tests are in progress

The local VS Code integration-host launch could not start (`spawn` exit `-2`), so it is not reported as passing.

### Manual Testing Steps

Not performed.

### Tested On

- [x] macOS
- [ ] Windows
- [ ] Linux

- [ ] VS Code Stable
- [x] VS Code Insiders

## Screenshots

Not applicable.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Documentation

- [ ] README.md updated
- [x] JSDoc comments added/updated
- [x] No user documentation changes needed

## Additional Notes

This keeps the behavior aligned with the README implementation from PR #251. In particular, `bundle build` returns the authored README path as the release asset, and local sources do not introduce a new README revision policy.

## Reviewer Guidelines

Please pay special attention to:

- The generated release workflow's JSON asset handling and optional README upload.
- Parity between the legacy README behavior and the new core/app/infra/CLI implementation.
- The extension remaining a thin adapter around app-level README hydration.

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**
