### PR TITLE
fix(mcp):install servers with warning on MCP that cannot resolve inputs

### DIFF
--- a/apps/vscode-extension/src/services/bundle-installer.ts
+++ b/apps/vscode-extension/src/services/bundle-installer.ts
@@ -474,10 +474,9 @@ export class BundleInstaller {
   /**
    * Surface MCP warnings for an otherwise successful install.
    *
-   * The servers were written, so this is not a failure, but the warnings cover cases
-   * the user still has to act on — most notably a host that cannot prompt for
-   * `${input:id}` values, where the server is present but needs the secret filled in
-   * manually before it will connect.
+   * Only user-actionable warnings (e.g. "host cannot prompt for inputs") are shown
+   * as notifications. Bundle-author concerns (auto-derived declarations) are logged
+   * but not surfaced to the end user.
    * @param bundleId - Bundle being installed.
    * @param warnings - Warnings reported by the MCP manager.
    */
@@ -485,11 +484,21 @@ export class BundleInstaller {
     if (!warnings || warnings.length === 0) {
       return;
     }
-    const detail = warnings.join(' ');
-    this.logger.warn(`MCP installation warnings: ${detail}`);
-    void vscode.window.showWarningMessage(
-      `MCP servers for "${bundleId}" ${detail}`
-    );
+    // Auto-derive warnings are bundle-author concerns — log only.
+    const userActionable = warnings.filter((w) => !w.includes('auto-derived'));
+    const logOnly = warnings.filter((w) => w.includes('auto-derived'));
+
+    for (const w of logOnly) {
+      this.logger.warn(`MCP installation: ${w}`);
+    }
+
+    if (userActionable.length > 0) {
+      const detail = userActionable.join(' ');
+      this.logger.warn(`MCP installation warnings: ${detail}`);
+      void vscode.window.showWarningMessage(
+        `MCP servers for "${bundleId}" ${detail}`
+      );
+    }
   }
 
   private async installMcpServers(

--- a/apps/vscode-extension/src/services/bundle-installer.ts
+++ b/apps/vscode-extension/src/services/bundle-installer.ts
@@ -484,20 +484,21 @@ export class BundleInstaller {
     if (!warnings || warnings.length === 0) {
       return;
     }
-    // Auto-derive warnings are bundle-author concerns — log only.
-    const userActionable = warnings.filter((w) => !w.includes('auto-derived'));
-    const logOnly = warnings.filter((w) => w.includes('auto-derived'));
 
-    for (const w of logOnly) {
-      this.logger.warn(`MCP installation: ${w}`);
+    const userActionable: string[] = [];
+    const nonActionable: string[] = [];
+    for (const w of warnings) {
+      (w.includes('auto-derived') ? nonActionable : userActionable).push(w);
+    }
+
+    if (nonActionable.length > 0) {
+      this.logger.warn(`MCP installation: ${nonActionable.join(' ')}`);
     }
 
     if (userActionable.length > 0) {
       const detail = userActionable.join(' ');
       this.logger.warn(`MCP installation warnings: ${detail}`);
-      void vscode.window.showWarningMessage(
-        `MCP servers for "${bundleId}" ${detail}`
-      );
+      void vscode.window.showWarningMessage(`MCP servers for "${bundleId}" ${detail}`);
     }
   }
 

--- a/apps/vscode-extension/src/services/bundle-installer.ts
+++ b/apps/vscode-extension/src/services/bundle-installer.ts
@@ -471,6 +471,27 @@ export class BundleInstaller {
     );
   }
 
+  /**
+   * Surface MCP warnings for an otherwise successful install.
+   *
+   * The servers were written, so this is not a failure, but the warnings cover cases
+   * the user still has to act on — most notably a host that cannot prompt for
+   * `${input:id}` values, where the server is present but needs the secret filled in
+   * manually before it will connect.
+   * @param bundleId - Bundle being installed.
+   * @param warnings - Warnings reported by the MCP manager.
+   */
+  private notifyMcpInstallWarnings(bundleId: string, warnings: string[] | undefined): void {
+    if (!warnings || warnings.length === 0) {
+      return;
+    }
+    const detail = warnings.join(' ');
+    this.logger.warn(`MCP installation warnings: ${detail}`);
+    void vscode.window.showWarningMessage(
+      `MCP servers for "${bundleId}" ${detail}`
+    );
+  }
+
   private async installMcpServers(
     bundleId: string,
     bundleVersion: string,
@@ -515,9 +536,7 @@ export class BundleInstaller {
           this.notifyMcpInstallFailure(bundleId, workspaceInstallationResult.errors);
         }
 
-        if (workspaceInstallationResult.warnings && workspaceInstallationResult.warnings.length > 0) {
-          this.logger.warn(`MCP installation warnings: ${workspaceInstallationResult.warnings.join(', ')}`);
-        }
+        this.notifyMcpInstallWarnings(bundleId, workspaceInstallationResult.warnings);
         return;
       }
 
@@ -542,9 +561,7 @@ export class BundleInstaller {
         this.notifyMcpInstallFailure(bundleId, result.errors);
       }
 
-      if (result.warnings && result.warnings.length > 0) {
-        this.logger.warn(`MCP installation warnings: ${result.warnings.join(', ')}`);
-      }
+      this.notifyMcpInstallWarnings(bundleId, result.warnings);
     } catch (error) {
       this.logger.error(`Failed to install MCP servers for bundle ${bundleId}`, error as Error);
       // Don't fail the entire bundle installation if MCP installation fails

--- a/apps/vscode-extension/src/services/mcp-config-service.ts
+++ b/apps/vscode-extension/src/services/mcp-config-service.ts
@@ -345,11 +345,22 @@ export class McpConfigService {
     return merged.length > 0 ? merged : undefined;
   }
 
+  /**
+   * Merge new servers and their input declarations into an existing MCP configuration.
+   * @param existingConfig - Current config read from the host's mcp.json.
+   * @param newServers - Servers to add, already prefixed with their bundle id.
+   * @param options - Install options (conflict handling).
+   * @param newInputs - Input declarations shipped by the bundle manifest.
+   * @param supportsInputs - Whether the target host resolves `${input:id}`. When
+   * false, missing declarations are not auto-derived because the host will never
+   * prompt for them and the entry would only mislead the user.
+   */
   public async mergeServers(
     existingConfig: McpConfiguration,
     newServers: Record<string, McpServerConfig>,
     options: McpInstallOptions,
-    newInputs?: McpInputDefinition[]
+    newInputs?: McpInputDefinition[],
+    supportsInputs = true
   ): Promise<{ config: McpConfiguration; conflicts: string[]; warnings: string[] }> {
     // Spread `existingConfig` first: hosts such as Claude Code keep unrelated state
     // (projects, account/OAuth data, preferences) as sibling top-level keys in the
@@ -360,7 +371,11 @@ export class McpConfigService {
       ...existingConfig,
       servers: { ...existingConfig.servers },
       tasks: existingConfig.tasks ? { ...existingConfig.tasks } : undefined,
-      inputs: this.mergeInputs(existingConfig.inputs, newInputs)
+      // Hosts without input support must not receive bundle declarations: they
+      // would never prompt, so preserve only input state already in the file.
+      inputs: supportsInputs
+        ? this.mergeInputs(existingConfig.inputs, newInputs)
+        : existingConfig.inputs
     };
     const conflicts: string[] = [];
     const warnings: string[] = [];
@@ -378,6 +393,35 @@ export class McpConfigService {
         }
       } else {
         result.servers[serverName] = serverConfig;
+      }
+    }
+
+    // Auto-derive missing input declarations from ${input:id} references in the
+    // newly-installed servers.  The bundle manifest's mcpInputs should always
+    // declare every referenced id, but if it doesn't we synthesise
+    // a minimal promptString entry so the placeholder is resolvable at runtime and
+    // the literal unresolved string is never sent as a header value.
+    // A warning is also emitted so bundle authors know their manifest is incomplete.
+    // Skipped on hosts that do not resolve inputs — the declaration would never be
+    // read and its presence suggests a prompt that will never appear.
+    const referencedInNewServers = supportsInputs
+      ? this.collectInputReferences(newServers)
+      : new Set<string>();
+    const declaredIds = new Set((result.inputs ?? []).map((i) => i.id));
+    const undeclared = [...referencedInNewServers].filter((id) => !declaredIds.has(id));
+
+    if (undeclared.length > 0) {
+      for (const id of undeclared) {
+        warnings.push(
+          `Input "${id}" is referenced by a server config but has no matching declaration in the bundle's mcpInputs. `
+          + `A placeholder declaration has been auto-derived; update the bundle manifest to provide a proper description.`
+        );
+        const synthetic: McpInputDefinition = {
+          id,
+          type: 'promptString',
+          description: `Enter value for "${id}"`
+        };
+        result.inputs = result.inputs ? [...result.inputs, synthetic] : [synthetic];
       }
     }
 

--- a/apps/vscode-extension/src/services/mcp-config-service.ts
+++ b/apps/vscode-extension/src/services/mcp-config-service.ts
@@ -1,6 +1,13 @@
 import type {
   McpConfigScope,
 } from '@ai-primitives-hub/app';
+import {
+  autoDeriveMissingInputs,
+  mergeInputDeclarations,
+} from '@ai-primitives-hub/app';
+import {
+  collectInputReferences,
+} from '@ai-primitives-hub/core';
 import * as fs from 'fs-extra';
 import {
   isRemoteServerConfig,
@@ -323,7 +330,7 @@ export class McpConfigService {
 
   /**
    * Merge new input definitions into existing ones, deduplicating by id.
-   * Existing inputs with the same id are preserved unchanged.
+   * Delegates to the pure domain helper in `@ai-primitives-hub/core`.
    * @param existing - Current inputs array from mcp.json
    * @param incoming - New inputs to add
    */
@@ -331,18 +338,7 @@ export class McpConfigService {
     existing: McpInputDefinition[] | undefined,
     incoming: McpInputDefinition[] | undefined
   ): McpInputDefinition[] | undefined {
-    if (!incoming || incoming.length === 0) {
-      return existing;
-    }
-    const merged = existing ? [...existing] : [];
-    const existingIds = new Set(merged.map((i) => i.id));
-    for (const input of incoming) {
-      if (!existingIds.has(input.id)) {
-        merged.push(input);
-        existingIds.add(input.id);
-      }
-    }
-    return merged.length > 0 ? merged : undefined;
+    return mergeInputDeclarations(existing, incoming);
   }
 
   /**
@@ -397,76 +393,39 @@ export class McpConfigService {
     }
 
     // Auto-derive missing input declarations from ${input:id} references in the
-    // newly-installed servers.  The bundle manifest's mcpInputs should always
-    // declare every referenced id, but if it doesn't we synthesise
-    // a minimal promptString entry so the placeholder is resolvable at runtime and
-    // the literal unresolved string is never sent as a header value.
-    // A warning is also emitted so bundle authors know their manifest is incomplete.
-    // Skipped on hosts that do not resolve inputs — the declaration would never be
-    // read and its presence suggests a prompt that will never appear.
-    const referencedInNewServers = supportsInputs
-      ? this.collectInputReferences(newServers)
-      : new Set<string>();
-    const declaredIds = new Set((result.inputs ?? []).map((i) => i.id));
-    const undeclared = [...referencedInNewServers].filter((id) => !declaredIds.has(id));
-
-    if (undeclared.length > 0) {
-      for (const id of undeclared) {
-        warnings.push(
-          `Input "${id}" is referenced by a server config but has no matching declaration in the bundle's mcpInputs. `
-          + `A placeholder declaration has been auto-derived; update the bundle manifest to provide a proper description.`
-        );
-        const synthetic: McpInputDefinition = {
-          id,
-          type: 'promptString',
-          description: `Enter value for "${id}"`
-        };
-        result.inputs = result.inputs ? [...result.inputs, synthetic] : [synthetic];
-      }
+    // newly-installed servers. Delegates to the pure core helper.
+    // Skipped on hosts that do not resolve inputs.
+    if (supportsInputs) {
+      const { inputs: derivedInputs, warnings: derivedWarnings } =
+        this.autoDeriveMissingInputs(newServers, result.inputs);
+      result.inputs = derivedInputs;
+      warnings.push(...derivedWarnings);
     }
 
     return { config: result, conflicts, warnings };
   }
 
   /**
+   * Auto-derive missing `${input:id}` declarations for newly-installed servers.
+   * Delegates to the pure domain helper in `@ai-primitives-hub/core`.
+   * @param servers - Servers to scan for `${input:id}` references.
+   * @param existingInputs - Inputs already declared (merged manifest + existing file).
+   */
+  public autoDeriveMissingInputs(
+    servers: Record<string, McpServerConfig>,
+    existingInputs: McpInputDefinition[] | undefined
+  ): { inputs: McpInputDefinition[] | undefined; warnings: string[] } {
+    return autoDeriveMissingInputs(servers, existingInputs);
+  }
+
+  /**
    * Collect all `${input:id}` references across the given server configurations.
-   *
-   * Public because the install path needs it to detect servers that cannot work on a
-   * host which does not resolve inputs — the placeholder would be written verbatim and
-   * the server would fail at startup rather than at install time.
+   * Delegates to the pure domain helper in `@ai-primitives-hub/core`.
    * @param servers - Server configurations to scan.
    * @returns The set of referenced input ids.
    */
   public collectInputReferences(servers: Record<string, McpServerConfig>): Set<string> {
-    const inputPattern = /\$\{input:([^}]+)\}/g;
-    const referenced = new Set<string>();
-
-    const scan = (value: string | undefined): void => {
-      if (!value) {
-        return;
-      }
-      let match: RegExpExecArray | null;
-      while ((match = inputPattern.exec(value)) !== null) {
-        referenced.add(match[1]);
-      }
-    };
-
-    for (const serverConfig of Object.values(servers)) {
-      if (isRemoteServerConfig(serverConfig)) {
-        scan(serverConfig.url);
-        if (serverConfig.headers) {
-          Object.values(serverConfig.headers).forEach((v) => scan(v));
-        }
-      } else {
-        scan(serverConfig.command);
-        serverConfig.args?.forEach((v) => scan(v));
-        if (serverConfig.env) {
-          Object.values(serverConfig.env).forEach((v) => scan(v));
-        }
-      }
-    }
-
-    return referenced;
+    return collectInputReferences(servers);
   }
 
   /**
@@ -478,7 +437,7 @@ export class McpConfigService {
     if (!config.inputs || config.inputs.length === 0) {
       return config;
     }
-    const referenced = this.collectInputReferences(config.servers);
+    const referenced = collectInputReferences(config.servers);
     const filteredInputs = config.inputs.filter((input) => referenced.has(input.id));
     return {
       ...config,

--- a/apps/vscode-extension/src/services/mcp-config-service.ts
+++ b/apps/vscode-extension/src/services/mcp-config-service.ts
@@ -12,7 +12,6 @@ import * as fs from 'fs-extra';
 import {
   isRemoteServerConfig,
   McpConfiguration,
-  McpInputDefinition,
   McpInstallOptions,
   McpRemoteServerConfig,
   McpServerConfig,
@@ -20,6 +19,7 @@ import {
   McpStdioServerConfig,
   McpTrackingMetadata,
   McpVariableContext,
+  VSCodeMcpInputDefinition,
 } from '../types/mcp';
 import {
   Logger,
@@ -335,9 +335,9 @@ export class McpConfigService {
    * @param incoming - New inputs to add
    */
   public mergeInputs(
-    existing: McpInputDefinition[] | undefined,
-    incoming: McpInputDefinition[] | undefined
-  ): McpInputDefinition[] | undefined {
+    existing: VSCodeMcpInputDefinition[] | undefined,
+    incoming: VSCodeMcpInputDefinition[] | undefined
+  ): VSCodeMcpInputDefinition[] | undefined {
     return mergeInputDeclarations(existing, incoming);
   }
 
@@ -355,7 +355,7 @@ export class McpConfigService {
     existingConfig: McpConfiguration,
     newServers: Record<string, McpServerConfig>,
     options: McpInstallOptions,
-    newInputs?: McpInputDefinition[],
+    newInputs?: VSCodeMcpInputDefinition[],
     supportsInputs = true
   ): Promise<{ config: McpConfiguration; conflicts: string[]; warnings: string[] }> {
     // Spread `existingConfig` first: hosts such as Claude Code keep unrelated state
@@ -413,8 +413,8 @@ export class McpConfigService {
    */
   public autoDeriveMissingInputs(
     servers: Record<string, McpServerConfig>,
-    existingInputs: McpInputDefinition[] | undefined
-  ): { inputs: McpInputDefinition[] | undefined; warnings: string[] } {
+    existingInputs: VSCodeMcpInputDefinition[] | undefined
+  ): { inputs: VSCodeMcpInputDefinition[] | undefined; warnings: string[] } {
     return autoDeriveMissingInputs(servers, existingInputs);
   }
 

--- a/apps/vscode-extension/src/services/mcp-server-manager.ts
+++ b/apps/vscode-extension/src/services/mcp-server-manager.ts
@@ -47,14 +47,14 @@ export class McpServerManager {
   }
 
   /**
-   * Reject servers that reference `${input:id}` when the host cannot resolve inputs.
+   * Describe servers that reference `${input:id}` when the host cannot resolve inputs.
    *
    * `inputs` and `${input:...}` are a VS Code Copilot feature. Other hosts receive the
-   * placeholder as a literal value, so the install would succeed and the server would
-   * then fail at startup with no indication why. Failing here converts that into an
-   * actionable install-time error.
+   * placeholder as a literal value, so the server needs manual configuration after
+   * installation. The caller surfaces this message as a warning while still writing
+   * the server configuration.
    *
-   * Returns `null` when the install may proceed, or a message describing what to do.
+   * Returns `null` when no warning is needed, or a message describing what to do.
    * @param servers - Servers about to be installed.
    * @param supportsInputs - Whether the resolved host/scope resolves inputs.
    */
@@ -70,9 +70,8 @@ export class McpServerManager {
       return null;
     }
     const ids = [...referenced].toSorted().join(', ');
-    return `This bundle's MCP servers require the input value(s) ${ids}, which this IDE `
-      + 'cannot prompt for. Install the bundle in VS Code, or set the value(s) directly in '
-      + 'the MCP configuration file after installing.';
+    return `Require the input value(s) ${ids}. `
+      + 'Set the value(s) directly in the MCP configuration file after installing.';
   }
 
   /**
@@ -501,21 +500,21 @@ export class McpServerManager {
       const location = McpConfigLocator.getMcpConfigLocation(
         options.scope === 'workspace' ? 'repository' : 'user'
       );
-      const unsupportedInputs = this.describeUnsupportedInputs(
-        serversToInstall,
-        location?.supportsInputs ?? false
-      );
+      // See the note in installServersToWorkspace: hosts that cannot resolve
+      // `${input:id}` still get the server written, with a warning instead of a hard
+      // failure, so the user can supply the value manually.
+      const supportsInputs = location?.supportsInputs ?? false;
+      const unsupportedInputs = this.describeUnsupportedInputs(serversToInstall, supportsInputs);
       if (unsupportedInputs) {
-        result.errors?.push(unsupportedInputs);
-        result.success = false;
-        return result;
+        result.warnings?.push(unsupportedInputs);
       }
 
       const mergeResult = await this.configService.mergeServers(
         existingConfig,
         serversToInstall,
         options,
-        inputsManifest
+        inputsManifest,
+        supportsInputs
       );
 
       result.warnings?.push(...mergeResult.warnings);
@@ -674,24 +673,53 @@ export class McpServerManager {
         return result;
       }
 
-      const unsupportedInputs = this.describeUnsupportedInputs(
-        serversToInstall,
-        this.getWorkspaceMcpLocation(workspaceRoot).supportsInputs
-      );
+      // Hosts that cannot resolve `${input:id}` (e.g. Kiro) still get the server
+      // written, because a present-but-unconfigured server is more useful than no
+      // server at all — the user can fill the value in directly. We surface a warning
+      // so they know the manual step is required.
+      const supportsInputs = this.getWorkspaceMcpLocation(workspaceRoot).supportsInputs;
+      const unsupportedInputs = this.describeUnsupportedInputs(serversToInstall, supportsInputs);
       if (unsupportedInputs) {
-        result.errors?.push(unsupportedInputs);
-        result.success = false;
-        return result;
+        result.warnings?.push(unsupportedInputs);
       }
 
       // Merge servers into existing config
       // Spread `existingConfig` first so unrelated top-level state in the host's file
       // survives the merge. See the equivalent note in McpConfigService.mergeServers.
+      // Do not add bundle input declarations on hosts that cannot resolve them.
+      // Preserve any existing declarations as part of the host config round-trip.
+      const mergedInputs = supportsInputs
+        ? this.configService.mergeInputs(existingConfig.inputs, inputsManifest)
+        : existingConfig.inputs;
+
+      // Auto-derive missing input declarations from ${input:id} references in the
+      // newly-installed servers, mirroring the same fix in McpConfigService.mergeServers.
+      // Skipped when the host does not resolve inputs: the declaration would be dead
+      // weight in the file and can mislead the user into thinking a prompt will appear.
+      let finalInputs = mergedInputs;
+      if (supportsInputs) {
+        const referencedInNew = this.configService.collectInputReferences(serversToInstall);
+        const declaredIds = new Set((mergedInputs ?? []).map((i: { id: string }) => i.id));
+        const undeclared = [...referencedInNew].filter((id) => !declaredIds.has(id));
+        for (const id of undeclared) {
+          this.logger.warn(
+            `Input "${id}" is referenced by a server config but has no matching declaration in the bundle's mcpInputs. `
+            + `A placeholder declaration has been auto-derived; update the bundle manifest to provide a proper description.`
+          );
+          const synthetic = {
+            id,
+            type: 'promptString' as const,
+            description: `Enter value for "${id}"`
+          };
+          finalInputs = finalInputs ? [...finalInputs, synthetic] : [synthetic];
+        }
+      }
+
       const mergedConfig: McpConfiguration = {
         ...existingConfig,
         servers: { ...existingConfig.servers, ...serversToInstall },
         tasks: existingConfig.tasks,
-        inputs: this.configService.mergeInputs(existingConfig.inputs, inputsManifest)
+        inputs: finalInputs
       };
 
       // Write config and tracking

--- a/apps/vscode-extension/src/services/mcp-server-manager.ts
+++ b/apps/vscode-extension/src/services/mcp-server-manager.ts
@@ -70,7 +70,7 @@ export class McpServerManager {
       return null;
     }
     const ids = [...referenced].toSorted().join(', ');
-    return `Require the input value(s) ${ids}. `
+    return `require the input value(s) ${ids}. `
       + 'Set the value(s) directly in the MCP configuration file after installing.';
   }
 
@@ -693,26 +693,18 @@ export class McpServerManager {
         : existingConfig.inputs;
 
       // Auto-derive missing input declarations from ${input:id} references in the
-      // newly-installed servers, mirroring the same fix in McpConfigService.mergeServers.
+      // newly-installed servers, using the shared helper in McpConfigService.
       // Skipped when the host does not resolve inputs: the declaration would be dead
       // weight in the file and can mislead the user into thinking a prompt will appear.
       let finalInputs = mergedInputs;
       if (supportsInputs) {
-        const referencedInNew = this.configService.collectInputReferences(serversToInstall);
-        const declaredIds = new Set((mergedInputs ?? []).map((i: { id: string }) => i.id));
-        const undeclared = [...referencedInNew].filter((id) => !declaredIds.has(id));
-        for (const id of undeclared) {
-          this.logger.warn(
-            `Input "${id}" is referenced by a server config but has no matching declaration in the bundle's mcpInputs. `
-            + `A placeholder declaration has been auto-derived; update the bundle manifest to provide a proper description.`
-          );
-          const synthetic = {
-            id,
-            type: 'promptString' as const,
-            description: `Enter value for "${id}"`
-          };
-          finalInputs = finalInputs ? [...finalInputs, synthetic] : [synthetic];
+        const { inputs: derivedInputs, warnings: derivedWarnings } =
+          this.configService.autoDeriveMissingInputs(serversToInstall, mergedInputs);
+        finalInputs = derivedInputs;
+        for (const w of derivedWarnings) {
+          this.logger.warn(w);
         }
+        result.warnings?.push(...derivedWarnings);
       }
 
       const mergedConfig: McpConfiguration = {

--- a/apps/vscode-extension/src/services/mcp-server-manager.ts
+++ b/apps/vscode-extension/src/services/mcp-server-manager.ts
@@ -2,7 +2,6 @@ import * as path from 'node:path';
 import * as fs from 'fs-extra';
 import {
   McpConfiguration,
-  McpInputDefinition,
   McpInstallOptions,
   McpInstallResult,
   McpServerConfig,
@@ -10,6 +9,7 @@ import {
   McpTrackingMetadata,
   McpUninstallResult,
   McpWorkspaceInstallOptions,
+  VSCodeMcpInputDefinition,
 } from '../types/mcp';
 import {
   detectHostApp,
@@ -450,7 +450,7 @@ export class McpServerManager {
     bundlePath: string,
     serversManifest: McpServersManifest,
     options: McpInstallOptions,
-    inputsManifest?: McpInputDefinition[]
+    inputsManifest?: VSCodeMcpInputDefinition[]
   ): Promise<McpInstallResult> {
     const result: McpInstallResult = {
       success: false,
@@ -605,7 +605,7 @@ export class McpServerManager {
     workspaceRoot: string,
     serversManifest: McpServersManifest,
     options: McpWorkspaceInstallOptions,
-    inputsManifest?: McpInputDefinition[]
+    inputsManifest?: VSCodeMcpInputDefinition[]
   ): Promise<McpInstallResult> {
     const result: McpInstallResult = {
       success: false,

--- a/apps/vscode-extension/src/types/mcp.ts
+++ b/apps/vscode-extension/src/types/mcp.ts
@@ -82,13 +82,13 @@ export interface McpTaskDefinition {
   description?: string;
 }
 
-export interface McpInputDefinition {
+export interface VSCodeMcpInputDefinition {
   id: string;
   type: 'promptString' | 'pickString' | 'command';
   description?: string;
   password?: boolean;
   default?: string;
-  options?: string[];
+  options?: (string | { value: string; label?: string })[];
 }
 
 /**
@@ -101,7 +101,7 @@ export interface McpRawConfig {
   readonly servers?: Record<string, McpServerConfig>;
   readonly mcpServers?: Record<string, McpServerConfig>;
   readonly tasks?: Record<string, McpTaskDefinition>;
-  readonly inputs?: McpInputDefinition[];
+  readonly inputs?: VSCodeMcpInputDefinition[];
   readonly [key: string]: unknown;
 }
 
@@ -117,7 +117,7 @@ export interface McpRawConfig {
 export interface McpConfiguration {
   servers: Record<string, McpServerConfig>;
   tasks?: Record<string, McpTaskDefinition>;
-  inputs?: McpInputDefinition[];
+  inputs?: VSCodeMcpInputDefinition[];
   [key: string]: unknown;
 }
 

--- a/apps/vscode-extension/src/types/registry.ts
+++ b/apps/vscode-extension/src/types/registry.ts
@@ -2,8 +2,8 @@
  * Core type definitions for the AI Primitives Hub system
  */
 import {
-  McpInputDefinition,
   McpServersManifest,
+  VSCodeMcpInputDefinition,
 } from './mcp';
 
 /**
@@ -336,5 +336,5 @@ export interface DeploymentManifest {
     type?: 'prompt' | 'instructions' | 'chatmode' | 'agent' | 'skill'; // GitHub Copilot file type
   }[];
   mcpServers?: McpServersManifest;
-  mcpInputs?: McpInputDefinition[];
+  mcpInputs?: VSCodeMcpInputDefinition[];
 }

--- a/apps/vscode-extension/test/services/mcp-config-service.inputs.test.ts
+++ b/apps/vscode-extension/test/services/mcp-config-service.inputs.test.ts
@@ -13,7 +13,7 @@ import {
 } from '../../src/services/mcp-config-service';
 import {
   McpConfiguration,
-  McpInputDefinition,
+  VSCodeMcpInputDefinition,
 } from '../../src/types/mcp';
 
 suite('McpConfigService - Input Merging', () => {
@@ -53,13 +53,13 @@ suite('McpConfigService - Input Merging', () => {
     });
 
     test('should return existing unchanged when incoming is empty', () => {
-      const existing: McpInputDefinition[] = [{ id: 'token', type: 'promptString' }];
+      const existing: VSCodeMcpInputDefinition[] = [{ id: 'token', type: 'promptString' }];
       const result = configService.mergeInputs(existing, []);
       assert.deepStrictEqual(result, existing);
     });
 
     test('should add new inputs when existing is undefined', () => {
-      const incoming: McpInputDefinition[] = [
+      const incoming: VSCodeMcpInputDefinition[] = [
         { id: 'ocToken', type: 'promptString', description: 'OpenShift token', password: true }
       ];
       const result = configService.mergeInputs(undefined, incoming);
@@ -67,10 +67,10 @@ suite('McpConfigService - Input Merging', () => {
     });
 
     test('should add new inputs that do not conflict with existing ones', () => {
-      const existing: McpInputDefinition[] = [
+      const existing: VSCodeMcpInputDefinition[] = [
         { id: 'existingToken', type: 'promptString' }
       ];
-      const incoming: McpInputDefinition[] = [
+      const incoming: VSCodeMcpInputDefinition[] = [
         { id: 'newToken', type: 'promptString', password: true }
       ];
 
@@ -82,10 +82,10 @@ suite('McpConfigService - Input Merging', () => {
     });
 
     test('should deduplicate inputs by id, preserving the existing definition', () => {
-      const existing: McpInputDefinition[] = [
+      const existing: VSCodeMcpInputDefinition[] = [
         { id: 'sharedToken', type: 'promptString', description: 'Original description' }
       ];
-      const incoming: McpInputDefinition[] = [
+      const incoming: VSCodeMcpInputDefinition[] = [
         { id: 'sharedToken', type: 'promptString', description: 'New description' }
       ];
 
@@ -96,11 +96,11 @@ suite('McpConfigService - Input Merging', () => {
     });
 
     test('should merge multiple inputs handling duplicates and new ones together', () => {
-      const existing: McpInputDefinition[] = [
+      const existing: VSCodeMcpInputDefinition[] = [
         { id: 'bbUser', type: 'promptString' },
         { id: 'bbPassword', type: 'promptString', password: true }
       ];
-      const incoming: McpInputDefinition[] = [
+      const incoming: VSCodeMcpInputDefinition[] = [
         { id: 'bbUser', type: 'promptString', description: 'Should be ignored (duplicate)' },
         { id: 'ocToken', type: 'promptString', password: true }
       ];
@@ -196,7 +196,7 @@ suite('McpConfigService - Input Merging', () => {
         inputs: [{ id: 'existingInput', type: 'promptString' }]
       };
 
-      const newInputs: McpInputDefinition[] = [
+      const newInputs: VSCodeMcpInputDefinition[] = [
         { id: 'ocToken', type: 'promptString', password: true }
       ];
 
@@ -230,7 +230,7 @@ suite('McpConfigService - Input Merging', () => {
       });
       sandbox.stub(McpConfigLocator, 'ensureConfigDirectory').resolves();
 
-      const inputs: McpInputDefinition[] = [
+      const inputs: VSCodeMcpInputDefinition[] = [
         { id: 'bbUser', type: 'promptString', description: 'Bitbucket username' },
         { id: 'bbPassword', type: 'promptString', password: true }
       ];

--- a/apps/vscode-extension/test/services/mcp-server-manager.scopes.test.ts
+++ b/apps/vscode-extension/test/services/mcp-server-manager.scopes.test.ts
@@ -6,8 +6,8 @@
  *   rather than silently retargeting the user's home config
  * - the .git/info/exclude pattern must use forward slashes and the host's real
  *   filename, not a hardcoded `mcp.json`
- * - a bundle whose servers reference `${input:id}` must be refused on hosts that
- *   cannot resolve inputs, instead of installing and failing at server startup
+ * - a bundle whose servers reference `${input:id}` is installed with a warning on
+ *   hosts that cannot resolve inputs, so the user can configure the value manually
  */
 
 import * as assert from 'node:assert';
@@ -149,17 +149,29 @@ suite('McpServerManager — host and scope behaviour', () => {
   });
 
   suite('inputs on hosts that cannot resolve them', () => {
-    test('Kiro: a server referencing ${input:...} is refused', async () => {
+    test('Kiro: a server referencing ${input:...} installs with a warning', async () => {
       await setHost('Kiro', 'kiro');
 
       const result = await new McpServerManager().installServersToWorkspace(
-        'bundle-a', '1.0.0', tmpRoot, inputReferencingManifest, { commitMode: 'commit' }
+        'bundle-a',
+        '1.0.0',
+        tmpRoot,
+        inputReferencingManifest,
+        { commitMode: 'commit' },
+        [{ id: 'api-key', type: 'promptString', description: 'API key' }]
       );
 
-      assert.strictEqual(result.success, false,
-        'installing an input-dependent server on Kiro must fail at install time');
-      assert.match(result.errors?.join(' ') ?? '', /api-key/,
-        'the error should name the input that cannot be resolved');
+      assert.strictEqual(result.success, true,
+        `the server should still be written so the user can supply the value manually, errors: ${result.errors?.join(', ')}`);
+      assert.match(result.warnings?.join(' ') ?? '', /api-key/,
+        'a warning should name the input the host cannot prompt for');
+
+      const written = await fsExtra.readJson(
+        path.join(tmpRoot, '.kiro', 'settings', 'mcp.json')
+      ) as Record<string, unknown>;
+      assert.ok(written.mcpServers, 'the server entry should be present in the Kiro file');
+      assert.strictEqual(written.inputs, undefined,
+        'no input declaration should be synthesised for a host that never resolves inputs');
     });
 
     test('Kiro: a server with no input references still installs', async () => {

--- a/apps/vscode-extension/test/services/mcp-server-manager.scopes.test.ts
+++ b/apps/vscode-extension/test/services/mcp-server-manager.scopes.test.ts
@@ -15,6 +15,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import * as fsExtra from 'fs-extra';
+import * as sinon from 'sinon';
 import {
   McpServerManager,
 } from '../../src/services/mcp-server-manager';
@@ -187,6 +188,49 @@ suite('McpServerManager — host and scope behaviour', () => {
         path.join(tmpRoot, '.kiro', 'settings', 'mcp.json')
       ) as Record<string, unknown>;
       assert.ok(written.mcpServers, 'Kiro file should use the mcpServers key');
+    });
+  });
+
+  suite('installServers (user scope) on hosts that cannot resolve inputs', () => {
+    test('Kiro user scope: input-referencing server installs with a warning', async () => {
+      await setHost('Kiro', 'kiro');
+
+      // Stub McpConfigLocator for user-scope resolution to point at our temp dir
+      const { McpConfigLocator } = await import('../../src/utils/mcp-config-locator');
+      const mockConfigPath = path.join(tmpRoot, 'mcp.json');
+      const mockTrackingPath = path.join(tmpRoot, 'mcp-tracking.json');
+      const localSandbox = sinon.createSandbox();
+      localSandbox.stub(McpConfigLocator, 'getMcpConfigLocation').returns({
+        configPath: mockConfigPath,
+        trackingPath: mockTrackingPath,
+        exists: false,
+        serversKey: 'mcpServers',
+        supportsInputs: false
+      });
+      localSandbox.stub(McpConfigLocator, 'ensureConfigDirectory').resolves();
+
+      try {
+        const result = await new McpServerManager().installServers(
+          'bundle-user',
+          '1.0.0',
+          tmpRoot,
+          inputReferencingManifest,
+          { scope: 'user', overwrite: false, skipOnConflict: false },
+          [{ id: 'api-key', type: 'promptString', description: 'API key' }]
+        );
+
+        assert.strictEqual(result.success, true,
+          `user-scope install should succeed with a warning, errors: ${result.errors?.join(', ')}`);
+        assert.match(result.warnings?.join(' ') ?? '', /api-key/,
+          'a warning should name the input the host cannot prompt for');
+
+        const written = JSON.parse(await fs.promises.readFile(mockConfigPath, 'utf8')) as Record<string, unknown>;
+        assert.ok(written.mcpServers, 'the server entry should be present');
+        assert.strictEqual(written.inputs, undefined,
+          'no input declaration should be synthesised for a host that never resolves inputs');
+      } finally {
+        localSandbox.restore();
+      }
     });
   });
 });

--- a/packages/app/src/index.ts
+++ b/packages/app/src/index.ts
@@ -16,6 +16,7 @@ export * from './collection';
 export * from './context-detection';
 export * from './discovery';
 export * from './install';
+export * from './mcp';
 export * from './writers';
 export * from './stores';
 export * from './update';

--- a/packages/app/src/mcp/index.ts
+++ b/packages/app/src/mcp/index.ts
@@ -1,0 +1,5 @@
+/**
+ * MCP use-case orchestration — barrel export.
+ * @module mcp
+ */
+export * from './input-merge';

--- a/packages/app/src/mcp/input-merge.ts
+++ b/packages/app/src/mcp/input-merge.ts
@@ -2,15 +2,18 @@
  * MCP input merge and auto-derive use-case logic.
  *
  * These functions orchestrate input declaration handling during MCP server
- * installation. They depend only on `@ai-primitives-hub/core` types and the
- * `collectInputReferences` scanner — no IO, no framework dependency.
+ * installation. They use the generic `McpInputDeclaration` from core and
+ * the `collectInputReferences` scanner — no IO, no framework dependency.
+ *
+ * The full IDE-specific input type (`McpInputDefinition`) lives in the
+ * delivery layer; these functions work with any object that has an `id` field.
  *
  * Pure: no IO, no side effects.
  * @module mcp/input-merge
  */
 
 import type {
-  McpInputDefinition,
+  McpInputDeclaration,
   McpServerInputView,
 } from '@ai-primitives-hub/core';
 import {
@@ -23,17 +26,18 @@ import {
  * Existing declarations win: if an id already exists, the incoming entry is
  * ignored so that a bundle author's re-install does not reset a user-edited
  * description or password flag.
- *
  * @param existing - Current inputs array from the host's config file.
  * @param incoming - New declarations from the bundle manifest.
  * @returns Merged array, or `undefined` when the result would be empty.
  */
-export function mergeInputDeclarations(
-  existing: McpInputDefinition[] | undefined,
-  incoming: McpInputDefinition[] | undefined
-): McpInputDefinition[] | undefined {
-  if (!incoming || incoming.length === 0) return existing;
-  const merged = existing ? [...existing] : [];
+export function mergeInputDeclarations<T extends McpInputDeclaration>(
+  existing: T[] | undefined,
+  incoming: T[] | undefined
+): T[] | undefined {
+  if (!incoming || incoming.length === 0) {
+    return existing;
+  }
+  const merged: T[] = existing ? [...existing] : [];
   const existingIds = new Set(merged.map((i) => i.id));
   for (const input of incoming) {
     if (!existingIds.has(input.id)) {
@@ -52,15 +56,14 @@ export function mergeInputDeclarations(
  * doesn't this function synthesises a minimal `promptString` entry so the
  * placeholder is resolvable at runtime and the literal unresolved string is
  * never sent as a header value.
- *
  * @param servers - Newly-installed servers to scan for references.
  * @param existingInputs - Declarations already present (merged manifest + file).
  * @returns Updated inputs array and warnings to surface to the user.
  */
-export function autoDeriveMissingInputs(
+export function autoDeriveMissingInputs<T extends McpInputDeclaration>(
   servers: Record<string, McpServerInputView>,
-  existingInputs: McpInputDefinition[] | undefined
-): { inputs: McpInputDefinition[] | undefined; warnings: string[] } {
+  existingInputs: T[] | undefined
+): { inputs: T[] | undefined; warnings: string[] } {
   const warnings: string[] = [];
   const referenced = collectInputReferences(servers);
   const declaredIds = new Set((existingInputs ?? []).map((i) => i.id));
@@ -70,7 +73,7 @@ export function autoDeriveMissingInputs(
     return { inputs: existingInputs, warnings };
   }
 
-  const inputs: McpInputDefinition[] = existingInputs ? [...existingInputs] : [];
+  const inputs: T[] = existingInputs ? [...existingInputs] : [];
   for (const id of undeclared) {
     warnings.push(
       `Input "${id}" is referenced by a server config but has no matching declaration in the bundle's mcpInputs. `
@@ -80,7 +83,7 @@ export function autoDeriveMissingInputs(
       id,
       type: 'promptString',
       description: `Enter value for "${id}"`
-    });
+    } as T);
   }
   return { inputs, warnings };
 }

--- a/packages/app/src/mcp/input-merge.ts
+++ b/packages/app/src/mcp/input-merge.ts
@@ -1,0 +1,86 @@
+/**
+ * MCP input merge and auto-derive use-case logic.
+ *
+ * These functions orchestrate input declaration handling during MCP server
+ * installation. They depend only on `@ai-primitives-hub/core` types and the
+ * `collectInputReferences` scanner — no IO, no framework dependency.
+ *
+ * Pure: no IO, no side effects.
+ * @module mcp/input-merge
+ */
+
+import type {
+  McpInputDefinition,
+  McpServerInputView,
+} from '@ai-primitives-hub/core';
+import {
+  collectInputReferences,
+} from '@ai-primitives-hub/core';
+
+/**
+ * Merge new input declarations into an existing set, deduplicating by id.
+ *
+ * Existing declarations win: if an id already exists, the incoming entry is
+ * ignored so that a bundle author's re-install does not reset a user-edited
+ * description or password flag.
+ *
+ * @param existing - Current inputs array from the host's config file.
+ * @param incoming - New declarations from the bundle manifest.
+ * @returns Merged array, or `undefined` when the result would be empty.
+ */
+export function mergeInputDeclarations(
+  existing: McpInputDefinition[] | undefined,
+  incoming: McpInputDefinition[] | undefined
+): McpInputDefinition[] | undefined {
+  if (!incoming || incoming.length === 0) return existing;
+  const merged = existing ? [...existing] : [];
+  const existingIds = new Set(merged.map((i) => i.id));
+  for (const input of incoming) {
+    if (!existingIds.has(input.id)) {
+      merged.push(input);
+      existingIds.add(input.id);
+    }
+  }
+  return merged.length > 0 ? merged : undefined;
+}
+
+/**
+ * Auto-derive synthetic input declarations for `${input:id}` references that
+ * have no matching declaration in the bundle's `mcpInputs`.
+ *
+ * The bundle manifest should always declare every referenced id, but if it
+ * doesn't this function synthesises a minimal `promptString` entry so the
+ * placeholder is resolvable at runtime and the literal unresolved string is
+ * never sent as a header value.
+ *
+ * @param servers - Newly-installed servers to scan for references.
+ * @param existingInputs - Declarations already present (merged manifest + file).
+ * @returns Updated inputs array and warnings to surface to the user.
+ */
+export function autoDeriveMissingInputs(
+  servers: Record<string, McpServerInputView>,
+  existingInputs: McpInputDefinition[] | undefined
+): { inputs: McpInputDefinition[] | undefined; warnings: string[] } {
+  const warnings: string[] = [];
+  const referenced = collectInputReferences(servers);
+  const declaredIds = new Set((existingInputs ?? []).map((i) => i.id));
+  const undeclared = [...referenced].filter((id) => !declaredIds.has(id));
+
+  if (undeclared.length === 0) {
+    return { inputs: existingInputs, warnings };
+  }
+
+  const inputs: McpInputDefinition[] = existingInputs ? [...existingInputs] : [];
+  for (const id of undeclared) {
+    warnings.push(
+      `Input "${id}" is referenced by a server config but has no matching declaration in the bundle's mcpInputs. `
+      + `A placeholder declaration has been auto-derived; update the bundle manifest to provide a proper description.`
+    );
+    inputs.push({
+      id,
+      type: 'promptString',
+      description: `Enter value for "${id}"`
+    });
+  }
+  return { inputs, warnings };
+}

--- a/packages/core/src/domain/index.ts
+++ b/packages/core/src/domain/index.ts
@@ -28,3 +28,4 @@ export * from './hub/types';
 export * from './hub/validate';
 export * from './primitive/types';
 export * from './skill/validate';
+export * from './mcp';

--- a/packages/core/src/domain/mcp/index.ts
+++ b/packages/core/src/domain/mcp/index.ts
@@ -1,0 +1,5 @@
+/**
+ * MCP (Model Context Protocol) domain types and pure helpers.
+ * @module domain/mcp
+ */
+export * from './inputs';

--- a/packages/core/src/domain/mcp/inputs.ts
+++ b/packages/core/src/domain/mcp/inputs.ts
@@ -1,0 +1,83 @@
+/**
+ * MCP input declaration types and the reference scanner.
+ *
+ * `${input:id}` is a VS Code Copilot feature: an `inputs` array at the root
+ * of an MCP config file declares the values the IDE should prompt for, and
+ * each server config can reference them via `${input:id}` placeholders.
+ *
+ * This module holds only the domain types and the pure scanner — use-case
+ * orchestration (merge, auto-derive) lives in `@ai-primitives-hub/app`.
+ *
+ * Pure: no IO, no side effects, no framework imports.
+ * @module domain/mcp/inputs
+ */
+
+/**
+ * A single input declaration as written in the `inputs` array of an MCP
+ * config file.  Mirrors the VS Code Copilot `inputs` schema.
+ */
+export interface McpInputDefinition {
+  /** Unique identifier referenced by `${input:<id>}` placeholders. */
+  id: string;
+  /** How the value is collected: `promptString` is the common case. */
+  type: 'promptString' | 'pickString' | 'command';
+  /** Human-readable label shown in the IDE prompt. */
+  description?: string;
+  /** Whether the value should be masked in the UI. */
+  password?: boolean;
+  /** Pre-filled default value. */
+  default?: string;
+  /** Choices for `pickString` type. */
+  options?: string[];
+}
+
+/**
+ * A minimal server config shape sufficient for input-reference scanning.
+ * The full per-IDE server shapes live in the extension layer; this interface
+ * only captures the fields that may carry `${input:id}` tokens.
+ */
+export interface McpServerInputView {
+  /** stdio server command string */
+  command?: string;
+  /** stdio server arguments */
+  args?: string[];
+  /** stdio server environment variables */
+  env?: Record<string, string>;
+  /** remote server URL */
+  url?: string;
+  /** remote server request headers (common source of `${input:id}` tokens) */
+  headers?: Record<string, string>;
+}
+
+/**
+ * Collect all `${input:id}` references from a map of server configurations.
+ *
+ * Scans command, args, env values, URL, and header values for every server.
+ * Pure: no IO.
+ * @param servers - Server config map (prefixed server name → config).
+ * @returns Set of referenced input ids (without the `${input:…}` delimiters).
+ */
+export function collectInputReferences(
+  servers: Record<string, McpServerInputView>
+): Set<string> {
+  const inputPattern = /\$\{input:([^}]+)\}/g;
+  const referenced = new Set<string>();
+
+  const scan = (value: string | undefined): void => {
+    if (!value) return;
+    let match: RegExpExecArray | null;
+    while ((match = inputPattern.exec(value)) !== null) {
+      referenced.add(match[1]);
+    }
+  };
+
+  for (const config of Object.values(servers)) {
+    scan(config.url);
+    scan(config.command);
+    config.args?.forEach(scan);
+    if (config.env) Object.values(config.env).forEach(scan);
+    if (config.headers) Object.values(config.headers).forEach(scan);
+  }
+
+  return referenced;
+}

--- a/packages/core/src/domain/mcp/inputs.ts
+++ b/packages/core/src/domain/mcp/inputs.ts
@@ -1,34 +1,34 @@
 /**
- * MCP input declaration types and the reference scanner.
+ * MCP input reference scanning — pure domain logic.
  *
- * `${input:id}` is a VS Code Copilot feature: an `inputs` array at the root
- * of an MCP config file declares the values the IDE should prompt for, and
- * each server config can reference them via `${input:id}` placeholders.
+ * `${input:id}` is a host-specific feature (currently VS Code Copilot): an
+ * `inputs` array at the root of an MCP config file declares the values the
+ * IDE should prompt for, and each server config can reference them via
+ * `${input:id}` placeholders.
  *
- * This module holds only the domain types and the pure scanner — use-case
- * orchestration (merge, auto-derive) lives in `@ai-primitives-hub/app`.
+ * This module provides only the generic scanner and minimal types needed by
+ * use-case orchestration in `@ai-primitives-hub/app`. The full
+ * IDE-specific input definition interface (`McpInputDefinition`) lives in
+ * the delivery layer (`apps/vscode-extension/src/types/mcp.ts`).
  *
  * Pure: no IO, no side effects, no framework imports.
  * @module domain/mcp/inputs
  */
 
 /**
- * A single input declaration as written in the `inputs` array of an MCP
- * config file.  Mirrors the VS Code Copilot `inputs` schema.
+ * Minimal shape for an input declaration — just enough for merge/derive
+ * logic to identify and deduplicate entries by `id`.
+ *
+ * The full schema (password, options, default, etc.) is delivery-layer
+ * specific and defined in the extension's type file.
  */
-export interface McpInputDefinition {
+export interface McpInputDeclaration {
   /** Unique identifier referenced by `${input:<id>}` placeholders. */
   id: string;
-  /** How the value is collected: `promptString` is the common case. */
-  type: 'promptString' | 'pickString' | 'command';
+  /** Discriminator for the prompt type. */
+  type: string;
   /** Human-readable label shown in the IDE prompt. */
   description?: string;
-  /** Whether the value should be masked in the UI. */
-  password?: boolean;
-  /** Pre-filled default value. */
-  default?: string;
-  /** Choices for `pickString` type. */
-  options?: string[];
 }
 
 /**
@@ -64,7 +64,9 @@ export function collectInputReferences(
   const referenced = new Set<string>();
 
   const scan = (value: string | undefined): void => {
-    if (!value) return;
+    if (!value) {
+      return;
+    }
     let match: RegExpExecArray | null;
     while ((match = inputPattern.exec(value)) !== null) {
       referenced.add(match[1]);
@@ -74,9 +76,19 @@ export function collectInputReferences(
   for (const config of Object.values(servers)) {
     scan(config.url);
     scan(config.command);
-    config.args?.forEach(scan);
-    if (config.env) Object.values(config.env).forEach(scan);
-    if (config.headers) Object.values(config.headers).forEach(scan);
+    config.args?.forEach((v) => {
+      scan(v);
+    });
+    if (config.env) {
+      Object.values(config.env).forEach((v) => {
+        scan(v);
+      });
+    }
+    if (config.headers) {
+      Object.values(config.headers).forEach((v) => {
+        scan(v);
+      });
+    }
   }
 
   return referenced;


### PR DESCRIPTION


Previously, hosts like Kiro that do not support ${input:id} prompts would hard-fail the MCP install. Now the server is written as-is (no synthetic input declarations) and a visible warning notification tells the user to configure the value manually.

VS Code retains the existing behavior: missing input declarations are auto-derived so the IDE can prompt for them.

Changes:
- McpConfigService.mergeServers: accept supportsInputs param, skip input merge and auto-derive on unsupported hosts
- McpServerManager: convert hard failure to warning, pass host capability downstream
- BundleInstaller: surface MCP warnings via showWarningMessage
- Test: updated Kiro scope test to expect success + warning + no inputs

## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Mark relevant items with an [x] -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔧 Configuration/build changes

## Related Issues

<!-- Link to related issues using #issue_number -->

Closes #
Fixes #
Relates to #

## Changes Made

<!-- Provide a detailed list of changes -->

- 
- 
- 

## Testing

<!-- Describe the testing you've done -->

### Test Coverage

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing completed
- [ ] All existing tests pass

### Manual Testing Steps

1. 
2. 
3. 

### Tested On

- [ ] macOS
- [ ] Windows
- [ ] Linux

- [ ] VS Code Stable
- [ ] VS Code Insiders

## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->

## Checklist

<!-- Mark completed items with an [x] -->

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Documentation

<!-- Describe any documentation changes needed -->

- [ ] README.md updated
- [ ] JSDoc comments added/updated
- [ ] No documentation changes needed

## Additional Notes

<!-- Add any additional notes for reviewers -->

## Reviewer Guidelines

<!-- For reviewers: What should they focus on? -->

Please pay special attention to:

- 
- 

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**
