### PR TITLE
chore: make the documented verification commands work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,6 +171,10 @@ post-compile-fixes-cross-platform.js
 # Cache directories
 .cache/
 
+# Local code-intelligence cache: hundreds of MB of single-line JSON that
+# search tools should never read.
+.gitnexus/
+
 # Claude local settings file
 .claude/settings.local.json
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,30 +20,37 @@ Use Node 24+ and pnpm 11+.
 
 ```bash
 pnpm install
-pnpm --filter './packages/*' build   # also required before the extension typechecks
-pnpm --filter './packages/*' test
-pnpm run compile                     # extension bundle
-pnpm run compile-tests               # extension tests -> test-dist/
-pnpm run test:unit                   # runs test-dist/, never src/
+pnpm run verify            # everything, in the right order, one exit code
+pnpm run verify:packages   # packages/ only: build + test + lint:fix (~30s)
+```
+
+`verify` is `verify:packages` followed by the extension's `compile`, `test:extension`, and `lint:extension`. Prefer it over running the steps by hand: the ordering matters and this bakes it in. It takes ~110s and prints thousands of lines, so redirect it and only read the tail on failure — a passing run needs no output at all:
+
+```bash
+pnpm run verify > /tmp/verify.log 2>&1 || tail -40 /tmp/verify.log
+```
+
+The individual steps, when you need a tighter loop:
+
+```bash
+pnpm run build:packages    # required before the extension typechecks
+pnpm run test:packages
+pnpm run compile           # extension bundle
+pnpm run test:extension    # compile-tests, then test:unit
+pnpm run lint:fix          # packages + extension
 pnpm run package:vsix
 ```
 
-Scope recursive commands with `--filter './packages/*'`. `pnpm -C packages -r <script>` looks scoped but resolves the whole workspace, so it also runs the extension, `lib/`, `website/`, and `github-actions/`: 4920 lines of output where the filter gives 181.
+Use these scripts rather than open-coding a recursive command. `pnpm -r <script>` and `pnpm -C packages -r <script>` both resolve the whole workspace — the latter looks scoped but is not — so they also run `lib/`, `website/`, and `github-actions/`: 4920 lines of output where the scoped script gives 181. The scripts filter on `@ai-primitives-hub/*`, matching what CI does.
 
 `lib/` has its own test cycle: `cd lib && npm test`.
 
-Lint per package. There is no root `lint:fix` script and no root `eslint.config.mjs`, so both `pnpm run lint:fix` and `npx eslint <path>` fail at the repository root:
-
-```bash
-pnpm --filter './packages/*' lint:fix
-pnpm -C apps/vscode-extension run lint:fix
-```
-
-Always run linting with its `:fix` option. Do not run the corresponding non-fixing lint command afterwards: it reports the same remaining issues without adding useful validation. `src test` carries accepted warnings, so add `--quiet` when you only want errors.
+There is no root `eslint.config.mjs`, so a bare `npx eslint <path>` fails at the repository root. Lint through `lint:fix` (or `lint:packages` / `lint:extension`), always with the `:fix` option. Do not run the corresponding non-fixing lint command afterwards: it reports the same remaining issues without adding useful validation. `src test` carries accepted warnings, so add `--quiet` when you only want errors.
 
 ## Verification
 
 - **Judge success by exit status, not by grepping output.** A pipe replaces the exit code with the last command's, so `vitest … | tail` and `eslint … | grep` both report success for a failing run. Run the command bare, or end it with `&& echo PASS || echo FAIL`.
