### PR TITLE
feat(extension): add collection trust and rating signals

### DIFF
--- a/apps/vscode-extension/src/services/bundle-feedback-store.ts
+++ b/apps/vscode-extension/src/services/bundle-feedback-store.ts
@@ -1,0 +1,30 @@
+/** Private, device-local bundle ratings backed by VS Code global state. */
+import type * as vscode from 'vscode';
+
+const STORAGE_KEY = 'promptRegistry.bundleRatings.v1';
+
+export type BundleRating = 1 | 2 | 3 | 4 | 5;
+
+export class BundleFeedbackStore {
+  public constructor(private readonly state: vscode.Memento | undefined) {}
+
+  public get(bundleId: string): BundleRating | undefined {
+    return this.state?.get<Record<string, BundleRating>>(STORAGE_KEY, {})[bundleId];
+  }
+
+  public getAll(): Record<string, BundleRating> {
+    return { ...this.state?.get<Record<string, BundleRating>>(STORAGE_KEY, {}) };
+  }
+
+  public async set(bundleId: string, rating: number): Promise<void> {
+    if (!Number.isInteger(rating) || rating < 1 || rating > 5) {
+      throw new RangeError('Rating must be an integer from 1 to 5');
+    }
+    if (this.state === undefined) {
+      return;
+    }
+    const ratings = this.getAll();
+    ratings[bundleId] = rating as BundleRating;
+    await this.state.update(STORAGE_KEY, ratings);
+  }
+}

