### PR TITLE
chore: add CODEOWNERS file to define repository ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @AmadeusITGroup/ai-primitives-hub_admins


### PR DESCRIPTION
Adds a repository-wide [CODEOWNERS](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) rule for @AmadeusITGroup/ai-primitives-hub_admins.

This automatically requests the team’s review for pull requests affecting any repository file, improving review visibility and ownership.

Closes #364.