+- **`pnpm run test:unit` alone proves nothing.** It executes the already-compiled `test-dist/` and compiles nothing, so after editing any `.ts` it silently re-runs the previous build and passes. Use `pnpm run test:extension`, which compiles first.
 - **Rebuild `packages/` after switching branches or changing a cross-package type.** Lint and `tsc` resolve `@ai-primitives-hub/*` through built `dist/`, so a stale build invents errors that are absent from the checked-out source and hides ones that are present. The usual symptoms are a new export reported as "has no exported member" and type errors naming a symbol you cannot find in `src/`.
 - Vitest (`packages/*`) prints `Tests N passed`; Mocha (the extension) prints `N passing`. Pass `--no-color` to Vitest before matching on that line; otherwise ANSI codes break the match.
 - Extension unit tests log expected errors from negative-path cases (`cmd.exe not found`, `[AI Primitives Hub] ERROR: …`). Those are not failures. Only the summary line and the exit status are.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,15 +20,33 @@ Use Node 24+ and pnpm 11+.
 
 ```bash
 pnpm install
-pnpm run compile
-pnpm run test:unit
-pnpm run lint:fix
+pnpm --filter './packages/*' build   # also required before the extension typechecks
+pnpm --filter './packages/*' test
+pnpm run compile                     # extension bundle
+pnpm run compile-tests               # extension tests -> test-dist/
+pnpm run test:unit                   # runs test-dist/, never src/
 pnpm run package:vsix
 ```
 
-`lib/` has its own test cycle: `cd lib && npm test`. For package work, run `pnpm -C packages -r build`, `pnpm -C packages -r lint:fix`, or `pnpm -C packages -r test`.
+Scope recursive commands with `--filter './packages/*'`. `pnpm -C packages -r <script>` looks scoped but resolves the whole workspace, so it also runs the extension, `lib/`, `website/`, and `github-actions/`: 4920 lines of output where the filter gives 181.
 
-Always run linting with its `:fix` option. Do not run the corresponding non-fixing lint command afterwards: it reports the same remaining issues without adding useful validation.
+`lib/` has its own test cycle: `cd lib && npm test`.
+
+Lint per package. There is no root `lint:fix` script and no root `eslint.config.mjs`, so both `pnpm run lint:fix` and `npx eslint <path>` fail at the repository root:
+
+```bash
+pnpm --filter './packages/*' lint:fix
+pnpm -C apps/vscode-extension run lint:fix
+```
+
+Always run linting with its `:fix` option. Do not run the corresponding non-fixing lint command afterwards: it reports the same remaining issues without adding useful validation. `src test` carries accepted warnings, so add `--quiet` when you only want errors.
+
+## Verification
+
+- **Judge success by exit status, not by grepping output.** A pipe replaces the exit code with the last command's, so `vitest … | tail` and `eslint … | grep` both report success for a failing run. Run the command bare, or end it with `&& echo PASS || echo FAIL`.
+- **Rebuild `packages/` after switching branches or changing a cross-package type.** Lint and `tsc` resolve `@ai-primitives-hub/*` through built `dist/`, so a stale build invents errors that are absent from the checked-out source and hides ones that are present. The usual symptoms are a new export reported as "has no exported member" and type errors naming a symbol you cannot find in `src/`.
+- Vitest (`packages/*`) prints `Tests N passed`; Mocha (the extension) prints `N passing`. Pass `--no-color` to Vitest before matching on that line; otherwise ANSI codes break the match.
+- Extension unit tests log expected errors from negative-path cases (`cmd.exe not found`, `[AI Primitives Hub] ERROR: …`). Those are not failures. Only the summary line and the exit status are.
 
 ## Architecture
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ pnpm run verify            # everything, in the right order, one exit code
 pnpm run verify:packages   # packages/ only: build + test + lint:fix (~30s)
 ```
 
-`verify` is `verify:packages` followed by the extension's `compile`, `test:extension`, and `lint:extension`. Prefer it over running the steps by hand: the ordering matters and this bakes it in. It takes ~110s and prints thousands of lines, so redirect it and only read the tail on failure — a passing run needs no output at all:
+`verify` is `verify:packages` followed by the extension's `compile`, `test:extension`, and `lint:extension`. Prefer it over running the steps by hand: the ordering matters and this bakes it in. It takes ~150s and prints thousands of lines, so redirect it and only read the tail on failure — a passing run needs no output at all:
 
 ```bash
 pnpm run verify > /tmp/verify.log 2>&1 || tail -40 /tmp/verify.log
