### PR TITLE
feat: new github workflow to allow publishing the packages to npmjs registry

### DIFF
--- a/.github/workflows/packages-release.yml
+++ b/.github/workflows/packages-release.yml
@@ -1,0 +1,160 @@
+name: Release @ai-primitives-hub packages to npmjs
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: "Semantic version bump"
+        required: true
+        default: "prerelease"
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+          - prerelease
+      preid:
+        description: "Prerelease id (only used when release-type is prerelease)"
+        required: false
+        default: "alpha"
+        type: string
+      packages:
+        description: "Packages to release"
+        required: true
+        default: "all"
+        type: choice
+        options:
+          - all
+          - core
+          - infra
+          - app
+          - cli
+      npm_tag:
+        description: "npm distribution tag"
+        required: true
+        default: "next"
+        type: choice
+        options:
+          - latest
+          - next
+          - alpha
+          - beta
+      dry_run:
+        description: "Dry run: bump and build, but do not commit, tag, or publish"
+        required: false
+        default: true
+        type: boolean
+      skip_checks:
+        description: "Skip lint/build/test gates"
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  NODE_VERSION: "24"
+
+jobs:
+  release:
+    name: Bump, tag and publish packages
+    runs-on: ubuntu-latest
+    environment: npmjs
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.5.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Lint, build and test packages
+        if: ${{ !inputs.skip_checks }}
+        run: |
+          pnpm --filter '@ai-primitives-hub/*' lint
+          pnpm --filter '@ai-primitives-hub/*' build
+          pnpm --filter '@ai-primitives-hub/*' test
+
+      - name: Determine package selector
+        id: selector
+        run: |
+          if [ "${{ inputs.packages }}" = "all" ]; then
+            echo "selector=@ai-primitives-hub/*" >> "$GITHUB_OUTPUT"
+            echo "names=core infra app cli" >> "$GITHUB_OUTPUT"
+          else
+            echo "selector=@ai-primitives-hub/${{ inputs.packages }}" >> "$GITHUB_OUTPUT"
+            echo "names=${{ inputs.packages }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Bump package versions
+        id: bump
+        run: |
+          PREID_ARG=""
+          if [ "${{ inputs.release_type }}" = "prerelease" ]; then
+            PREID_ARG="--preid ${{ inputs.preid }}"
+          fi
+          pnpm version ${{ inputs.release_type }} $PREID_ARG -r --filter "${{ steps.selector.outputs.selector }}" --no-git-tag-version
+
+      - name: Update lockfile
+        run: pnpm install --lockfile-only
+
+      - name: Show versions to release
+        run: |
+          for name in ${{ steps.selector.outputs.names }}; do
+            version=$(node -p "require('./packages/$name/package.json').version")
+            echo "$name -> $version"
+          done
+
+      - name: Commit and push version bump
+        if: ${{ !inputs.dry_run }}
+        run: |
+          git add pnpm-lock.yaml packages/*/package.json
+          git commit -m "chore(release): bump @ai-primitives-hub packages"
+          git push origin "HEAD:${{ github.ref_name }}"
+
+      - name: Create and push git tags
+        if: ${{ !inputs.dry_run }}
+        run: |
+          for name in ${{ steps.selector.outputs.names }}; do
+            version=$(node -p "require('./packages/$name/package.json').version")
+            tag="packages/${name}-v${version}"
+            git tag "$tag"
+            git push origin "refs/tags/${tag}:refs/tags/${tag}"
+          done
+
+      - name: Publish packages to npmjs
+        if: ${{ !inputs.dry_run }}
+        run: |
+          for name in ${{ steps.selector.outputs.names }}; do
+            echo "Publishing @ai-primitives-hub/$name ..."
+            pnpm --filter "@ai-primitives-hub/$name" publish \
+              --access public \
+              --tag "${{ inputs.npm_tag }}" \
+              --no-git-checks \
+              --provenance
+          done


### PR DESCRIPTION
## Description

Introduces a new GitHub Actions workflow, `.github/workflows/packages-release.yml`, that automates bumping, tagging, and publishing the `@ai-primitives-hub/*` packages to the npmjs registry.

## Type of Change

<!-- Mark relevant items with an [x] -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [x] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [x] 🔧 Configuration/build changes

## Related Issues

<!-- Link to related issues using #issue_number -->

Closes #
Fixes #
Relates to #

## Changes Made

<!-- Provide a detailed list of changes -->

- Added `.github/workflows/packages-release.yml` to release `@ai-primitives-hub/*` packages to npmjs.
- Configured `workflow_dispatch` inputs for release type (patch/minor/major/prerelease), prerelease id, package selector, npm dist-tag, dry-run mode, and optional skip of lint/build/test gates.
- Implemented jobs to checkout, set up pnpm and Node.js, install dependencies, run lint/build/test checks, determine package selector, bump versions with `pnpm version`, update the lockfile, commit and push version bumps, create and push per-package git tags, and publish each selected package to npmjs with `--provenance` and `--no-git-checks`.
- Set required permissions (`contents: write`, `id-token: write`) and environment `npmjs` for OIDC-based npm publishing.

## Testing

<!-- Describe the testing you've done -->

### Test Coverage

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

### Manual Testing Steps

1. Open the Actions tab and trigger the `Release @ai-primitives-hub packages to npmjs` workflow manually.
2. Select `dry_run: true` and a package selector (e.g., `all` or `core`) to verify the version bump and tag generation without side effects.
3. Review the workflow output for the selected package versions and confirm the generated tags would be correct.
4. Run a full (non-dry) release against a chosen package and npm dist-tag, then verify the package appears on npmjs with the expected version and provenance.

### Tested On

- [ ] macOS
- [ ] Windows
- [x] Linux

- [ ] VS Code Stable
- [ ] VS Code Insiders

## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->

N/A — this is a CI/CD workflow change.

## Checklist

<!-- Mark completed items with an [x] -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Documentation

<!-- Describe any documentation changes needed -->

- [ ] README.md updated
- [ ] JSDoc comments added/updated
- [x] No documentation changes needed

## Additional Notes

- The workflow uses `pnpm version` with `--no-git-tag-version` so that tags can be pushed explicitly in a separate step.
- Dry-run mode skips the commit, tag, and publish steps, making it safe to validate the bump logic.
- `id-token: write` is required for npm provenance via OIDC.

## Reviewer Guidelines

<!-- For reviewers: What should they focus on? -->

Please pay special attention to:

- Correctness of the `pnpm version` and `pnpm publish` commands for the selected package scopes.
- GitHub Actions permissions and environment configuration for npmjs OIDC publishing.
- Handling of `dry_run` and `skip_checks` inputs to prevent accidental publishes or bypassed validation.

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**
