### PR TITLE
fix: bump vulnerable dependencies and mark docs dependencies as dev

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   js-yaml: ^4.1.1
   mocha>chokidar: ^5.0.0
   mocha>diff: ^8.0.3
+  nanoid@<3.3.17: ^3.3.17
   serialize-javascript: ^7.0.7
   uuid: ^11.1.1
 
@@ -446,7 +447,7 @@ importers:
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0))
 
   website:
-    dependencies:
+    devDependencies:
       '@docusaurus/core':
         specifier: ^3.10.2
         version: 3.10.2(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(debug@4.4.3)(esbuild@0.28.1)(postcss@8.5.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
@@ -471,7 +472,6 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
-    devDependencies:
       '@docusaurus/module-type-aliases':
         specifier: ^3.10.2
         version: 3.10.2(esbuild@0.28.1)(postcss@8.5.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -7248,8 +7248,8 @@ packages:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -18450,7 +18450,7 @@ snapshots:
 
   mute-stream@2.0.0: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   napi-build-utils@2.0.0:
     optional: true
@@ -19464,7 +19464,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,7 @@ overrides:
   js-yaml: ^4.1.1
   mocha>chokidar: ^5.0.0
   mocha>diff: ^8.0.3
+  nanoid@<3.3.17: ^3.3.17
   serialize-javascript: ^7.0.7
   uuid: ^11.1.1
 

--- a/website/package.json
+++ b/website/package.json
@@ -12,7 +12,7 @@
     "serve": "docusaurus serve",
     "test": "vitest run"
   },
-  "dependencies": {
+  "devDependencies": {
     "@docusaurus/core": "^3.10.2",
     "@docusaurus/preset-classic": "^3.10.2",
     "@easyops-cn/docusaurus-search-local": "^0.55.2",
@@ -20,9 +20,7 @@
     "clsx": "^2.1.1",
     "prism-react-renderer": "^2.4.1",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
-  },
-  "devDependencies": {
+    "react-dom": "^18.3.1",
     "@docusaurus/module-type-aliases": "^3.10.2",
     "@docusaurus/types": "^3.10.2",
     "vitest": "^4.1.10"


### PR DESCRIPTION
## Description

Fixes the production vulnerability audit failure in the VS Code extension publishing workflow without suppressing unfixable advisories.

The workspace now forces vulnerable `nanoid` versions below `3.3.17` onto a patched release. The private Docusaurus website dependencies are classified as build-time dependencies because CI builds and deploys static files rather than running the website as a Node.js production service.

Failed workflow: https://github.com/AmadeusITGroup/ai-primitives-hub/actions/runs/31697700644/job/94439168520

## Type of Change

- [] Bug fix
- [x] Configuration/build changes
- [ ] Breaking change

## Changes Made

- Added a workspace override for `nanoid@<3.3.17` and resolved it to patched version `3.3.18`.
- Updated the pnpm lockfile with the patched `nanoid` resolution.
- Moved the private static website packages to `devDependencies` so production audits cover shipped runtime dependencies.
- Kept the publish security gate strict: `pnpm audit --prod --audit-level=moderate`.

## Impact

- The VS Code extension production dependency graph no longer contains the vulnerable `nanoid` release.
- Normal workspace installs, website tests, and website builds are unchanged.
- The deployed GitHub Pages output is unchanged because only generated static files from `website/build` are deployed.
- A production-only website install (`pnpm install --prod`) will not install the Docusaurus build toolchain. This matches the current CI and deployment model.
- Full audits still include website build dependencies, and the docs workflow reports website findings separately.

## Testing

- [x] `pnpm install --frozen-lockfile --prefer-offline`
- [x] `pnpm audit --prod --audit-level=moderate`
- [x] `pnpm -C website run build`
- [x] VS Code extension production compile

### Results

- Strict production audit reports: `No known vulnerabilities found`.
- Docusaurus production build completes successfully.
- Lockfile passes the repository supply-chain policies.

## Checklist

- [x] Changes are limited to dependency security and classification.
- [x] No vulnerability ignore flags or advisory suppressions were added.
- [x] No new warnings or validation errors were introduced.
- [x] No documentation changes are required.

## Reviewer Guidelines

Please pay particular attention to:

- The scoped `nanoid` override and lockfile resolution.
- The classification of the private static website packages as build-time dependencies.
- The continued use of the strict production audit command without `--ignore-unfixable`.