@@ -33,13 +33,16 @@ pnpm run verify > /tmp/verify.log 2>&1 || tail -40 /tmp/verify.log
 The individual steps, when you need a tighter loop:
 
 ```bash
-pnpm run build:packages    # required before the extension typechecks
+pnpm run build:packages       # required before the extension typechecks
 pnpm run test:packages
-pnpm run compile           # extension bundle
-pnpm run test:extension    # compile-tests, then test:unit
-pnpm run lint:fix          # packages + extension
+pnpm run compile              # extension bundle
+pnpm run test:extension       # unit + integration (delegates to the extension's test:all)
+pnpm run test:extension:unit  # unit only: no real VS Code, ~20s
+pnpm run lint:fix             # packages + extension
 pnpm run package:vsix
 ```
+
+`test:extension` launches a real VS Code through `@vscode/test-electron` for the `test/suite/` tests, so it needs a display (CI wraps it in `xvfb-run` on Linux). That layer is the only one that sees command registration and `package.json` contributions, so a change to either is not verified until it runs — use `test:extension:unit` for the inner loop, but not as your final check.
 
 Use these scripts rather than open-coding a recursive command. `pnpm -r <script>` and `pnpm -C packages -r <script>` both resolve the whole workspace — the latter looks scoped but is not — so they also run `lib/`, `website/`, and `github-actions/`: 4920 lines of output where the scoped script gives 181. The scripts filter on `@ai-primitives-hub/*`, matching what CI does.
 
@@ -50,8 +53,7 @@ There is no root `eslint.config.mjs`, so a bare `npx eslint <path>` fails at the
 ## Verification
 
 - **Judge success by exit status, not by grepping output.** A pipe replaces the exit code with the last command's, so `vitest … | tail` and `eslint … | grep` both report success for a failing run. Run the command bare, or end it with `&& echo PASS || echo FAIL`.
-- **`pnpm run test:unit` alone proves nothing.** It executes the already-compiled `test-dist/` and compiles nothing, so after editing any `.ts` it silently re-runs the previous build and passes. Use `pnpm run test:extension`, which compiles first.
-- **Rebuild `packages/` after switching branches or changing a cross-package type.** Lint and `tsc` resolve `@ai-primitives-hub/*` through built `dist/`, so a stale build invents errors that are absent from the checked-out source and hides ones that are present. The usual symptoms are a new export reported as "has no exported member" and type errors naming a symbol you cannot find in `src/`.
+- **`pnpm run test:unit` alone proves nothing.** It executes the already-compiled `test-dist/` and compiles nothing, so after editing any `.ts` it silently re-runs the previous build and passes. Use `pnpm run test:extension`, which compiles first.- **Rebuild `packages/` after switching branches or changing a cross-package type.** Lint and `tsc` resolve `@ai-primitives-hub/*` through built `dist/`, so a stale build invents errors that are absent from the checked-out source and hides ones that are present. The usual symptoms are a new export reported as "has no exported member" and type errors naming a symbol you cannot find in `src/`.
 - Vitest (`packages/*`) prints `Tests N passed`; Mocha (the extension) prints `N passing`. Pass `--no-color` to Vitest before matching on that line; otherwise ANSI codes break the match.
 - Extension unit tests log expected errors from negative-path cases (`cmd.exe not found`, `[AI Primitives Hub] ERROR: …`). Those are not failures. Only the summary line and the exit status are.
 

--- a/apps/vscode-extension/AGENTS.md
+++ b/apps/vscode-extension/AGENTS.md
@@ -14,7 +14,14 @@ pnpm -C apps/vscode-extension run compile-tests
 pnpm -C apps/vscode-extension run test:unit
 pnpm -C apps/vscode-extension run test:integration
 pnpm -C apps/vscode-extension run package:vsix