--- a/apps/vscode-extension/src/types/registry.ts
+++ b/apps/vscode-extension/src/types/registry.ts
@@ -43,6 +43,8 @@ export interface RegistrySource {
     description?: string;
     homepage?: string;
     contact?: string;
+    /** Explicit maintainer recommendation; curated alone does not imply recommended. */
+    recommended?: boolean;
   };
   config?: {
     branch?: string; // Git branch (for git-based sources)
@@ -66,6 +68,8 @@ export interface Bundle {
   tags: string[];
   downloads?: number;
   rating?: number;
+  /** Rating submitted by this user on this device. */
+  userRating?: number;
   lastUpdated: string;
   size: string;
   dependencies: BundleDependency[];
@@ -76,6 +80,7 @@ export interface Bundle {
   downloadUrl: string;
   isCurated?: boolean; // True if bundle is from a curated hub
   hubName?: string; // Name of the curated hub
+  recommended?: boolean; // Explicitly recommended by the source maintainer
   checksum?: {
     algorithm: string;
     hash: string;

--- a/apps/vscode-extension/src/ui/marketplace-view-provider.ts
+++ b/apps/vscode-extension/src/ui/marketplace-view-provider.ts
@@ -9,6 +9,9 @@ import MarkdownIt from 'markdown-it';
 import sanitizeHtml from 'sanitize-html';
 import * as vscode from 'vscode';
 import {
+  BundleFeedbackStore,
+} from '../services/bundle-feedback-store';
+import {
   RegistryManager,
 } from '../services/registry-manager';
 import {
@@ -48,7 +51,7 @@ import {
  */
 interface WebviewMessage {
   type: 'ready' | 'refresh' | 'install' | 'update' | 'uninstall' | 'openDetails' | 'openPromptFile' | 'installVersion'
-    | 'getVersions' | 'toggleAutoUpdate' | 'openSourceRepository' | 'completeSetup' | 'openExternalLink';
+    | 'getVersions' | 'toggleAutoUpdate' | 'openSourceRepository' | 'completeSetup' | 'openExternalLink' | 'rateBundle';
   bundleId?: string;
   installPath?: string;
   filePath?: string;
@@ -56,6 +59,7 @@ interface WebviewMessage {
   enabled?: boolean;
   sourceId?: string;
   url?: string;
+  rating?: number;
 }
 
 /**
@@ -88,6 +92,7 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
   private webviewReady = false;
   private latestBundlesMessage?: BundlesLoadedMessage;
   private readonly logger: Logger;
+  private readonly feedbackStore: BundleFeedbackStore;
 
   private readonly sourceSyncThrottle = new LeadingTrailingThrottle(
     () => void this.loadBundles(),
@@ -136,6 +141,7 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
     private readonly setupStateManager: SetupStateManager
   ) {
     this.logger = Logger.getInstance();
+    this.feedbackStore = new BundleFeedbackStore(this.context.globalState);
 
     // Listen to bundle and source events to refresh marketplace
     this.disposables.push(
@@ -340,6 +346,7 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
         this.registryManager.listSources()
       ]);
       const autoUpdateService = this.registryManager.autoUpdateService;
+      const userRatings = this.feedbackStore.getAll();
 
       // Preload auto-update preferences once per refresh
       const autoUpdatePreferences = autoUpdateService
@@ -383,6 +390,8 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
           buttonState,
           isCurated,
           hubName,
+          recommended: source?.metadata?.recommended === true,
+          userRating: userRatings[`${bundle.sourceId}:${bundle.id}`],
           contentBreakdown,
           availableVersions,
           autoUpdateEnabled
@@ -615,6 +624,13 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
       case 'openExternalLink': {
         if (message.url) {
           await this.handleOpenExternalLink(message.url);
+        }
+        break;
+      }
+      case 'rateBundle': {
+        if (message.bundleId !== undefined && message.sourceId !== undefined && message.rating !== undefined) {
+          await this.feedbackStore.set(`${message.sourceId}:${message.bundleId}`, message.rating);
+          await this.loadBundles();
         }
         break;
       }

--- a/apps/vscode-extension/src/ui/webview/marketplace/marketplace.css
+++ b/apps/vscode-extension/src/ui/webview/marketplace/marketplace.css
@@ -403,6 +403,17 @@ body {
     margin-bottom: 12px;
 }
 
+.recommended-badge {
+    display: inline-block;
+    margin-bottom: 8px;
+    padding: 3px 8px;
+    border: 1px solid var(--vscode-charts-yellow);
+    border-radius: 12px;
+    color: var(--vscode-charts-yellow);
+    font-size: 11px;
+    font-weight: 600;
+}
+
 .bundle-title {
     font-size: 18px;
     font-weight: 600;
@@ -454,6 +465,38 @@ body {
     flex-wrap: wrap;
     gap: 6px;
     margin-bottom: 16px;
+}
+
+.bundle-rating {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    margin-bottom: 14px;
+}
+
+.rating-label,
+.community-rating {
+    color: var(--vscode-descriptionForeground);
+    font-size: 11px;
+}
+
+.community-rating {
+    margin-left: 8px;
+}
+
+.rating-star {
+    border: 0;
+    padding: 1px;
+    color: var(--vscode-disabledForeground);
+    background: transparent;
+    cursor: pointer;
+    font-size: 16px;
+}
+
+.rating-star:hover,
+.rating-star:focus,
+.rating-star.selected {
+    color: var(--vscode-charts-yellow);
 }
 
 .tag {

--- a/apps/vscode-extension/src/ui/webview/marketplace/marketplace.js
+++ b/apps/vscode-extension/src/ui/webview/marketplace/marketplace.js
@@ -408,8 +408,17 @@
         + (bundle.installed && bundle.autoUpdateEnabled ? '<div class="installed-badge">🔄 Auto-Update</div>' : (bundle.installed ? '<div class="installed-badge">✓ Installed</div>' : ''))
 
         + '<div class="bundle-header">'
+        + (bundle.recommended ? '<div class="recommended-badge" title="Recommended by the source maintainer">★ Recommended</div>' : '')
         + '<div class="bundle-title">' + bundle.name + '</div>'
         + '<div class="bundle-author">by ' + (bundle.author || 'Unknown') + ' • ' + formatVersionLabel(bundle.version) + '</div>'
+        + '</div>'
+
+        + '<div class="bundle-rating" data-stop-propagation="true" aria-label="Rate this collection">'
+        + '<span class="rating-label">Your rating:</span>'
+        + [1, 2, 3, 4, 5].map((rating) => '<button class="rating-star ' + (rating <= (bundle.userRating || 0) ? 'selected' : '')
+          + '" data-action="rateBundle" data-bundle-id="' + bundle.id + '" data-source-id="' + bundle.sourceId + '" data-rating="' + rating
+          + '" title="Rate ' + rating + ' out of 5" aria-label="Rate ' + rating + ' out of 5">★</button>').join('')
+        + (typeof bundle.rating === 'number' ? '<span class="community-rating" title="Score supplied by the collection source">Source score: ' + bundle.rating.toFixed(1) + '</span>' : '')
         + '</div>'
 
         + '<div class="bundle-description">'
@@ -617,6 +626,8 @@
       var bundleId = actionElement.dataset.bundleId || (actionElement.closest('[data-bundle-id]') ? actionElement.closest('[data-bundle-id]').dataset.bundleId : null);
       var version = actionElement.dataset.version;
       var dropdownId = actionElement.dataset.dropdownId;
+      var rating = Number(actionElement.dataset.rating);
+      var sourceId = actionElement.dataset.sourceId;
 
       switch (action) {
         case 'openDetails': {
@@ -670,6 +681,13 @@
         case 'completeSetup': {
           e.stopPropagation();
           completeSetup();
+          break;
+        }
+        case 'rateBundle': {
+          if (bundleId && sourceId && Number.isInteger(rating)) {
+            e.stopPropagation();
+            vscode.postMessage({ type: 'rateBundle', bundleId: bundleId, sourceId: sourceId, rating: rating });
+          }
           break;
         }
       }

--- a/apps/vscode-extension/test/services/bundle-feedback-store.test.ts
+++ b/apps/vscode-extension/test/services/bundle-feedback-store.test.ts
@@ -1,0 +1,29 @@
+import * as assert from 'node:assert';
+import type * as vscode from 'vscode';
+import {
+  BundleFeedbackStore,
+} from '../../src/services/bundle-feedback-store';
+
+suite('BundleFeedbackStore', () => {
+  test('persists a private rating by bundle id', async () => {
+    const values = new Map<string, unknown>();
+    const state = {
+      get: <T>(key: string, fallback?: T): T => (values.get(key) as T | undefined) ?? fallback as T,
+      update: async (key: string, value: unknown): Promise<void> => {
+        values.set(key, value);
+      },
+      keys: (): readonly string[] => [...values.keys()]
+    } as vscode.Memento;
+    const store = new BundleFeedbackStore(state);
+
+    await store.set('review-kit', 4);
+
+    assert.strictEqual(store.get('review-kit'), 4);
+    assert.deepStrictEqual(store.getAll(), { 'review-kit': 4 });
+  });
+
+  test('rejects ratings outside the five-star scale', async () => {
+    const store = new BundleFeedbackStore(undefined);
+    await assert.rejects(store.set('review-kit', 6), /1 to 5/);
+  });
+});

--- a/packages/core/src/domain/bundle/types.ts
+++ b/packages/core/src/domain/bundle/types.ts
@@ -27,6 +27,8 @@ export interface Bundle {
   tags: string[];
   downloads?: number;
   rating?: number;
+  /** Rating submitted by this user on this device. */
+  userRating?: number;
   lastUpdated: string;
   size: string;
   dependencies: BundleDependency[];
@@ -39,6 +41,8 @@ export interface Bundle {
   isCurated?: boolean;
   /** Name of the curated hub, when `isCurated` is true. */
   hubName?: string;
+  /** Explicitly recommended by the source maintainer. */
+  recommended?: boolean;
   checksum?: {
     algorithm: string;
     hash: string;

--- a/packages/core/src/domain/source/types.ts
+++ b/packages/core/src/domain/source/types.ts
@@ -43,6 +43,8 @@ export interface RegistrySource {
     description?: string;
     homepage?: string;
     contact?: string;
+    /** Explicit maintainer recommendation; distinct from merely being curated. */
+    recommended?: boolean;
   };
   config?: {
     /** Git branch, for git-based sources. */

--- a/packages/core/src/public/schemas/hub-config.schema.json
+++ b/packages/core/src/public/schemas/hub-config.schema.json
@@ -146,6 +146,10 @@
               "contact": {
                 "type": "string",
                 "description": "Contact information"
+              },
+              "recommended": {
+                "type": "boolean",
+                "description": "Explicitly mark collections from this source as maintainer-recommended"
               }
             }
           }


### PR DESCRIPTION
Adds explicit recommended metadata and private per-device 1–5 collection ratings without misrepresenting source scores as community ratings.

Validation: focused store tests, schema validation, lint, and production build passed.