### PR TITLE
feat(extension): expose and change install scope

### DIFF
--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -351,34 +351,34 @@ export class PromptRegistryExtension {
       vscode.commands.registerCommand('promptRegistry.listInstalled', () => this.bundleCommands!.listInstalled()),
 
       // Bundle Scope Management Commands
-      vscode.commands.registerCommand('promptRegistry.moveToRepositoryCommit', (arg?) => {
+      vscode.commands.registerCommand('promptRegistry.moveToRepositoryCommit', async (arg?) => {
         const bundleId = this.extractBundleId(arg);
         if (bundleId && this.bundleScopeCommands) {
-          void this.bundleScopeCommands.moveToRepository(bundleId, 'commit');
+          await this.bundleScopeCommands.moveToRepository(bundleId, 'commit');
         }
       }),
-      vscode.commands.registerCommand('promptRegistry.moveToRepositoryLocalOnly', (arg?) => {
+      vscode.commands.registerCommand('promptRegistry.moveToRepositoryLocalOnly', async (arg?) => {
         const bundleId = this.extractBundleId(arg);
         if (bundleId && this.bundleScopeCommands) {
-          void this.bundleScopeCommands.moveToRepository(bundleId, 'local-only');
+          await this.bundleScopeCommands.moveToRepository(bundleId, 'local-only');
         }
       }),
-      vscode.commands.registerCommand('promptRegistry.moveToUser', (arg?) => {
+      vscode.commands.registerCommand('promptRegistry.moveToUser', async (arg?) => {
         const bundleId = this.extractBundleId(arg);
         if (bundleId && this.bundleScopeCommands) {
-          void this.bundleScopeCommands.moveToUser(bundleId);
+          await this.bundleScopeCommands.moveToUser(bundleId);
         }
       }),
-      vscode.commands.registerCommand('promptRegistry.switchToLocalOnly', (arg?) => {
+      vscode.commands.registerCommand('promptRegistry.switchToLocalOnly', async (arg?) => {
         const bundleId = this.extractBundleId(arg);
         if (bundleId && this.bundleScopeCommands) {
-          void this.bundleScopeCommands.switchCommitMode(bundleId, 'local-only');
+          await this.bundleScopeCommands.switchCommitMode(bundleId, 'local-only');
         }
       }),
-      vscode.commands.registerCommand('promptRegistry.switchToCommit', (arg?) => {
+      vscode.commands.registerCommand('promptRegistry.switchToCommit', async (arg?) => {
         const bundleId = this.extractBundleId(arg);
         if (bundleId && this.bundleScopeCommands) {
-          void this.bundleScopeCommands.switchCommitMode(bundleId, 'commit');
+          await this.bundleScopeCommands.switchCommitMode(bundleId, 'commit');
         }
       }),
 

--- a/apps/vscode-extension/src/ui/marketplace-view-provider.ts
+++ b/apps/vscode-extension/src/ui/marketplace-view-provider.ts
@@ -40,6 +40,9 @@ import {
   Logger,
 } from '../utils/logger';
 import {
+  formatInstallationScope,
+} from '../utils/scope-selection-ui';
+import {
   VersionManager,
 } from '../utils/version-manager';
 
@@ -48,7 +51,7 @@ import {
  */
 interface WebviewMessage {
   type: 'ready' | 'refresh' | 'install' | 'update' | 'uninstall' | 'openDetails' | 'openPromptFile' | 'installVersion'
-    | 'getVersions' | 'toggleAutoUpdate' | 'openSourceRepository' | 'completeSetup' | 'openExternalLink';
+    | 'getVersions' | 'toggleAutoUpdate' | 'openSourceRepository' | 'completeSetup' | 'openExternalLink' | 'changeScope';
   bundleId?: string;
   installPath?: string;
   filePath?: string;
@@ -380,6 +383,11 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
           ...bundle,
           installed: !!installed,
           installedVersion: installed?.version,
+          installedScope: installed?.scope,
+          installedCommitMode: installed?.commitMode,
+          installedScopeLabel: installed
+            ? this.formatInstalledScope(installed)
+            : undefined,
           buttonState,
           isCurated,
           hubName,
@@ -618,6 +626,12 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
         }
         break;
       }
+      case 'changeScope': {
+        if (message.bundleId) {
+          await this.handleChangeScope(message.bundleId);
+        }
+        break;
+      }
       default: {
         // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- value is safely stringifiable at runtime
         this.logger.warn(`Unknown message type: ${message.type}`);
@@ -744,11 +758,65 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
 
   /**
    * Show scope selection dialog and return result
+   * @param bundleName - Optional name used in the picker title.
+   * @param current - Optional current installation to mark in the picker.
    * @returns Scope selection result or undefined if cancelled
    */
-  private async promptForScope(): Promise<import('../utils/scope-selection-ui').ScopeSelectionResult | undefined> {
+  private async promptForScope(
+    bundleName?: string,
+    current?: Pick<InstalledBundle, 'scope' | 'commitMode'>
+  ): Promise<import('../utils/scope-selection-ui').ScopeSelectionResult | undefined> {
     const { showScopeSelectionDialog } = await import('../utils/scope-selection-ui');
-    return showScopeSelectionDialog();
+    return showScopeSelectionDialog(bundleName, current);
+  }
+
+  private formatInstalledScope(installed: Pick<InstalledBundle, 'scope' | 'commitMode'>): string {
+    return formatInstallationScope(installed);
+  }
+
+  /**
+   * Move an installed bundle to another scope, or switch its repository mode.
+   * Existing scope commands provide transactional migration and rollback.
+   * @param bundleId - Marketplace bundle ID.
+   * @returns Whether a scope change command was run.
+   */
+  private async handleChangeScope(bundleId: string): Promise<boolean> {
+    const { bundle, installed } = await this.findInstalledBundleByMarketplaceId(bundleId);
+    if (!installed) {
+      vscode.window.showErrorMessage(`Bundle "${bundle.name}" is not installed.`);
+      return false;
+    }
+
+    const selected = await this.promptForScope(bundle.name, installed);
+    if (!selected) {
+      return false;
+    }
+
+    const currentMode = installed.commitMode ?? 'commit';
+    if (selected.scope === installed.scope
+      && (selected.scope === 'user' || selected.commitMode === currentMode)) {
+      vscode.window.showInformationMessage(
+        `"${bundle.name}" is already installed in ${this.formatInstalledScope(installed)}.`
+      );
+      return false;
+    }
+
+    let command: string;
+    if (selected.scope === 'user') {
+      command = 'promptRegistry.moveToUser';
+    } else if (installed.scope === 'user') {
+      command = selected.commitMode === 'local-only'
+        ? 'promptRegistry.moveToRepositoryLocalOnly'
+        : 'promptRegistry.moveToRepositoryCommit';
+    } else {
+      command = selected.commitMode === 'local-only'
+        ? 'promptRegistry.switchToLocalOnly'
+        : 'promptRegistry.switchToCommit';
+    }
+
+    await vscode.commands.executeCommand(command, installed.bundleId);
+    await this.loadBundles();
+    return true;
   }
 
   /**
@@ -1024,7 +1092,9 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
     let html = fs.readFileSync(htmlPath.fsPath, 'utf8');
 
     // Generate dynamic sections
-    const installedBadge = isInstalled ? '<span class="badge">✓ Installed</span>' : '';
+    const installedBadge = isInstalled
+      ? `<span class="badge">✓ Installed: ${this.escapeHtml(this.formatInstalledScope(installed))}</span>`
+      : '';
 
     const autoUpdateSection = isInstalled
       ? `
@@ -1078,6 +1148,13 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
 
     const installedInfoRows = isInstalled
       ? `
+            <div class="info-row">
+                <div class="info-label">Installation Scope:</div>
+                <div class="info-value">
+                    ${this.escapeHtml(this.formatInstalledScope(installed))}
+                    <button class="scope-change-button" data-action="changeScope">Change</button>
+                </div>
+            </div>
             <div class="info-row">
                 <div class="info-label">Installed At:</div>
                 <div class="info-value">${new Date(installed.installedAt).toLocaleString()}</div>
@@ -1409,6 +1486,15 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
               if (installed) {
                 const newStatus = await this.registryManager.autoUpdateService?.isAutoUpdateEnabled(installed.bundleId) || false;
                 panel.webview.postMessage({ type: 'autoUpdateStatusChanged', enabled: newStatus });
+              }
+
+              break;
+            }
+            case 'changeScope': {
+              const changed = await this.handleChangeScope(bundle.id);
+              if (changed) {
+                panel.dispose();
+                await this.openBundleDetails(bundle.id);
               }
 
               break;

--- a/apps/vscode-extension/src/ui/webview/bundle-details/bundle-details.css
+++ b/apps/vscode-extension/src/ui/webview/bundle-details/bundle-details.css
@@ -167,6 +167,20 @@ h1 {
     color: var(--vscode-foreground);
 }
 
+.scope-change-button {
+    margin-left: 10px;
+    padding: 3px 8px;
+    color: var(--vscode-button-secondaryForeground);
+    background: var(--vscode-button-secondaryBackground);
+    border: none;
+    border-radius: 3px;
+    cursor: pointer;
+}
+
+.scope-change-button:hover {
+    background: var(--vscode-button-secondaryHoverBackground);
+}
+
 code {
     background: var(--vscode-textCodeBlock-background);
     padding: 2px 6px;

--- a/apps/vscode-extension/src/ui/webview/bundle-details/bundle-details.js
+++ b/apps/vscode-extension/src/ui/webview/bundle-details/bundle-details.js
@@ -44,6 +44,13 @@
     });
   };
 
+  const changeScope = () => {
+    vscode.postMessage({
+      type: 'changeScope',
+      bundleId: bundleId
+    });
+  };
+
   // Listen for status updates from extension
   window.addEventListener('message', (event) => {
     var message = event.data;
@@ -94,6 +101,10 @@
         }
         case 'toggleAutoUpdate': {
           toggleAutoUpdate();
+          break;
+        }
+        case 'changeScope': {
+          changeScope();
           break;
         }
       }

--- a/apps/vscode-extension/src/ui/webview/marketplace/marketplace.js
+++ b/apps/vscode-extension/src/ui/webview/marketplace/marketplace.js
@@ -405,7 +405,10 @@
 
     marketplace.innerHTML = filteredBundles.map((bundle) => {
       return '<div class="bundle-card ' + (bundle.installed ? 'installed' : '') + '" data-bundle-id="' + bundle.id + '" data-action="openDetails">'
-        + (bundle.installed && bundle.autoUpdateEnabled ? '<div class="installed-badge">🔄 Auto-Update</div>' : (bundle.installed ? '<div class="installed-badge">✓ Installed</div>' : ''))
+        + (bundle.installed
+          ? '<div class="installed-badge">✓ ' + (bundle.installedScopeLabel || 'Installed')
+          + (bundle.autoUpdateEnabled ? ' • Auto-update' : '') + '</div>'
+          : '')
 
         + '<div class="bundle-header">'
         + '<div class="bundle-title">' + bundle.name + '</div>'
@@ -432,6 +435,9 @@
 
         + '<div class="bundle-actions" data-stop-propagation="true">'
         + renderBundleButtons(bundle)
+        + (bundle.installed
+          ? '<button class="btn btn-secondary" data-action="changeScope" data-bundle-id="' + bundle.id + '">Scope</button>'
+          : '')
         + '<button class="btn btn-secondary" data-action="openDetails" data-bundle-id="' + bundle.id + '">Details</button>'
         + '<button class="btn btn-link" data-action="openSourceRepo" data-bundle-id="' + bundle.id + '" title="Open Source Repository">'
         + '<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">'
@@ -558,6 +564,10 @@
     vscode.postMessage({ type: 'openSourceRepository', bundleId: bundleId });
   };
 
+  const changeScope = (bundleId) => {
+    vscode.postMessage({ type: 'changeScope', bundleId: bundleId });
+  };
+
   const completeSetup = () => {
     vscode.postMessage({ type: 'completeSetup' });
   };
@@ -657,6 +667,13 @@
           if (bundleId) {
             e.stopPropagation();
             openSourceRepo(bundleId);
+          }
+          break;
+        }
+        case 'changeScope': {
+          if (bundleId) {
+            e.stopPropagation();
+            changeScope(bundleId);
           }
           break;
         }

--- a/apps/vscode-extension/src/utils/scope-selection-ui.ts
+++ b/apps/vscode-extension/src/utils/scope-selection-ui.ts
@@ -29,6 +29,25 @@ export interface ScopeSelectionResult {
   commitMode?: RepositoryCommitMode;
 }
 
+/** Installation information used to mark the current location in the picker. */
+export interface CurrentScopeSelection {
+  scope: InstallationScope;
+  commitMode?: RepositoryCommitMode;
+}
+
+/**
+ * Build the short scope label shown in bundle cards and details.
+ * @param installation - Installed scope and optional repository mode.
+ */
+export function formatInstallationScope(installation: CurrentScopeSelection): string {
+  if (installation.scope === 'user') {
+    return 'User profile';
+  }
+  return installation.commitMode === 'local-only'
+    ? 'Repository (local only)'
+    : 'Repository (committed)';
+}
+
 /**
  * Internal option structure for QuickPick items
  */
@@ -75,8 +94,12 @@ export function getRepositoryRootFolder(): string {
 /**
  * Creates the QuickPick items for scope selection
  * @param hasWorkspace
+ * @param current - Optional current installation to identify in the picker.
  */
-export function createScopeQuickPickItems(hasWorkspace: boolean): ScopeQuickPickItem[] {
+export function createScopeQuickPickItems(
+  hasWorkspace: boolean,
+  current?: CurrentScopeSelection
+): ScopeQuickPickItem[] {
   const repoRoot = getRepositoryRootFolder();
   const options: ScopeSelectionOption[] = [
     {
@@ -103,16 +126,20 @@ export function createScopeQuickPickItems(hasWorkspace: boolean): ScopeQuickPick
     }
   ];
 
-  return options.map((opt) => ({
-    label: opt.label,
-    description: opt.description,
-    detail: opt.detail,
-    picked: opt.scope === 'repository' && opt.commitMode === 'commit' && hasWorkspace,
-    _scope: opt.scope,
-    _commitMode: opt.commitMode,
-    _disabled: opt.disabled,
-    _originalDetail: opt.detail
-  }));
+  return options.map((opt) => {
+    const isCurrent = current?.scope === opt.scope
+      && (opt.scope === 'user' || (current.commitMode ?? 'commit') === opt.commitMode);
+    return {
+      label: `${opt.label}${isCurrent ? ' $(check)' : ''}`,
+      description: `${opt.description}${isCurrent ? ' • Current installation' : ''}`,
+      detail: opt.detail,
+      picked: isCurrent || (!current && opt.scope === 'repository' && opt.commitMode === 'commit' && hasWorkspace),
+      _scope: opt.scope,
+      _commitMode: opt.commitMode,
+      _disabled: opt.disabled,
+      _originalDetail: opt.detail
+    };
+  });
 }
 
 /**
@@ -126,6 +153,7 @@ export function createScopeQuickPickItems(hasWorkspace: boolean): ScopeQuickPick
  * Repository options are disabled when no workspace is open.
  * When a disabled option is clicked, the dialog remains open and shows an inline warning.
  * @param bundleName - Optional bundle name to display in the dialog title
+ * @param current - Optional current installation when changing scope.
  * @returns The selected scope and commit mode, or undefined if cancelled
  * @example
  * ```typescript
@@ -138,12 +166,15 @@ export function createScopeQuickPickItems(hasWorkspace: boolean): ScopeQuickPick
  * }
  * ```
  */
-export async function showScopeSelectionDialog(bundleName?: string): Promise<ScopeSelectionResult | undefined> {
+export async function showScopeSelectionDialog(
+  bundleName?: string,
+  current?: CurrentScopeSelection
+): Promise<ScopeSelectionResult | undefined> {
   const hasWorkspace = hasOpenWorkspace();
-  const quickPickItems = createScopeQuickPickItems(hasWorkspace);
+  const quickPickItems = createScopeQuickPickItems(hasWorkspace, current);
 
   const title = bundleName
-    ? `Install ${bundleName} - Select Scope`
+    ? `${current ? 'Change installation scope for' : 'Install'} ${bundleName}`
     : 'Select Installation Scope';
 
   // Use custom QuickPick to handle disabled option selection

--- a/apps/vscode-extension/test/ui/marketplace-view-provider.scopeSelection.test.ts
+++ b/apps/vscode-extension/test/ui/marketplace-view-provider.scopeSelection.test.ts
@@ -76,6 +76,32 @@ suite('MarketplaceViewProvider - Scope Selection Bug', () => {
       assert.strictEqual(enabledAndPicked.length, 0,
         'No enabled option should be pre-selected when workspace is closed');
     });
+
+    test('should identify the current installation and pre-select it', () => {
+      const items = scopeSelectionUI.createScopeQuickPickItems(true, {
+        scope: 'repository',
+        commitMode: 'local-only'
+      });
+      const current = items.find((item) => item.picked);
+
+      assert.strictEqual(current?._scope, 'repository');
+      assert.strictEqual(current?._commitMode, 'local-only');
+      assert.match(current?.description || '', /Current installation/);
+    });
+  });
+
+  suite('Installed scope labels', () => {
+    test('should clearly label user and repository installation modes', () => {
+      assert.strictEqual(scopeSelectionUI.formatInstallationScope({ scope: 'user' }), 'User profile');
+      assert.strictEqual(
+        scopeSelectionUI.formatInstallationScope({ scope: 'repository', commitMode: 'commit' }),
+        'Repository (committed)'
+      );
+      assert.strictEqual(
+        scopeSelectionUI.formatInstallationScope({ scope: 'repository', commitMode: 'local-only' }),
+        'Repository (local only)'
+      );
+    });
   });
 
   suite('Scope option labels and descriptions', () => {


### PR DESCRIPTION
Shows the current installation scope and lets users safely move collections between user, repository committed, and repository local-only scopes.

Validation: scope and migration tests, compilation, lint, and production build passed.