+pnpm -C apps/vscode-extension run lint:fix
 ```
+
+**`test:unit` executes `test-dist/`, and does not compile anything.** It has no `pre` hook (`pretest` belongs to `test`, not `test:unit`), so running it after editing a `.ts` file silently re-runs the previous build: a changed test keeps its old assertions and a new test file is simply absent from the glob. The suite then passes and tells you nothing. Always run `compile-tests` first, and treat a pass that arrives without one as unverified.
+
+`compile-tests` is also the only typecheck for `test/**`, since `compile` (webpack) only covers `src/`. It emits JavaScript even when it reports type errors, so tests can pass while the types are broken — read its output, do not just check that tests ran afterwards.
+
+Building `packages/` first is a precondition for both: cross-package types resolve through the built `dist/`.
 
 ## Architecture
 

--- a/apps/vscode-extension/AGENTS.md
+++ b/apps/vscode-extension/AGENTS.md
@@ -6,22 +6,21 @@ Business logic lives in `@ai-primitives-hub/app`/`core`/`infra`, not here. Per [
 
 ## Commands
 
-Run from the repository root:
+From the repository root:
 
 ```bash
-pnpm -C apps/vscode-extension run compile
-pnpm -C apps/vscode-extension run compile-tests
-pnpm -C apps/vscode-extension run test:unit
+pnpm run compile                                        # bundle src/
+pnpm run test:extension                                 # compile-tests, then test:unit
+pnpm run lint:extension
 pnpm -C apps/vscode-extension run test:integration
 pnpm -C apps/vscode-extension run package:vsix
-pnpm -C apps/vscode-extension run lint:fix
 ```
 
-**`test:unit` executes `test-dist/`, and does not compile anything.** It has no `pre` hook (`pretest` belongs to `test`, not `test:unit`), so running it after editing a `.ts` file silently re-runs the previous build: a changed test keeps its old assertions and a new test file is simply absent from the glob. The suite then passes and tells you nothing. Always run `compile-tests` first, and treat a pass that arrives without one as unverified.
+**Use `test:extension`, not `test:unit` on its own.** `test:unit` executes `test-dist/` and compiles nothing — it has no `pre` hook (`pretest` belongs to `test`), so running it after editing a `.ts` file silently re-runs the previous build: a changed test keeps its old assertions and a new test file is simply absent from the glob. The suite then passes and tells you nothing. `test:extension` runs `compile-tests` first. `test:unit` stays a separate script because CI applies post-compilation fixes between the two steps.
 
 `compile-tests` is also the only typecheck for `test/**`, since `compile` (webpack) only covers `src/`. It emits JavaScript even when it reports type errors, so tests can pass while the types are broken — read its output, do not just check that tests ran afterwards.
 
-Building `packages/` first is a precondition for both: cross-package types resolve through the built `dist/`.
+Building `packages/` first is a precondition for both: cross-package types resolve through the built `dist/`. `pnpm run verify` does the whole chain in order.
 
 ## Architecture
 

--- a/apps/vscode-extension/AGENTS.md
+++ b/apps/vscode-extension/AGENTS.md
@@ -9,14 +9,23 @@ Business logic lives in `@ai-primitives-hub/app`/`core`/`infra`, not here. Per [
 From the repository root:
 
 ```bash
-pnpm run compile                                        # bundle src/
-pnpm run test:extension                                 # compile-tests, then test:unit
+pnpm run compile                  # bundle src/
+pnpm run test:extension           # unit + integration (the package's own test:all)
+pnpm run test:extension:unit      # unit only, ~20s
 pnpm run lint:extension
-pnpm -C apps/vscode-extension run test:integration
 pnpm -C apps/vscode-extension run package:vsix
 ```
 
-**Use `test:extension`, not `test:unit` on its own.** `test:unit` executes `test-dist/` and compiles nothing — it has no `pre` hook (`pretest` belongs to `test`), so running it after editing a `.ts` file silently re-runs the previous build: a changed test keeps its old assertions and a new test file is simply absent from the glob. The suite then passes and tells you nothing. `test:extension` runs `compile-tests` first. `test:unit` stays a separate script because CI applies post-compilation fixes between the two steps.
+**Use one of the `test:extension*` scripts, not `test:unit` on its own.** `test:unit` executes `test-dist/` and compiles nothing — it has no `pre` hook (`pretest` belongs to `test`), so running it after editing a `.ts` file silently re-runs the previous build: a changed test keeps its old assertions and a new test file is simply absent from the glob. The suite then passes and tells you nothing. `test:unit` stays a separate script because CI applies post-compilation fixes between the two steps.
+
+Two layers, and only the second one sees VS Code:
+
+| Layer | Files | Sees |
+|---|---|---|
+| unit | `test/**` except `test/suite/` | everything importable with a mocked `vscode` |
+| integration | `test/suite/` | command registration, `package.json` contributions, real activation |
+
+So a change to `package.json` contributions or to `extension.ts` command wiring is **not** verified by a passing unit run. `test:extension` covers both; it launches a real VS Code and needs a display.
 
 `compile-tests` is also the only typecheck for `test/**`, since `compile` (webpack) only covers `src/`. It emits JavaScript even when it reports type errors, so tests can pass while the types are broken — read its output, do not just check that tests ran afterwards.
 

--- a/apps/vscode-extension/test/AGENTS.md
+++ b/apps/vscode-extension/test/AGENTS.md
@@ -21,7 +21,9 @@ pnpm run test:one -- test/services/telemetry-service.test.ts
 pnpm run test:coverage:unit
 ```
 
-`compile-tests` before `test:unit` is mandatory, not conventional: `test:unit` runs the already-compiled `test-dist/` and compiles nothing, so skipping it re-runs the previous build and reports a pass that covers none of your changes. From the repository root, `pnpm run test:extension` chains the two.
+`compile-tests` before `test:unit` is mandatory, not conventional: `test:unit` runs the already-compiled `test-dist/` and compiles nothing, so skipping it re-runs the previous build and reports a pass that covers none of your changes. From the repository root, `pnpm run test:extension` chains compile, unit, and integration; `pnpm run test:extension:unit` stops at unit.
+
+`test:unit` excludes `test-dist/test/suite/**`, so a passing unit run says nothing about command registration or `package.json` contributions — those only run under `test:integration`.
 
 ## Test Design
 

--- a/apps/vscode-extension/test/AGENTS.md
+++ b/apps/vscode-extension/test/AGENTS.md
@@ -21,7 +21,7 @@ pnpm run test:one -- test/services/telemetry-service.test.ts
 pnpm run test:coverage:unit
 ```
 
-`compile-tests` before `test:unit` is mandatory, not conventional: `test:unit` runs the already-compiled `test-dist/` and compiles nothing, so skipping it re-runs the previous build and reports a pass that covers none of your changes.
+`compile-tests` before `test:unit` is mandatory, not conventional: `test:unit` runs the already-compiled `test-dist/` and compiles nothing, so skipping it re-runs the previous build and reports a pass that covers none of your changes. From the repository root, `pnpm run test:extension` chains the two.
 
 ## Test Design
 

--- a/apps/vscode-extension/test/AGENTS.md
+++ b/apps/vscode-extension/test/AGENTS.md
@@ -21,6 +21,8 @@ pnpm run test:one -- test/services/telemetry-service.test.ts
 pnpm run test:coverage:unit
 ```
 
+`compile-tests` before `test:unit` is mandatory, not conventional: `test:unit` runs the already-compiled `test-dist/` and compiles nothing, so skipping it re-runs the previous build and reports a pass that covers none of your changes.
+
 ## Test Design
 
 - Test public behavior: return values, visible side effects, and errors. Do not test private methods, operation order, or internal call counts.

--- a/eslint.shared.mjs
+++ b/eslint.shared.mjs
@@ -58,7 +58,11 @@ export function createSharedConfig({ name, tsProjects, tsconfigRootDir, nodeGlob
         'import/resolver': {
           node: true,
           typescript: {
-            project: tsProjects
+            project: tsProjects,
+            // Every package legitimately has both a src and a test tsconfig;
+            // without this the resolver prints a "Multiple projects found"
+            // warning on stderr for each lint run, which reads like a fault.
+            noWarnOnMultipleProjects: true
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "compile": "pnpm -C apps/vscode-extension run compile",
     "compile-tests": "pnpm -C apps/vscode-extension run compile-tests",
     "test:unit": "pnpm -C apps/vscode-extension run test:unit",
-    "test:extension": "pnpm run compile-tests && pnpm run test:unit",
+    "test:extension": "pnpm -C apps/vscode-extension run test:all",
+    "test:extension:unit": "pnpm run compile-tests && pnpm run test:unit",
     "verify:packages": "pnpm run build:packages && pnpm run test:packages && pnpm run lint:packages",
     "verify": "pnpm run verify:packages && pnpm run compile && pnpm run test:extension && pnpm run lint:extension",
     "package:vsix": "pnpm -C apps/vscode-extension run package:vsix"

--- a/package.json
+++ b/package.json
@@ -13,9 +13,17 @@
     "watch": "pnpm -r watch",
     "lint": "pnpm -r lint",
     "test": "pnpm -r test",
+    "build:packages": "pnpm --filter \"@ai-primitives-hub/*\" build",
+    "test:packages": "pnpm --filter \"@ai-primitives-hub/*\" test",
+    "lint:packages": "pnpm --filter \"@ai-primitives-hub/*\" lint:fix",
+    "lint:extension": "pnpm -C apps/vscode-extension run lint:fix",
+    "lint:fix": "pnpm run lint:packages && pnpm run lint:extension",
     "compile": "pnpm -C apps/vscode-extension run compile",
     "compile-tests": "pnpm -C apps/vscode-extension run compile-tests",
     "test:unit": "pnpm -C apps/vscode-extension run test:unit",
+    "test:extension": "pnpm run compile-tests && pnpm run test:unit",
+    "verify:packages": "pnpm run build:packages && pnpm run test:packages && pnpm run lint:packages",
+    "verify": "pnpm run verify:packages && pnpm run compile && pnpm run test:extension && pnpm run lint:extension",
     "package:vsix": "pnpm -C apps/vscode-extension run package:vsix"
   },
   "devDependencies": {

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -23,12 +23,16 @@ CLI / Extension → app → infra → core
 ## Commands
 
 ```bash
-pnpm -C packages -r build
-pnpm -C packages -r test
-pnpm -C packages -r lint
+pnpm --filter './packages/*' build
+pnpm --filter './packages/*' test
+pnpm --filter './packages/*' lint:fix
 ```
 
-Tests use Vitest. For a bug fix or feature: add a focused failing test in the owning package, make the minimal change, rerun, then run that package's suite.
+Use the filter, not `pnpm -C packages -r <script>`: the latter resolves the whole workspace and also runs the extension, `lib/`, `website/`, and `github-actions/`.
+
+Tests use Vitest, which exits non-zero on failure — check that exit status rather than grepping the summary, and pass `--no-color` when you do need to match `Tests N passed`. For a bug fix or feature: add a focused failing test in the owning package, make the minimal change, rerun, then run that package's suite.
+
+A cross-package type change is only visible to the other packages after a build, because they resolve `@ai-primitives-hub/*` through `dist/`. Build before trusting a lint or typecheck result.
 
 ## References
 

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -22,13 +22,16 @@ CLI / Extension → app → infra → core
 
 ## Commands
 
+From the repository root:
+
 ```bash
-pnpm --filter './packages/*' build
-pnpm --filter './packages/*' test
-pnpm --filter './packages/*' lint:fix
+pnpm run verify:packages   # build + test + lint:fix for these four packages
+pnpm run build:packages
+pnpm run test:packages
+pnpm run lint:packages
 ```
 
-Use the filter, not `pnpm -C packages -r <script>`: the latter resolves the whole workspace and also runs the extension, `lib/`, `website/`, and `github-actions/`.
+These filter on `@ai-primitives-hub/*`. Do not open-code `pnpm -C packages -r <script>`: it resolves the whole workspace and also runs the extension, `lib/`, `website/`, and `github-actions/`. For a single package, `pnpm -C packages/<name> test` is fine.
 
 Tests use Vitest, which exits non-zero on failure — check that exit status rather than grepping the summary, and pass `--no-color` when you do need to match `Tests N passed`. For a bug fix or feature: add a focused failing test in the owning package, make the minimal change, rerun, then run that package's suite.
 


### PR DESCRIPTION
## Description

Working through the auth-diagnostics change surfaced several places where the documented workflow either fails outright or reports success on work it never checked. This fixes the commands, adds scripts so the correct sequence is one invocation, and records the traps in the `AGENTS.md` guides.

Three of the findings are correctness issues, not conveniences — each one lets a broken change look verified:

| Trap | Evidence |
|---|---|
| Piping a test or lint run through `grep`/`tail` replaces the runner's exit code with the pipe's | a deliberately failing Vitest run piped to `tail` exits **0**; bare, it exits 1. A Mocha run reported exit 0 while printing `2 failing`. |
| `test:unit` executes `test-dist/` and compiles nothing | appended an always-throwing test to a compiled test file; the **whole suite still passed** |
| Lint and `tsc` resolve `@ai-primitives-hub/*` through built `dist/` | on a clean `main` checkout with a stale build, `packages/infra` lint reported **6 errors about a type that exists nowhere in main's source**; they vanished after a rebuild, with no source change |

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [x] 🔧 Configuration/build changes

## Related Issues

None. Fallout from the work in the auth-diagnostics PR; independent of it and mergeable on its own.

## Changes Made

**Broken commands that were documented**
- `AGENTS.md` told everyone to run `pnpm run lint:fix`, which **does not exist at the root**. There is also no root `eslint.config.mjs`, so the `npx eslint <changed-paths> --fix --quiet` form (introduced by #374's own `AGENTS.md` rewrite, and repeated in the plan I was following) fails there too.
- `pnpm -C packages -r <script>` looks scoped to `packages/` but `-r` still resolves the whole workspace, so it also runs the extension, `lib/`, `website/` and `github-actions/`: **4920 lines of output where the scoped form gives 181.**

**New root scripts** (all filtering on `@ai-primitives-hub/*`, the same filter CI already uses)
- `build:packages`, `test:packages`, `lint:packages`, `lint:extension`
- `lint:fix` — packages + extension, so the long-documented command now exists
- `test:extension` — delegates to the extension's existing `test:all` (compile-tests → unit → integration). My first cut hand-rolled `compile-tests && test:unit`, which both duplicated `test:all` and silently dropped the integration layer
- `test:extension:unit` — the fast path (~20s, no VS Code) for the inner loop
- `verify:packages` (~30s) and `verify` (~132s), chaining everything in dependency order behind a single exit code

**Every pre-existing script is byte-identical** — `build`, `watch`, `lint`, `test`, `compile`, `compile-tests`, `test:unit`, `package:vsix`. I checked which ones CI invokes (`build` in the publish workflow, `lint` and `test:unit` in `quick-check.sh`, `compile`/`compile-tests`/`test:integration` in the secure CI) and only added alongside them.

**Notably not done:** a `pretest:unit` hook, which would make the staleness trap structurally impossible. CI runs `compile → post-compile-fixes → compile-tests → post-compile-fixes-essential.js → test:unit`, so a pretest hook would re-run the compile *after* those fixes are applied. `test:unit` keeps its exact definition; `test:extension` is the safe path instead. Closing the hole properly means pointing CI at the underlying Mocha invocation — a CI change, so it is left as a decision rather than assumed.

**Lint noise**
- Set `noWarnOnMultipleProjects` on the shared `eslint-import-resolver-typescript` config. Every package legitimately has both a `src` and a `test` tsconfig, so each lint run printed a `Multiple projects found` warning to stderr that reads like a fault.

**Guides**
- Root `AGENTS.md`: rewritten Commands section plus a new **Verification** section covering the three traps, the two different test-runner summary formats (Vitest `Tests N passed` vs Mocha `N passing`, and that ANSI codes break naive matching unless you pass `--no-color`), and the fact that extension tests log expected errors from negative-path cases that are not failures.
- `packages/AGENTS.md`: points at the scoped scripts; notes that a cross-package type change is invisible until a build.
- `apps/vscode-extension/AGENTS.md`: a table of what each test layer sees, and why a passing unit run says nothing about command registration or `package.json` contributions.
- `apps/vscode-extension/test/AGENTS.md`: `compile-tests` before `test:unit` is mandatory, not conventional.

**`.gitignore`**
- Ignore `.gitnexus/`, a local code-intelligence cache — ~111 MB of single-line JSON. One shell `grep -r` of mine read it and returned a six-figure-character line. It was only excluded via this clone's `.git/info/exclude`, so nothing protected anyone else.

## Testing

No product code changes, so the testing here is that the documented commands actually run and that the composite scripts fail when they should.

### Test Coverage

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

### Manual Testing Steps

1. Every new script run individually: `build:packages`, `test:packages`, `lint:packages`, `lint:extension`, `lint:fix`, `test:extension:unit` (23s), `test:extension` (39s), `verify:packages`, `verify` — all exit 0.
2. `pnpm run verify` → **PASS in 132s**, running 2196 unit + 7 integration tests, with lint leaving no files rewritten.
3. `verify` fails correctly: injected a failing Vitest test, `verify:packages` exited non-zero.
4. Confirmed the eslint stderr warning is gone and lint still exits 0.
5. Machine-checked that every `pnpm run <script>` named in the four guides exists in the right `package.json` (accounting for the one guide whose commands run from `apps/vscode-extension/`).
6. Confirmed no pre-existing script definition changed: `git diff package.json` shows no `-` line for any of the eight.

### Tested On

- [x] macOS
- [ ] Windows
- [ ] Linux

- [x] VS Code Stable
- [ ] VS Code Insiders

VS Code Stable via `@vscode/test-electron`, as part of `verify`.

## Screenshots

Not applicable.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

No automated tests: the deliverable is scripts and guidance. Each claim in the guides was verified by running the command, and each trap was reproduced deliberately before being written down — details under Manual Testing.

## Documentation

- [ ] README.md updated
- [ ] JSDoc comments added/updated
- [x] No documentation changes needed

The `AGENTS.md` guides *are* the change; no other docs needed updating.

## Additional Notes

**`verify` runs `lint:fix`, which rewrites source files.** That follows the house rule ("always run linting with its `:fix` option"), but if you would rather have a read-only gate I can split `verify` (checking) from `verify:fix` (mutating). Say which you prefer.

**`verify` requires a display** for the integration layer (CI wraps it in `xvfb-run` on Linux). `verify:packages` and `test:extension:unit` are the headless-safe subsets.

**One loose end I could not explain:** the `AGENTS.md` injected into my session context already contained this exact guidance, including the "4920 lines" figure — yet no branch, remote ref or stash in the repository contains that text, and `main` has the old version. Something in the local setup appears to serve a newer `AGENTS.md` than any committed state. Worth checking, since an agent reading guidance that is not on `main` will diverge from what CI and other contributors see.

## Reviewer Guidelines

Please pay special attention to:

- **Whether `verify` should include `lint:fix`** (mutating) or be split.
- **Whether to go further and add `pretest:unit`**, accepting a double compile in CI, so `pnpm run test:unit` cannot silently pass on stale artifacts. I chose not to touch a CI-critical path unasked; the trade-off is yours.
- The claim that no CI-invoked script changed. I verified it by diff, but a second pair of eyes on `.github/workflows/` is cheap insurance.

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**
