### PR TITLE
feat(cli): export Microsoft 365 declarative agent MVP

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,7 @@ Marketplace and registry for Copilot prompt bundles in VS Code.
   - [Scaffolding](contributor-guide/architecture/scaffolding.md)
   - [Validation](contributor-guide/architecture/validation.md)
 - **[Core Flows](contributor-guide/core-flows.md)** — Key system flows
+- **[Microsoft 365 Copilot MVP](contributor-guide/microsoft-365-copilot-mvp.md)** — Declarative-agent export design and limits
 - **[Testing](contributor-guide/testing.md)** — Testing strategy
 - **[Testing SSH Remote](contributor-guide/testing-ssh-remote.md)** — SSH testing
 - **[Validation](contributor-guide/validation.md)** — Local validation commands

--- a/docs/contributor-guide/microsoft-365-copilot-mvp.md
+++ b/docs/contributor-guide/microsoft-365-copilot-mvp.md
@@ -1,0 +1,56 @@
+# Microsoft 365 Copilot support MVP
+
+Microsoft 365 Copilot does not consume portable `SKILL.md` folders directly. Its closest packaging model is a declarative agent: a Microsoft 365 app ZIP containing an app manifest, a declarative-agent manifest, and two icons.
+
+## What the MVP exports
+
+```mermaid
+flowchart LR
+    C[Collection YAML] --> I[Instruction and agent files]
+    C --> P[Described prompts]
+    I --> D[declarativeAgent.json]
+    P --> D
+    D --> Z[Microsoft 365 app ZIP]
+    A[manifest.json and icons] --> Z
+```
+
+The `bundle export-m365` command:
+
+- combines `instruction` and `agent` files into the agent instructions, enforcing Microsoft's 8,000-character limit;
+- turns described prompt items into up to 12 conversation starters;
+- generates Microsoft 365 app manifest 1.29 and declarative-agent manifest 1.8;
+- validates the required 192×192 color and 32×32 outline PNG dimensions;
+- creates a deterministic ZIP suitable for validation and tenant testing.
+
+Example:
+
+```bash
+ai-primitives-hub bundle export-m365 \
+  --collection-file collections/review.collection.yml \
+  --app-id 00000000-0000-4000-8000-000000000000 \
+  --developer-name Contoso \
+  --website-url https://example.com \
+  --privacy-url https://example.com/privacy \
+  --terms-url https://example.com/terms \
+  --color-icon assets/color.png \
+  --outline-icon assets/outline.png
+```
+
+## Deliberate limitations
+
+Portable skills are not silently converted. Microsoft 365 uses the word *skill* for built-in capabilities and custom MCP/API actions, which require platform manifests, HTTPS endpoints, authentication, consent, and security review. MCP declarations therefore need a later, explicit plugin-export phase. The generated package must still be validated with Microsoft 365 Agents Toolkit and tested in a licensed tenant before deployment.
+
+## Next phases
+
+1. Add an MCP plugin-manifest generator with authentication mapping.
+2. Add Microsoft schema validation in CI.
+3. Add knowledge-source mapping and tenant capability checks.
+4. Add publishing through Microsoft 365 Agents Toolkit after an explicit user confirmation step.
+
+## Primary references
+
+- [Declarative agent schema 1.8](https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/declarative-agent-manifest-1.8)
+- [Microsoft 365 app model for agents](https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/agents-are-apps)
+- [Microsoft 365 app manifest schema](https://learn.microsoft.com/en-us/microsoft-365/extensibility/schema/?view=m365-app-1.29)
+- [Add skills to a declarative agent](https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/build-declarative-agents-add-skills)
+- [Build a plugin from an MCP server](https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/build-mcp-plugins)

--- a/packages/cli/src/commands/bundle-export-m365.ts
+++ b/packages/cli/src/commands/bundle-export-m365.ts
@@ -1,0 +1,230 @@
+/** Export an AI Primitives Hub collection as a Microsoft 365 declarative agent. */
+import {
+  createReadStream,
+  createWriteStream,
+  readFileSync,
+} from 'node:fs';
+import * as path from 'node:path';
+import {
+  readCollection,
+} from '@ai-primitives-hub/app';
+import type {
+  Collection,
+} from '@ai-primitives-hub/core';
+import {
+  normalizeRepoRelativePath,
+} from '@ai-primitives-hub/core';
+import archiver from 'archiver';
+import {
+  Command,
+  type Context,
+  formatOutput,
+  Option,
+  type OutputFormat,
+  RegistryError,
+} from '../framework';
+import {
+  resolveCollectionFile,
+} from './bundle-manifest';
+
+const APP_SCHEMA = 'https://developer.microsoft.com/json-schemas/teams/v1.29/MicrosoftTeams.schema.json';
+const AGENT_SCHEMA = 'https://developer.microsoft.com/json-schemas/copilot/declarative-agent/v1.8/schema.json';
+const FIXED_DATE = new Date('1980-01-01T00:00:00.000Z');
+
+interface ExportOptions {
+  appId: string;
+  version: string;
+  developerName: string;
+  websiteUrl: string;
+  privacyUrl: string;
+  termsUrl: string;
+}
+
+interface ExportedManifests {
+  appManifest: Record<string, unknown>;
+  agentManifest: Record<string, unknown>;
+  warnings: string[];
+}
+
+const truncate = (value: string, limit: number): string => value.slice(0, limit);
+
+/**
+ * Convert compatible collection fields into Microsoft 365 manifest objects.
+ * @param collection Source collection.
+ * @param repoRoot Repository root containing item paths.
+ * @param options Required publisher and package identifiers.
+ * @returns Manifest objects and explicit conversion warnings.
+ */
+export function createM365Manifests(
+  collection: Collection,
+  repoRoot: string,
+  options: ExportOptions
+): ExportedManifests {
+  const warnings: string[] = [];
+  const instructionItems = collection.items.filter((item) => ['instruction', 'agent'].includes(item.kind));
+  const instructions = instructionItems
+    .map((item) => readFileSync(path.join(repoRoot, normalizeRepoRelativePath(item.path)), 'utf8').trim())
+    .filter((content) => content.length > 0)
+    .join('\n\n---\n\n') || collection.description || `Help users with ${collection.name}.`;
+  if (instructions.length > 8000) {
+    throw new RegistryError({
+      code: 'BUNDLE.INVALID_MANIFEST',
+      message: `Microsoft 365 instructions exceed the 8,000 character limit (${String(instructions.length)})`,
+      hint: 'Shorten instruction and agent files or split this collection into multiple agents.'
+    });
+  }
+
+  const promptItems = collection.items.filter((item) => item.kind === 'prompt' && item.description !== undefined);
+  const starters = promptItems.slice(0, 12).map((item) => ({
+    title: truncate(item.name ?? path.basename(item.path, path.extname(item.path)), 50),
+    text: truncate(item.description as string, 128)
+  }));
+  if (starters.length < 3) {
+    warnings.push('Store readiness: add descriptions to at least three prompt items for conversation starters.');
+  }
+  if (collection.items.some((item) => item.kind === 'skill')) {
+    warnings.push('SKILL.md items are not embedded: Microsoft 365 skills require capabilities or MCP/API actions.');
+  }
+  if (collection.items.some((item) => ['mcp', 'plugin'].includes(item.kind))) {
+    warnings.push('MCP/plugin items require a Microsoft 365 plugin manifest and authentication review; they were not exported.');
+  }
+
+  const name = truncate(collection.name, 100);
+  const description = truncate(collection.description ?? `Microsoft 365 agent for ${collection.name}`, 1000);
+  const agentManifest = {
+    $schema: AGENT_SCHEMA,
+    version: 'v1.8',
+    name,
+    description,
+    instructions,
+    ...(starters.length === 0 ? {} : { conversation_starters: starters })
+  };
+  const appManifest = {
+    $schema: APP_SCHEMA,
+    manifestVersion: '1.29',
+    version: options.version,
+    id: options.appId,
+    developer: {
+      name: options.developerName,
+      websiteUrl: options.websiteUrl,
+      privacyUrl: options.privacyUrl,
+      termsOfUseUrl: options.termsUrl
+    },
+    icons: { color: 'color.png', outline: 'outline.png' },
+    name: { short: truncate(name, 30), full: name },
+    description: { short: truncate(description, 80), full: description },
+    accentColor: '#FFFFFF',
+    copilotAgents: {
+      declarativeAgents: [{ id: 'collectionAgent', file: 'declarativeAgent.json' }]
+    },
+    validDomains: []
+  };
+  return { appManifest, agentManifest, warnings };
+}
+
+function assertPngDimensions(filePath: string, width: number, height: number): void {
+  const bytes = readFileSync(filePath);
+  const pngSignature = '89504e470d0a1a0a';
+  const valid = bytes.length >= 24
+    && bytes.subarray(0, 8).toString('hex') === pngSignature
+    && bytes.readUInt32BE(16) === width
+    && bytes.readUInt32BE(20) === height;
+  if (!valid) {
+    throw new RegistryError({
+      code: 'BUNDLE.INVALID_MANIFEST',
+      message: `${filePath} must be a ${String(width)}x${String(height)} PNG`
+    });
+  }
+}
+
+function writePackage(
+  zipPath: string,
+  files: readonly { name: string; path?: string; content?: string }[]
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const output = createWriteStream(zipPath);
+    const archive = archiver('zip', { zlib: { level: 9 } });
+    output.on('close', resolve);
+    output.on('error', reject);
+    archive.on('error', reject);
+    archive.pipe(output);
+    for (const file of files.toSorted((a, b) => a.name.localeCompare(b.name))) {
+      if (file.path === undefined) {
+        archive.append(file.content as string, { name: file.name, date: FIXED_DATE });
+      } else {
+        archive.append(createReadStream(file.path), { name: file.name, date: FIXED_DATE });
+      }
+    }
+    archive.finalize().catch(reject);
+  });
+}
+
+export class BundleExportM365Command extends Command {
+  public static readonly paths = [['bundle', 'export-m365']];
+  public static readonly usage = Command.Usage({
+    description: 'Export a collection as a Microsoft 365 declarative-agent app package.',
+    category: 'Build & Author',
+    details: `
+      Requires a stable Microsoft app ID, publisher URLs, and valid 192x192
+      color and 32x32 outline PNG icons. Portable SKILL.md and MCP items are
+      reported for explicit follow-up because they cannot be copied directly.
+    `
+  });
+
+  public collectionFile = Option.String('--collection-file');
+  public appId = Option.String('--app-id');
+  public version = Option.String('--version', '1.0.0');
+  public colorIcon = Option.String('--color-icon');
+  public outlineIcon = Option.String('--outline-icon');
+  public developerName = Option.String('--developer-name');
+  public websiteUrl = Option.String('--website-url');
+  public privacyUrl = Option.String('--privacy-url');
+  public termsUrl = Option.String('--terms-url');
+  public outDir = Option.String('--out-dir', 'dist/m365');
+  public output = Option.String('-o', '--output') as OutputFormat | undefined;
+  public commandContext!: { ctx: Context };
+
+  public async execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+    const required = [this.appId, this.colorIcon, this.outlineIcon, this.developerName,
+      this.websiteUrl, this.privacyUrl, this.termsUrl];
+    if (required.some((value) => value === undefined || value.length === 0)) {
+      throw new RegistryError({
+        code: 'USAGE.MISSING_FLAG',
+        message: 'export-m365 requires app id, publisher URLs, developer name, and both icon paths'
+      });
+    }
+    const collectionFile = await resolveCollectionFile(ctx, ctx.cwd(), this.collectionFile);
+    const collection = readCollection(ctx.cwd(), collectionFile);
+    const colorPath = path.resolve(ctx.cwd(), this.colorIcon as string);
+    const outlinePath = path.resolve(ctx.cwd(), this.outlineIcon as string);
+    assertPngDimensions(colorPath, 192, 192);
+    assertPngDimensions(outlinePath, 32, 32);
+    const manifests = createM365Manifests(collection, ctx.cwd(), {
+      appId: this.appId as string,
+      version: this.version,
+      developerName: this.developerName as string,
+      websiteUrl: this.websiteUrl as string,
+      privacyUrl: this.privacyUrl as string,
+      termsUrl: this.termsUrl as string
+    });
+    const outDir = path.resolve(ctx.cwd(), this.outDir);
+    await ctx.fs.mkdir(outDir, { recursive: true });
+    const packagePath = path.join(outDir, `${collection.id}.m365.zip`);
+    await writePackage(packagePath, [
+      { name: 'color.png', path: colorPath },
+      { name: 'declarativeAgent.json', content: `${JSON.stringify(manifests.agentManifest, null, 2)}\n` },
+      { name: 'manifest.json', content: `${JSON.stringify(manifests.appManifest, null, 2)}\n` },
+      { name: 'outline.png', path: outlinePath }
+    ]);
+    formatOutput({
+      ctx,
+      command: 'bundle.export-m365',
+      output: this.output ?? 'text',
+      status: 'ok',
+      data: { packagePath, warnings: manifests.warnings },
+      textRenderer: (data) => `Built ${data.packagePath}\n${data.warnings.join('\n')}\n`
+    });
+    return 0;
+  }
+}

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -17,6 +17,9 @@ import {
   BundleBuildCommand,
 } from './commands/bundle-build';
 import {
+  BundleExportM365Command,
+} from './commands/bundle-export-m365';
+import {
   BundleManifestCommand,
 } from './commands/bundle-manifest';
 import {
@@ -216,6 +219,7 @@ async function main(): Promise<number> {
     ApplyCommand,
     SkillNewCommand,
     BundleBuildCommand,
+    BundleExportM365Command,
     BundleManifestCommand,
     VersionComputeCommand,
     IndexEvalCommand,

--- a/packages/cli/test/commands/bundle-export-m365.test.ts
+++ b/packages/cli/test/commands/bundle-export-m365.test.ts
@@ -1,0 +1,85 @@
+import {
+  mkdir,
+  mkdtemp,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type {
+  Collection,
+} from '@ai-primitives-hub/core';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  createM365Manifests,
+} from '../../src/commands/bundle-export-m365';
+
+describe('Microsoft 365 declarative-agent export', () => {
+  let workspace: string;
+
+  beforeEach(async () => {
+    workspace = await mkdtemp(path.join(os.tmpdir(), 'm365-export-'));
+    await mkdir(path.join(workspace, 'instructions'), { recursive: true });
+    await writeFile(path.join(workspace, 'instructions', 'review.md'), 'Review changes safely.');
+  });
+
+  afterEach(async () => {
+    await rm(workspace, { recursive: true, force: true });
+  });
+
+  it('maps instructions and prompt descriptions without treating SKILL.md as an M365 skill', () => {
+    const collection: Collection = {
+      id: 'review-kit',
+      name: 'Review Kit',
+      description: 'Review code changes',
+      items: [
+        { path: 'instructions/review.md', kind: 'instruction' },
+        { path: 'prompts/security.md', kind: 'prompt', name: 'Security review', description: 'Review this change for security issues' },
+        { path: 'skills/reviewer/SKILL.md', kind: 'skill' }
+      ]
+    };
+    const result = createM365Manifests(collection, workspace, {
+      appId: '00000000-0000-4000-8000-000000000000',
+      version: '1.0.0',
+      developerName: 'Contoso',
+      websiteUrl: 'https://example.com',
+      privacyUrl: 'https://example.com/privacy',
+      termsUrl: 'https://example.com/terms'
+    });
+
+    expect(result.agentManifest).toMatchObject({
+      version: 'v1.8',
+      name: 'Review Kit',
+      instructions: 'Review changes safely.',
+      conversation_starters: [{ title: 'Security review', text: 'Review this change for security issues' }]
+    });
+    expect(result.appManifest).toMatchObject({
+      manifestVersion: '1.29',
+      copilotAgents: { declarativeAgents: [{ file: 'declarativeAgent.json' }] }
+    });
+    expect(result.warnings.join(' ')).toContain('SKILL.md items are not embedded');
+    expect(result.warnings.join(' ')).toContain('at least three prompt items');
+  });
+
+  it('rejects instructions beyond the Microsoft 365 limit', async () => {
+    await writeFile(path.join(workspace, 'instructions', 'review.md'), 'x'.repeat(8001));
+    const collection: Collection = {
+      id: 'review-kit', name: 'Review Kit', items: [{ path: 'instructions/review.md', kind: 'instruction' }]
+    };
+
+    expect(() => createM365Manifests(collection, workspace, {
+      appId: '00000000-0000-4000-8000-000000000000',
+      version: '1.0.0',
+      developerName: 'Contoso',
+      websiteUrl: 'https://example.com',
+      privacyUrl: 'https://example.com/privacy',
+      termsUrl: 'https://example.com/terms'
+    })).toThrow(/8,000 character limit/);
+  });
+});

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -55,6 +55,7 @@ const sidebars: SidebarsConfig = {
           ],
         },
         { type: "doc", id: "contributor-guide/core-flows", label: "Core Flows" },
+        { type: "doc", id: "contributor-guide/microsoft-365-copilot-mvp", label: "Microsoft 365 Copilot MVP" },
         { type: "doc", id: "contributor-guide/testing", label: "Testing" },
         { type: "doc", id: "contributor-guide/testing-ssh-remote", label: "Testing SSH Remote" },
         { type: "doc", id: "contributor-guide/validation", label: "Validation" },


### PR DESCRIPTION
Adds a deterministic Microsoft 365 declarative-agent package export with validated manifests, icons, conversation starters, warnings, tests, and documentation.

Validation: focused tests, builds, lint, documentation build, and end-to-end ZIP smoke test passed.